### PR TITLE
feat: implement lease MVP endpoints and due-soon reminder candidates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LOCAL_USER_ID ?= user-local
 PROPERTY_NAME ?= HQ
 PROPERTY_ADDRESS ?= Main Street 1
 
-.PHONY: format lint test migrate check-local-env migrate-local db-check-local test-local test-integration-local invoke-local-health invoke-local-list-properties invoke-local-create-property tf-fmt
+.PHONY: format lint test migrate check-local-env migrate-local db-check-local test-local test-integration-local invoke-local-health invoke-local-list-properties invoke-local-list-due-lease-reminders invoke-local-create-property tf-fmt
 
 format:
 	cd $(BACKEND_DIR) && $(PYTHON) -m ruff format src tests migrations
@@ -41,6 +41,9 @@ invoke-local-health:
 
 invoke-local-list-properties: check-local-env
 	cd $(BACKEND_DIR) && set -a && . ./$(LOCAL_ENV_FILE) && set +a && $(PYTHON) scripts/invoke_local.py list-properties --tenant-id "$(LOCAL_TENANT_ID)" --user-id "$(LOCAL_USER_ID)"
+
+invoke-local-list-due-lease-reminders: check-local-env
+	cd $(BACKEND_DIR) && set -a && . ./$(LOCAL_ENV_FILE) && set +a && $(PYTHON) scripts/invoke_local.py list-due-lease-reminders --tenant-id "$(LOCAL_TENANT_ID)" --user-id "$(LOCAL_USER_ID)"
 
 invoke-local-create-property: check-local-env
 	cd $(BACKEND_DIR) && set -a && . ./$(LOCAL_ENV_FILE) && set +a && $(PYTHON) scripts/invoke_local.py create-property --tenant-id "$(LOCAL_TENANT_ID)" --user-id "$(LOCAL_USER_ID)" --name "$(PROPERTY_NAME)" --address "$(PROPERTY_ADDRESS)"

--- a/README.md
+++ b/README.md
@@ -34,15 +34,18 @@ Implemented now:
 - `GET /health`
 - `POST /properties`
 - `GET /properties`
+- `POST /leases`
+- `GET /leases`
 - JWT claim extraction with tenant-aware request context
 - Tenant-scoped PostgreSQL access
-- Audit logging for property creation
-- Alembic migrations for initial tables
+- Explicit `rent_due_day_of_month` on leases to prepare future reminder flows
+- Audit logging for property and lease creation
+- Alembic migrations for initial property and lease tables
 - Terraform modules for network, RDS, Cognito, Lambda, and API Gateway
 
 Planned next:
 
-- Expand core rental management flows beyond properties
+- Prepare reminder and scheduled workflow support on top of leases
 - Add more automated backend and tenant-isolation test coverage
 - Refine operational setup for scheduled workflows and monitoring
 

--- a/backend/migrations/versions/20260407_0002_add_leases.py
+++ b/backend/migrations/versions/20260407_0002_add_leases.py
@@ -1,0 +1,67 @@
+"""Add leases table with tenant-safe property reference."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "20260407_0002"
+down_revision = "20260310_0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint(
+        "uq_properties_tenant_property",
+        "properties",
+        ["tenant_id", "property_id"],
+    )
+
+    op.create_table(
+        "leases",
+        sa.Column(
+            "lease_id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("tenant_id", sa.Text(), nullable=False),
+        sa.Column("property_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("resident_name", sa.Text(), nullable=False),
+        sa.Column("start_date", sa.Date(), nullable=False),
+        sa.Column("end_date", sa.Date(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["tenant_id", "property_id"],
+            ["properties.tenant_id", "properties.property_id"],
+            name="fk_leases_property_tenant",
+        ),
+    )
+    op.create_index(
+        "ix_leases_tenant_created_at",
+        "leases",
+        ["tenant_id", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_leases_tenant_property",
+        "leases",
+        ["tenant_id", "property_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_leases_tenant_property", table_name="leases")
+    op.drop_index("ix_leases_tenant_created_at", table_name="leases")
+    op.drop_table("leases")
+    op.drop_constraint("uq_properties_tenant_property", "properties", type_="unique")

--- a/backend/migrations/versions/20260407_0003_add_lease_due_day.py
+++ b/backend/migrations/versions/20260407_0003_add_lease_due_day.py
@@ -1,0 +1,29 @@
+"""Add reminder-ready rent due day to leases."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260407_0003"
+down_revision = "20260407_0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "leases",
+        sa.Column("rent_due_day_of_month", sa.Integer(), nullable=True),
+    )
+    op.create_check_constraint(
+        "ck_leases_rent_due_day_of_month",
+        "leases",
+        "rent_due_day_of_month IS NULL OR rent_due_day_of_month BETWEEN 1 AND 31",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_leases_rent_due_day_of_month", "leases", type_="check")
+    op.drop_column("leases", "rent_due_day_of_month")

--- a/backend/scripts/invoke_local.py
+++ b/backend/scripts/invoke_local.py
@@ -18,6 +18,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     list_parser.add_argument("--tenant-id", default="tenant-local")
     list_parser.add_argument("--user-id", default="user-local")
 
+    reminders_parser = subparsers.add_parser(
+        "list-due-lease-reminders",
+        help="Invoke GET /lease-reminders/due-soon.",
+    )
+    reminders_parser.add_argument("--tenant-id", default="tenant-local")
+    reminders_parser.add_argument("--user-id", default="user-local")
+    reminders_parser.add_argument("--days", type=int, default=7)
+
     create_parser = subparsers.add_parser("create-property", help="Invoke POST /properties.")
     create_parser.add_argument("--tenant-id", default="tenant-local")
     create_parser.add_argument("--user-id", default="user-local")
@@ -34,8 +42,13 @@ def build_event(args: argparse.Namespace) -> dict[str, Any]:
             "requestContext": {"http": {"method": "GET"}},
         }
 
+    raw_path = (
+        "/lease-reminders/due-soon"
+        if args.command == "list-due-lease-reminders"
+        else "/properties"
+    )
     event = {
-        "rawPath": "/properties",
+        "rawPath": raw_path,
         "requestContext": {
             "http": {"method": "GET" if args.command == "list-properties" else "POST"},
             "authorizer": {
@@ -48,6 +61,11 @@ def build_event(args: argparse.Namespace) -> dict[str, Any]:
             },
         },
     }
+
+    if args.command == "list-due-lease-reminders":
+        event["requestContext"]["http"]["method"] = "GET"
+        event["queryStringParameters"] = {"days": str(args.days)}
+        return event
 
     if args.command == "create-property":
         event["body"] = json.dumps({"name": args.name, "address": args.address})

--- a/backend/src/app/db.py
+++ b/backend/src/app/db.py
@@ -1,18 +1,92 @@
 from __future__ import annotations
 
+import calendar
 from collections.abc import Sequence
+from datetime import date, timedelta
 from typing import Any
+from uuid import UUID
 
 import psycopg
 from psycopg.rows import dict_row
 
 from app.config import Settings
-from app.models import Property
+from app.models import Lease, LeaseReminderCandidate, Property
 
 
 class Database:
     def __init__(self, settings: Settings) -> None:
         self._dsn = settings.db_dsn()
+
+    def list_due_lease_reminders(
+        self,
+        tenant_id: str,
+        as_of_date: date,
+        days: int,
+    ) -> list[LeaseReminderCandidate]:
+        range_end = as_of_date + timedelta(days=days)
+        sql = """
+            SELECT
+                lease_id,
+                tenant_id,
+                property_id,
+                resident_name,
+                rent_due_day_of_month,
+                start_date,
+                end_date
+            FROM leases
+            WHERE tenant_id = %s
+              AND rent_due_day_of_month IS NOT NULL
+              AND start_date <= %s
+              AND end_date >= %s
+            ORDER BY created_at DESC
+        """
+        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+            rows = conn.execute(sql, (tenant_id, range_end, as_of_date)).fetchall()
+
+        candidates: list[LeaseReminderCandidate] = []
+        for row in rows:
+            due_date = _next_due_date(
+                as_of_date=as_of_date,
+                due_day_of_month=int(row["rent_due_day_of_month"]),
+            )
+            if due_date > range_end:
+                continue
+            if due_date < row["start_date"] or due_date > row["end_date"]:
+                continue
+
+            candidates.append(
+                LeaseReminderCandidate(
+                    lease_id=row["lease_id"],
+                    tenant_id=row["tenant_id"],
+                    property_id=row["property_id"],
+                    resident_name=row["resident_name"],
+                    rent_due_day_of_month=int(row["rent_due_day_of_month"]),
+                    due_date=due_date,
+                    days_until_due=(due_date - as_of_date).days,
+                )
+            )
+
+        candidates.sort(key=lambda item: (item.due_date, item.lease_id))
+        return candidates
+
+    def list_leases(self, tenant_id: str) -> list[Lease]:
+        sql = """
+            SELECT
+                lease_id,
+                tenant_id,
+                property_id,
+                resident_name,
+                rent_due_day_of_month,
+                start_date,
+                end_date,
+                created_at
+            FROM leases
+            WHERE tenant_id = %s
+            ORDER BY created_at DESC
+        """
+        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+            rows = conn.execute(sql, (tenant_id,)).fetchall()
+        return [self._row_to_lease(row) for row in rows]
 
     def list_properties(self, tenant_id: str) -> list[Property]:
         sql = """
@@ -24,6 +98,66 @@ class Database:
         with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
             rows = conn.execute(sql, (tenant_id,)).fetchall()
         return [self._row_to_property(row) for row in rows]
+
+    def create_lease(
+        self,
+        tenant_id: str,
+        actor_user_id: str,
+        property_id: UUID,
+        resident_name: str,
+        rent_due_day_of_month: int,
+        start_date: date,
+        end_date: date,
+    ) -> Lease:
+        lease_sql = """
+            INSERT INTO leases (
+                tenant_id, property_id, resident_name, rent_due_day_of_month, start_date, end_date
+            )
+            SELECT p.tenant_id, p.property_id, %s, %s, %s, %s
+            FROM properties p
+            WHERE p.tenant_id = %s AND p.property_id = %s
+            RETURNING
+                lease_id,
+                tenant_id,
+                property_id,
+                resident_name,
+                rent_due_day_of_month,
+                start_date,
+                end_date,
+                created_at
+        """
+        audit_sql = """
+            INSERT INTO audit_logs (
+                tenant_id, actor_user_id, action, entity_type, entity_id, metadata
+            ) VALUES (%s, %s, %s, %s, %s, %s::jsonb)
+        """
+        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+            with conn.transaction():
+                lease_row = conn.execute(
+                    lease_sql,
+                    (
+                        resident_name,
+                        rent_due_day_of_month,
+                        start_date,
+                        end_date,
+                        tenant_id,
+                        property_id,
+                    ),
+                ).fetchone()
+                if not lease_row:
+                    raise ValueError("Property not found for tenant.")
+                conn.execute(
+                    audit_sql,
+                    (
+                        tenant_id,
+                        actor_user_id,
+                        "lease.create",
+                        "lease",
+                        lease_row["lease_id"],
+                        '{"source":"api"}',
+                    ),
+                )
+        return self._row_to_lease(lease_row)
 
     def create_property(
         self,
@@ -70,6 +204,19 @@ class Database:
             created_at=row["created_at"],
         )
 
+    @staticmethod
+    def _row_to_lease(row: dict[str, Any]) -> Lease:
+        return Lease(
+            lease_id=row["lease_id"],
+            tenant_id=row["tenant_id"],
+            property_id=row["property_id"],
+            resident_name=row["resident_name"],
+            rent_due_day_of_month=row["rent_due_day_of_month"],
+            start_date=row["start_date"],
+            end_date=row["end_date"],
+            created_at=row["created_at"],
+        )
+
 
 def properties_to_dict(items: Sequence[Property]) -> list[dict[str, Any]]:
     return [
@@ -82,3 +229,56 @@ def properties_to_dict(items: Sequence[Property]) -> list[dict[str, Any]]:
         }
         for item in items
     ]
+
+
+def leases_to_dict(items: Sequence[Lease]) -> list[dict[str, Any]]:
+    return [
+        {
+            "lease_id": str(item.lease_id),
+            "tenant_id": item.tenant_id,
+            "property_id": str(item.property_id),
+            "resident_name": item.resident_name,
+            "rent_due_day_of_month": item.rent_due_day_of_month,
+            "start_date": item.start_date.isoformat(),
+            "end_date": item.end_date.isoformat(),
+            "created_at": item.created_at.isoformat(),
+        }
+        for item in items
+    ]
+
+
+def lease_reminders_to_dict(items: Sequence[LeaseReminderCandidate]) -> list[dict[str, Any]]:
+    return [
+        {
+            "lease_id": str(item.lease_id),
+            "tenant_id": item.tenant_id,
+            "property_id": str(item.property_id),
+            "resident_name": item.resident_name,
+            "rent_due_day_of_month": item.rent_due_day_of_month,
+            "due_date": item.due_date.isoformat(),
+            "days_until_due": item.days_until_due,
+        }
+        for item in items
+    ]
+
+
+def _next_due_date(as_of_date: date, due_day_of_month: int) -> date:
+    current_month_due = _month_due_date(
+        year=as_of_date.year,
+        month=as_of_date.month,
+        due_day_of_month=due_day_of_month,
+    )
+    if current_month_due >= as_of_date:
+        return current_month_due
+
+    next_month_anchor = as_of_date.replace(day=28) + timedelta(days=4)
+    return _month_due_date(
+        year=next_month_anchor.year,
+        month=next_month_anchor.month,
+        due_day_of_month=due_day_of_month,
+    )
+
+
+def _month_due_date(year: int, month: int, due_day_of_month: int) -> date:
+    last_day = calendar.monthrange(year, month)[1]
+    return date(year, month, min(due_day_of_month, last_day))

--- a/backend/src/app/handler.py
+++ b/backend/src/app/handler.py
@@ -9,6 +9,8 @@ from app.config import ConfigError, load_settings
 from app.db import Database
 from app.logging import get_logger, setup_logging
 from app.routes.health import get_health
+from app.routes.lease_reminders import list_due_lease_reminders
+from app.routes.leases import create_lease, list_leases
 from app.routes.properties import create_property, list_properties
 
 setup_logging()
@@ -63,6 +65,12 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         settings = load_settings()
         setup_logging(settings.log_level)
         db = Database(settings)
+        if method == "GET" and path == "/lease-reminders/due-soon":
+            return _response(HTTPStatus.OK, list_due_lease_reminders(event, db))
+        if method == "GET" and path == "/leases":
+            return _response(HTTPStatus.OK, list_leases(event, db))
+        if method == "POST" and path == "/leases":
+            return _response(HTTPStatus.CREATED, create_lease(event, db, _json_body(event)))
         if method == "GET" and path == "/properties":
             return _response(HTTPStatus.OK, list_properties(event, db))
         if method == "POST" and path == "/properties":

--- a/backend/src/app/models.py
+++ b/backend/src/app/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime
 from uuid import UUID
 
 
@@ -22,3 +22,26 @@ class Property:
     name: str
     address: str
     created_at: datetime
+
+
+@dataclass(slots=True)
+class Lease:
+    lease_id: UUID
+    tenant_id: str
+    property_id: UUID
+    resident_name: str
+    rent_due_day_of_month: int | None
+    start_date: date
+    end_date: date
+    created_at: datetime
+
+
+@dataclass(slots=True)
+class LeaseReminderCandidate:
+    lease_id: UUID
+    tenant_id: str
+    property_id: UUID
+    resident_name: str
+    rent_due_day_of_month: int
+    due_date: date
+    days_until_due: int

--- a/backend/src/app/routes/lease_reminders.py
+++ b/backend/src/app/routes/lease_reminders.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from app.auth import extract_auth_context
+from app.db import Database, lease_reminders_to_dict
+
+
+def list_due_lease_reminders(event: dict[str, Any], db: Database) -> dict[str, Any]:
+    auth = extract_auth_context(event)
+    days = _parse_days(event.get("queryStringParameters") or {})
+    items = db.list_due_lease_reminders(
+        tenant_id=auth.tenant_id,
+        as_of_date=_today(),
+        days=days,
+    )
+    return {"items": lease_reminders_to_dict(items)}
+
+
+def _parse_days(query_params: dict[str, Any]) -> int:
+    raw_days = query_params.get("days")
+    if raw_days in (None, ""):
+        return 7
+
+    try:
+        days = int(raw_days)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Query parameter 'days' must be an integer between 1 and 31.") from exc
+
+    if days < 1 or days > 31:
+        raise ValueError("Query parameter 'days' must be an integer between 1 and 31.")
+
+    return days
+
+
+def _today() -> date:
+    return date.today()

--- a/backend/src/app/routes/leases.py
+++ b/backend/src/app/routes/leases.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+from uuid import UUID
+
+from app.auth import extract_auth_context
+from app.db import Database, leases_to_dict
+
+
+def list_leases(event: dict[str, Any], db: Database) -> dict[str, Any]:
+    auth = extract_auth_context(event)
+    items = db.list_leases(tenant_id=auth.tenant_id)
+    return {"items": leases_to_dict(items)}
+
+
+def create_lease(event: dict[str, Any], db: Database, body: dict[str, Any]) -> dict[str, Any]:
+    auth = extract_auth_context(event)
+
+    property_id_raw = str(body.get("property_id", "")).strip()
+    resident_name = str(body.get("resident_name", "")).strip()
+    rent_due_day_of_month_raw = body.get("rent_due_day_of_month")
+    start_date_raw = str(body.get("start_date", "")).strip()
+    end_date_raw = str(body.get("end_date", "")).strip()
+
+    if (
+        not property_id_raw
+        or not resident_name
+        or rent_due_day_of_month_raw in (None, "")
+        or not start_date_raw
+        or not end_date_raw
+    ):
+        raise ValueError(
+            "Fields 'property_id', 'resident_name', "
+            "'rent_due_day_of_month', 'start_date', and 'end_date' are required."
+        )
+
+    try:
+        property_id = UUID(property_id_raw)
+    except ValueError as exc:
+        raise ValueError("Field 'property_id' must be a valid UUID.") from exc
+
+    rent_due_day_of_month = _parse_rent_due_day_of_month(rent_due_day_of_month_raw)
+    start_date, end_date = _parse_dates(start_date_raw, end_date_raw)
+    if end_date < start_date:
+        raise ValueError("'end_date' must be on or after 'start_date'.")
+
+    created = db.create_lease(
+        tenant_id=auth.tenant_id,
+        actor_user_id=auth.user_id,
+        property_id=property_id,
+        resident_name=resident_name,
+        rent_due_day_of_month=rent_due_day_of_month,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    return leases_to_dict([created])[0]
+
+
+def _parse_dates(start_date_raw: str, end_date_raw: str) -> tuple[date, date]:
+    try:
+        return date.fromisoformat(start_date_raw), date.fromisoformat(end_date_raw)
+    except ValueError as exc:
+        raise ValueError("Fields 'start_date' and 'end_date' must use YYYY-MM-DD.") from exc
+
+
+def _parse_rent_due_day_of_month(value: Any) -> int:
+    if isinstance(value, bool):
+        raise ValueError("Field 'rent_due_day_of_month' must be an integer between 1 and 31.")
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "Field 'rent_due_day_of_month' must be an integer between 1 and 31."
+        ) from exc
+
+    if parsed < 1 or parsed > 31:
+        raise ValueError("Field 'rent_due_day_of_month' must be an integer between 1 and 31.")
+
+    return parsed

--- a/backend/tests/test_db_integration.py
+++ b/backend/tests/test_db_integration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from datetime import date
 from uuid import uuid4
 
 import psycopg
@@ -31,6 +32,7 @@ def _cleanup_test_tenant(settings: Settings, tenant_id: str) -> None:
     with psycopg.connect(settings.db_dsn(), row_factory=dict_row) as conn:
         with conn.transaction():
             conn.execute("DELETE FROM audit_logs WHERE tenant_id = %s", (tenant_id,))
+            conn.execute("DELETE FROM leases WHERE tenant_id = %s", (tenant_id,))
             conn.execute("DELETE FROM properties WHERE tenant_id = %s", (tenant_id,))
 
 
@@ -180,6 +182,329 @@ def test_list_properties_returns_only_requested_tenant_rows(
         assert listed[0].tenant_id == tenant_id
         assert listed[0].name == name
         assert listed[0].address == address
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+        _cleanup_test_tenant(integration_settings, other_tenant_id)
+
+
+def test_create_lease_writes_lease_and_audit_log(integration_settings: Settings) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+    resident_name = f"Alice {uuid4().hex[:8]}"
+    rent_due_day_of_month = 5
+    start_date = date(2026, 5, 1)
+    end_date = date(2027, 4, 30)
+
+    try:
+        property_record = db.create_property(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Lease HQ {uuid4().hex[:8]}",
+            address=f"Lease Street {uuid4().hex[:8]}",
+        )
+        created = db.create_lease(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=property_record.property_id,
+            resident_name=resident_name,
+            rent_due_day_of_month=rent_due_day_of_month,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            lease_rows = conn.execute(
+                """
+                SELECT
+                    lease_id,
+                    tenant_id,
+                    property_id,
+                    resident_name,
+                    rent_due_day_of_month,
+                    start_date,
+                    end_date
+                FROM leases
+                WHERE tenant_id = %s AND lease_id = %s
+                """,
+                (tenant_id, created.lease_id),
+            ).fetchall()
+            audit_rows = conn.execute(
+                """
+                SELECT tenant_id, actor_user_id, action, entity_type, entity_id, metadata
+                FROM audit_logs
+                WHERE tenant_id = %s AND entity_id = %s
+                """,
+                (tenant_id, created.lease_id),
+            ).fetchall()
+
+        assert len(lease_rows) == 1
+        assert lease_rows[0]["tenant_id"] == tenant_id
+        assert lease_rows[0]["property_id"] == property_record.property_id
+        assert lease_rows[0]["resident_name"] == resident_name
+        assert lease_rows[0]["rent_due_day_of_month"] == rent_due_day_of_month
+        assert lease_rows[0]["start_date"] == start_date
+        assert lease_rows[0]["end_date"] == end_date
+
+        assert len(audit_rows) == 1
+        assert audit_rows[0]["tenant_id"] == tenant_id
+        assert audit_rows[0]["actor_user_id"] == actor_user_id
+        assert audit_rows[0]["action"] == "lease.create"
+        assert audit_rows[0]["entity_type"] == "lease"
+        assert audit_rows[0]["entity_id"] == created.lease_id
+        assert audit_rows[0]["metadata"] == {"source": "api"}
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+
+
+def test_create_lease_rejects_cross_tenant_property_reference(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    other_tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+
+    try:
+        other_property = db.create_property(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Other HQ {uuid4().hex[:8]}",
+            address=f"Other Street {uuid4().hex[:8]}",
+        )
+
+        with pytest.raises(ValueError, match="Property not found for tenant."):
+            db.create_lease(
+                tenant_id=tenant_id,
+                actor_user_id=actor_user_id,
+                property_id=other_property.property_id,
+                resident_name=f"Bob {uuid4().hex[:8]}",
+                rent_due_day_of_month=5,
+                start_date=date(2026, 5, 1),
+                end_date=date(2027, 4, 30),
+            )
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            lease_rows = conn.execute(
+                """
+                SELECT lease_id
+                FROM leases
+                WHERE tenant_id IN (%s, %s)
+                """,
+                (tenant_id, other_tenant_id),
+            ).fetchall()
+            audit_rows = conn.execute(
+                """
+                SELECT audit_id
+                FROM audit_logs
+                WHERE tenant_id = %s AND action = 'lease.create'
+                """,
+                (tenant_id,),
+            ).fetchall()
+
+        assert lease_rows == []
+        assert audit_rows == []
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+        _cleanup_test_tenant(integration_settings, other_tenant_id)
+
+
+def test_create_lease_rolls_back_when_audit_log_write_fails(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+    constraint_name = f"audit_logs_reject_{uuid4().hex[:12]}"
+
+    try:
+        property_record = db.create_property(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Rollback HQ {uuid4().hex[:8]}",
+            address=f"Rollback Street {uuid4().hex[:8]}",
+        )
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            with conn.transaction():
+                conn.execute(
+                    SQL(
+                        """
+                        ALTER TABLE audit_logs
+                        ADD CONSTRAINT {constraint_name}
+                        CHECK (action <> 'lease.create' OR tenant_id <> {tenant_id})
+                        """
+                    ).format(
+                        constraint_name=Identifier(constraint_name),
+                        tenant_id=Literal(tenant_id),
+                    )
+                )
+
+        with pytest.raises(psycopg.Error):
+            db.create_lease(
+                tenant_id=tenant_id,
+                actor_user_id=actor_user_id,
+                property_id=property_record.property_id,
+                resident_name=f"Carol {uuid4().hex[:8]}",
+                rent_due_day_of_month=5,
+                start_date=date(2026, 5, 1),
+                end_date=date(2027, 4, 30),
+            )
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            lease_rows = conn.execute(
+                """
+                SELECT lease_id
+                FROM leases
+                WHERE tenant_id = %s
+                """,
+                (tenant_id,),
+            ).fetchall()
+            audit_rows = conn.execute(
+                """
+                SELECT audit_id
+                FROM audit_logs
+                WHERE tenant_id = %s AND action = 'lease.create'
+                """,
+                (tenant_id,),
+            ).fetchall()
+
+        assert lease_rows == []
+        assert audit_rows == []
+    finally:
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            with conn.transaction():
+                conn.execute(
+                    SQL(
+                        "ALTER TABLE audit_logs DROP CONSTRAINT IF EXISTS {constraint_name}"
+                    ).format(constraint_name=Identifier(constraint_name))
+                )
+        _cleanup_test_tenant(integration_settings, tenant_id)
+
+
+def test_list_leases_returns_only_requested_tenant_rows(integration_settings: Settings) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    other_tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+
+    try:
+        property_record = db.create_property(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Lease HQ {uuid4().hex[:8]}",
+            address=f"Lease Street {uuid4().hex[:8]}",
+        )
+        other_property = db.create_property(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Other Lease HQ {uuid4().hex[:8]}",
+            address=f"Other Lease Street {uuid4().hex[:8]}",
+        )
+        created = db.create_lease(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=property_record.property_id,
+            resident_name=f"Dana {uuid4().hex[:8]}",
+            rent_due_day_of_month=5,
+            start_date=date(2026, 5, 1),
+            end_date=date(2027, 4, 30),
+        )
+        db.create_lease(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=other_property.property_id,
+            resident_name=f"Eve {uuid4().hex[:8]}",
+            rent_due_day_of_month=7,
+            start_date=date(2026, 6, 1),
+            end_date=date(2027, 5, 31),
+        )
+
+        listed = db.list_leases(tenant_id=tenant_id)
+
+        assert len(listed) == 1
+        assert listed[0].lease_id == created.lease_id
+        assert listed[0].tenant_id == tenant_id
+        assert listed[0].property_id == property_record.property_id
+        assert listed[0].rent_due_day_of_month == 5
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+        _cleanup_test_tenant(integration_settings, other_tenant_id)
+
+
+def test_list_due_lease_reminders_returns_only_due_active_tenant_leases(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    other_tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+    as_of_date = date(2026, 4, 3)
+
+    try:
+        property_record = db.create_property(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Reminder HQ {uuid4().hex[:8]}",
+            address=f"Reminder Street {uuid4().hex[:8]}",
+        )
+        other_property = db.create_property(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Other Reminder HQ {uuid4().hex[:8]}",
+            address=f"Other Reminder Street {uuid4().hex[:8]}",
+        )
+
+        due_soon = db.create_lease(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=property_record.property_id,
+            resident_name=f"Due Soon {uuid4().hex[:8]}",
+            rent_due_day_of_month=5,
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+        )
+        db.create_lease(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=property_record.property_id,
+            resident_name=f"Too Late {uuid4().hex[:8]}",
+            rent_due_day_of_month=20,
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+        )
+        db.create_lease(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=property_record.property_id,
+            resident_name=f"Inactive {uuid4().hex[:8]}",
+            rent_due_day_of_month=4,
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 4, 2),
+        )
+        db.create_lease(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=other_property.property_id,
+            resident_name=f"Other Tenant {uuid4().hex[:8]}",
+            rent_due_day_of_month=5,
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+        )
+
+        listed = db.list_due_lease_reminders(
+            tenant_id=tenant_id,
+            as_of_date=as_of_date,
+            days=7,
+        )
+
+        assert len(listed) == 1
+        assert listed[0].lease_id == due_soon.lease_id
+        assert listed[0].tenant_id == tenant_id
+        assert listed[0].property_id == property_record.property_id
+        assert listed[0].resident_name == due_soon.resident_name
+        assert listed[0].rent_due_day_of_month == 5
+        assert listed[0].due_date == date(2026, 4, 5)
+        assert listed[0].days_until_due == 2
     finally:
         _cleanup_test_tenant(integration_settings, tenant_id)
         _cleanup_test_tenant(integration_settings, other_tenant_id)

--- a/backend/tests/test_handler.py
+++ b/backend/tests/test_handler.py
@@ -60,3 +60,114 @@ def test_list_properties_accepts_stage_prefixed_raw_path(monkeypatch) -> None:
 
     assert response["statusCode"] == 200
     assert json.loads(response["body"]) == {"items": []}
+
+
+def test_list_leases_accepts_stage_prefixed_raw_path(monkeypatch) -> None:
+    monkeypatch.setattr(
+        handler,
+        "load_settings",
+        lambda: SimpleNamespace(log_level="INFO"),
+    )
+    monkeypatch.setattr(handler, "Database", lambda settings: object())
+    monkeypatch.setattr(handler, "list_leases", lambda event, db: {"items": []}, raising=False)
+
+    event = {
+        "rawPath": "/dev/leases",
+        "requestContext": {
+            "stage": "dev",
+            "http": {"method": "GET"},
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": "user-123",
+                        "custom:tenant_id": "tenant-123",
+                    }
+                }
+            },
+        },
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 200
+    assert json.loads(response["body"]) == {"items": []}
+
+
+def test_create_lease_accepts_stage_prefixed_raw_path(monkeypatch) -> None:
+    monkeypatch.setattr(
+        handler,
+        "load_settings",
+        lambda: SimpleNamespace(log_level="INFO"),
+    )
+    monkeypatch.setattr(handler, "Database", lambda settings: object())
+    monkeypatch.setattr(
+        handler,
+        "create_lease",
+        lambda event, db, body: {"lease_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"},
+        raising=False,
+    )
+
+    event = {
+        "rawPath": "/dev/leases",
+        "body": json.dumps(
+            {
+                "property_id": "11111111-1111-1111-1111-111111111111",
+                "resident_name": "Alice Example",
+                "start_date": "2026-05-01",
+                "end_date": "2027-04-30",
+            }
+        ),
+        "requestContext": {
+            "stage": "dev",
+            "http": {"method": "POST"},
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": "user-123",
+                        "custom:tenant_id": "tenant-123",
+                    }
+                }
+            },
+        },
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 201
+    assert json.loads(response["body"]) == {"lease_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}
+
+
+def test_list_due_lease_reminders_accepts_stage_prefixed_raw_path(monkeypatch) -> None:
+    monkeypatch.setattr(
+        handler,
+        "load_settings",
+        lambda: SimpleNamespace(log_level="INFO"),
+    )
+    monkeypatch.setattr(handler, "Database", lambda settings: object())
+    monkeypatch.setattr(
+        handler,
+        "list_due_lease_reminders",
+        lambda event, db: {"items": []},
+        raising=False,
+    )
+
+    event = {
+        "rawPath": "/dev/lease-reminders/due-soon",
+        "requestContext": {
+            "stage": "dev",
+            "http": {"method": "GET"},
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": "user-123",
+                        "custom:tenant_id": "tenant-123",
+                    }
+                }
+            },
+        },
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 200
+    assert json.loads(response["body"]) == {"items": []}

--- a/backend/tests/test_invoke_local.py
+++ b/backend/tests/test_invoke_local.py
@@ -64,6 +64,38 @@ def test_build_event_for_create_property_uses_body_and_jwt_claims() -> None:
     }
 
 
+def test_build_event_for_list_due_lease_reminders_uses_query_and_jwt_claims() -> None:
+    args = invoke_local.parse_args(
+        [
+            "list-due-lease-reminders",
+            "--tenant-id",
+            "tenant-local",
+            "--user-id",
+            "user-local",
+            "--days",
+            "14",
+        ]
+    )
+
+    event = invoke_local.build_event(args)
+
+    assert event == {
+        "rawPath": "/lease-reminders/due-soon",
+        "queryStringParameters": {"days": "14"},
+        "requestContext": {
+            "http": {"method": "GET"},
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": "user-local",
+                        "custom:tenant_id": "tenant-local",
+                    }
+                }
+            },
+        },
+    }
+
+
 def test_main_invokes_lambda_handler_and_prints_response(monkeypatch: Any, capsys: Any) -> None:
     captured: dict[str, Any] = {}
 

--- a/backend/tests/test_lease_reminders_route.py
+++ b/backend/tests/test_lease_reminders_route.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from datetime import date
+from uuid import UUID
+
+import pytest
+
+from app.auth import AuthError
+
+
+def _reminders_module():
+    return importlib.import_module("app.routes.lease_reminders")
+
+
+@dataclass(slots=True)
+class _ReminderCandidate:
+    lease_id: UUID
+    tenant_id: str
+    property_id: UUID
+    resident_name: str
+    rent_due_day_of_month: int
+    due_date: date
+    days_until_due: int
+
+
+class _FakeDb:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def list_due_lease_reminders(
+        self,
+        tenant_id: str,
+        as_of_date: date,
+        days: int,
+    ) -> list[_ReminderCandidate]:
+        self.calls.append(
+            {
+                "tenant_id": tenant_id,
+                "as_of_date": as_of_date,
+                "days": days,
+            }
+        )
+        return [
+            _ReminderCandidate(
+                lease_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+                tenant_id=tenant_id,
+                property_id=UUID("11111111-1111-1111-1111-111111111111"),
+                resident_name="Alice Example",
+                rent_due_day_of_month=5,
+                due_date=date(2026, 4, 5),
+                days_until_due=2,
+            )
+        ]
+
+
+def _event_with_auth(*, tenant_id: str = "tenant-from-token", user_id: str = "user-123") -> dict:
+    return {
+        "requestContext": {
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": user_id,
+                        "custom:tenant_id": tenant_id,
+                    }
+                }
+            }
+        }
+    }
+
+
+def test_list_due_lease_reminders_uses_auth_tenant_and_default_days(monkeypatch) -> None:
+    reminders = _reminders_module()
+    db = _FakeDb()
+    event = _event_with_auth(tenant_id="tenant-auth", user_id="user-auth")
+    event["queryStringParameters"] = {"tenant_id": "tenant-body-should-be-ignored"}
+    monkeypatch.setattr(reminders, "_today", lambda: date(2026, 4, 3))
+
+    payload = reminders.list_due_lease_reminders(event, db)
+
+    assert db.calls == [
+        {
+            "tenant_id": "tenant-auth",
+            "as_of_date": date(2026, 4, 3),
+            "days": 7,
+        }
+    ]
+    assert payload == {
+        "items": [
+            {
+                "lease_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "tenant_id": "tenant-auth",
+                "property_id": "11111111-1111-1111-1111-111111111111",
+                "resident_name": "Alice Example",
+                "rent_due_day_of_month": 5,
+                "due_date": "2026-04-05",
+                "days_until_due": 2,
+            }
+        ]
+    }
+
+
+def test_list_due_lease_reminders_supports_days_query_parameter(monkeypatch) -> None:
+    reminders = _reminders_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+    event["queryStringParameters"] = {"days": "14"}
+    monkeypatch.setattr(reminders, "_today", lambda: date(2026, 4, 3))
+
+    reminders.list_due_lease_reminders(event, db)
+
+    assert db.calls[0]["days"] == 14
+
+
+def test_list_due_lease_reminders_rejects_invalid_days(monkeypatch) -> None:
+    reminders = _reminders_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+    event["queryStringParameters"] = {"days": "0"}
+    monkeypatch.setattr(reminders, "_today", lambda: date(2026, 4, 3))
+
+    with pytest.raises(
+        ValueError,
+        match="Query parameter 'days' must be an integer between 1 and 31.",
+    ):
+        reminders.list_due_lease_reminders(event, db)
+
+    assert db.calls == []
+
+
+def test_list_due_lease_reminders_requires_jwt_claims() -> None:
+    reminders = _reminders_module()
+    db = _FakeDb()
+
+    with pytest.raises(AuthError, match="Missing JWT claims."):
+        reminders.list_due_lease_reminders({}, db)

--- a/backend/tests/test_leases_route.py
+++ b/backend/tests/test_leases_route.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from uuid import UUID
+
+import pytest
+
+from app.auth import AuthError
+
+
+def _leases_module():
+    return importlib.import_module("app.routes.leases")
+
+
+@dataclass(slots=True)
+class _LeaseRecord:
+    lease_id: UUID
+    tenant_id: str
+    property_id: UUID
+    resident_name: str
+    rent_due_day_of_month: int
+    start_date: date
+    end_date: date
+    created_at: datetime
+
+
+class _FakeDb:
+    def __init__(self) -> None:
+        self.create_calls: list[dict[str, object]] = []
+        self.list_calls: list[str] = []
+
+    def create_lease(
+        self,
+        tenant_id: str,
+        actor_user_id: str,
+        property_id: UUID,
+        resident_name: str,
+        rent_due_day_of_month: int,
+        start_date: date,
+        end_date: date,
+    ) -> _LeaseRecord:
+        self.create_calls.append(
+            {
+                "tenant_id": tenant_id,
+                "actor_user_id": actor_user_id,
+                "property_id": property_id,
+                "resident_name": resident_name,
+                "rent_due_day_of_month": rent_due_day_of_month,
+                "start_date": start_date,
+                "end_date": end_date,
+            }
+        )
+        return _LeaseRecord(
+            lease_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            tenant_id=tenant_id,
+            property_id=property_id,
+            resident_name=resident_name,
+            rent_due_day_of_month=5,
+            start_date=start_date,
+            end_date=end_date,
+            created_at=datetime(2026, 4, 7, tzinfo=UTC),
+        )
+
+    def list_leases(self, tenant_id: str) -> list[_LeaseRecord]:
+        self.list_calls.append(tenant_id)
+        return [
+            _LeaseRecord(
+                lease_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+                tenant_id=tenant_id,
+                property_id=UUID("11111111-1111-1111-1111-111111111111"),
+                resident_name="Alice Example",
+                rent_due_day_of_month=5,
+                start_date=date(2026, 5, 1),
+                end_date=date(2027, 4, 30),
+                created_at=datetime(2026, 4, 7, tzinfo=UTC),
+            )
+        ]
+
+
+def _event_with_auth(*, tenant_id: str = "tenant-from-token", user_id: str = "user-123") -> dict:
+    return {
+        "requestContext": {
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": user_id,
+                        "custom:tenant_id": tenant_id,
+                    }
+                }
+            }
+        }
+    }
+
+
+def _get_leases_event(*, tenant_id: str = "tenant-from-token", user_id: str = "user-123") -> dict:
+    event = _event_with_auth(tenant_id=tenant_id, user_id=user_id)
+    event["queryStringParameters"] = {"tenant_id": "tenant-from-client-should-be-ignored"}
+    return event
+
+
+def test_list_leases_uses_auth_tenant_not_client_input() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+    event = _get_leases_event(tenant_id="tenant-auth", user_id="user-auth")
+
+    payload = leases.list_leases(event, db)
+
+    assert db.list_calls == ["tenant-auth"]
+    assert payload == {
+        "items": [
+            {
+                "lease_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "tenant_id": "tenant-auth",
+                "property_id": "11111111-1111-1111-1111-111111111111",
+                "resident_name": "Alice Example",
+                "rent_due_day_of_month": 5,
+                "start_date": "2026-05-01",
+                "end_date": "2027-04-30",
+                "created_at": "2026-04-07T00:00:00+00:00",
+            }
+        ]
+    }
+
+
+def test_list_leases_requires_jwt_claims() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+
+    with pytest.raises(AuthError, match="Missing JWT claims."):
+        leases.list_leases({}, db)
+
+
+def test_create_lease_uses_auth_tenant_not_body_tenant() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+    event = _event_with_auth(tenant_id="tenant-auth", user_id="user-auth")
+    property_id = UUID("11111111-1111-1111-1111-111111111111")
+    body = {
+        "tenant_id": "tenant-body-should-be-ignored",
+        "property_id": str(property_id),
+        "resident_name": "Alice Example",
+        "rent_due_day_of_month": 5,
+        "start_date": "2026-05-01",
+        "end_date": "2027-04-30",
+    }
+
+    payload = leases.create_lease(event, db, body)
+
+    assert db.create_calls == [
+        {
+            "tenant_id": "tenant-auth",
+            "actor_user_id": "user-auth",
+            "property_id": property_id,
+            "resident_name": "Alice Example",
+            "rent_due_day_of_month": 5,
+            "start_date": date(2026, 5, 1),
+            "end_date": date(2027, 4, 30),
+        }
+    ]
+    assert payload == {
+        "lease_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "tenant_id": "tenant-auth",
+        "property_id": "11111111-1111-1111-1111-111111111111",
+        "resident_name": "Alice Example",
+        "rent_due_day_of_month": 5,
+        "start_date": "2026-05-01",
+        "end_date": "2027-04-30",
+        "created_at": "2026-04-07T00:00:00+00:00",
+    }
+
+
+def test_create_lease_requires_all_fields() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Fields 'property_id', 'resident_name', "
+            "'rent_due_day_of_month', 'start_date', and 'end_date' are required."
+        ),
+    ):
+        leases.create_lease(
+            event,
+            db,
+            {
+                "property_id": "11111111-1111-1111-1111-111111111111",
+                "resident_name": "Alice Example",
+                "start_date": "2026-05-01",
+            },
+        )
+
+    assert db.create_calls == []
+
+
+def test_create_lease_rejects_invalid_date_format() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+
+    with pytest.raises(ValueError, match="Fields 'start_date' and 'end_date' must use YYYY-MM-DD."):
+        leases.create_lease(
+            event,
+            db,
+            {
+                "property_id": "11111111-1111-1111-1111-111111111111",
+                "resident_name": "Alice Example",
+                "rent_due_day_of_month": 5,
+                "start_date": "05/01/2026",
+                "end_date": "2027-04-30",
+            },
+        )
+
+    assert db.create_calls == []
+
+
+def test_create_lease_rejects_end_date_before_start_date() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+
+    with pytest.raises(ValueError, match="'end_date' must be on or after 'start_date'."):
+        leases.create_lease(
+            event,
+            db,
+            {
+                "property_id": "11111111-1111-1111-1111-111111111111",
+                "resident_name": "Alice Example",
+                "rent_due_day_of_month": 5,
+                "start_date": "2027-05-01",
+                "end_date": "2027-04-30",
+            },
+        )
+
+    assert db.create_calls == []
+
+
+def test_create_lease_rejects_invalid_rent_due_day_of_month() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+
+    with pytest.raises(
+        ValueError,
+        match="Field 'rent_due_day_of_month' must be an integer between 1 and 31.",
+    ):
+        leases.create_lease(
+            event,
+            db,
+            {
+                "property_id": "11111111-1111-1111-1111-111111111111",
+                "resident_name": "Alice Example",
+                "rent_due_day_of_month": 32,
+                "start_date": "2026-05-01",
+                "end_date": "2027-04-30",
+            },
+        )
+
+    assert db.create_calls == []

--- a/docs/mvp-scope.md
+++ b/docs/mvp-scope.md
@@ -7,6 +7,8 @@
   - `GET /health`
   - `POST /properties`
   - `GET /properties`
+  - `POST /leases`
+  - `GET /leases`
 - Cognito JWT-based authentication and tenant claim extraction.
 - PostgreSQL persistence for domain data and audit logs.
 - Infrastructure provisioning with Terraform modules.
@@ -15,6 +17,8 @@
 ## Data Scope (Initial)
 
 - `properties` table for tenant-owned rental units.
+- `leases` table for tenant-owned rental agreements linked to properties.
+- lease contract data includes explicit `rent_due_day_of_month` for future reminder workflows.
 - `audit_logs` table for basic traceability of critical actions.
 - `tenant_id` enforced in all tenant-owned rows.
 


### PR DESCRIPTION
## Summary

Implements the lease MVP vertical slice on top of the existing properties flow.

This PR adds:
- `POST /leases`
- `GET /leases`
- tenant-safe lease persistence and audit logging
- `rent_due_day_of_month` on leases to prepare future reminder workflows
- `GET /lease-reminders/due-soon` for reminder candidate reads
- local invoke support for reminder smoke testing
- updated MVP docs

## Why

The project had strong backend and AWS foundations, but it still lacked the first real rental-management flow beyond properties.

This change adds the smallest useful lease domain slice while preserving strict tenant isolation. It also prepares the backend for a later EventBridge / Scheduler phase without introducing scheduling infrastructure yet.

Main risks addressed:
- cross-tenant property references when creating leases
- missing audit traceability for lease creation
- lack of reminder-ready lease contract data

## Validation

- [x] `make lint`
- [x] `make test`
- [ ] `make tf-fmt` (if `infra/` changed)
- [x] Other relevant checks were run when needed

Other checks run:
- [x] `make test-integration-local`
- [x] local smoke test for `GET /lease-reminders/due-soon`

## Review Notes

- [x] Tenant-scoped queries explicitly filter by `tenant_id` where applicable
- [x] `tenant_id` comes from validated JWT claims, not client input
- [x] Write flows keep domain changes and audit records in one transaction where required
- [x] Structured logging or audit logging was updated if the change affects important write flows
- [x] Docs were updated if architecture, security, or MVP scope changed materially

## Deployment Notes

- Run Alembic migrations to head before using the new lease and reminder flows.
- New migrations in this PR:
  - add `leases` table
  - add `rent_due_day_of_month` to `leases`
- No Terraform changes are required.
- No new AWS services or config values are required for this PR.