### PR TITLE
Implements stale label deletion feature in sync_labels script

### DIFF
--- a/.github/scripts/sync_labels.py
+++ b/.github/scripts/sync_labels.py
@@ -1,4 +1,4 @@
-"""Create or update GitHub labels from .github/labels.json."""
+"""Sync GitHub labels from .github/labels.json."""
 
 from __future__ import annotations
 
@@ -19,10 +19,16 @@ def gh_api(*args: str) -> str:
     return result.stdout
 
 
+def is_enabled(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def main() -> None:
     repo = os.environ["GITHUB_REPOSITORY"]
     labels_path = Path(".github/labels.json")
     desired_labels = json.loads(labels_path.read_text(encoding="utf-8"))
+    desired_names = {label["name"] for label in desired_labels}
+    delete_stale_labels = is_enabled(os.environ.get("DELETE_STALE_LABELS"))
 
     existing_labels = json.loads(gh_api(f"repos/{repo}/labels?per_page=100"))
     existing_by_name = {label["name"]: label for label in existing_labels}
@@ -66,6 +72,19 @@ def main() -> None:
             f"description={description}",
         )
         print(f"updated {name}")
+
+    if not delete_stale_labels:
+        print("strict mode disabled; stale labels were not deleted")
+        return
+
+    stale_label_names = sorted(set(existing_by_name) - desired_names)
+    for name in stale_label_names:
+        gh_api(
+            "-X",
+            "DELETE",
+            f"repos/{repo}/labels/{quote(name, safe='')}",
+        )
+        print(f"deleted {name}")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Sync repository labels
         env:
+          DELETE_STALE_LABELS: "true"
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: python .github/scripts/sync_labels.py


### PR DESCRIPTION
Adds functionality to delete stale labels not present in the updated labels configuration.

Introduces a strict mode for managing stale labels, which can be toggled via an environment variable.

Updates the GitHub Actions workflow to enable stale label deletion by default, enhancing label management consistency.

## Summary

Describe the change in a few sentences.

## Why

Explain the problem, risk, or goal behind this PR.

## Validation

- [ ] `make lint`
- [ ] `make test`
- [ ] `make tf-fmt` (if `infra/` changed)
- [ ] Other relevant checks were run when needed

## Review Notes

- [ ] Tenant-scoped queries explicitly filter by `tenant_id` where applicable
- [ ] `tenant_id` comes from validated JWT claims, not client input
- [ ] Write flows keep domain changes and audit records in one transaction where required
- [ ] Structured logging or audit logging was updated if the change affects important write flows
- [ ] Docs were updated if architecture, security, or MVP scope changed materially

## Deployment Notes

List migration, config, or rollout steps if this change needs them.
