### PR TITLE
fix: unblock Lambda SSM SecureString access in private VPC

### DIFF
--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -39,6 +39,7 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
 - Least-privilege IAM for Lambda and API integration.
 - Least-privilege IAM for EventBridge Scheduler to invoke the backend Lambda.
 - Secrets via SSM Parameter Store SecureString, not hardcoded values.
+- Private Lambda access to SSM and KMS uses interface VPC endpoints instead of a NAT path.
 - Structured JSON logging for traceability.
 
 ## Cost-Aware Decisions
@@ -46,6 +47,7 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
 - Single backend Lambda for MVP simplicity.
 - One RDS instance in dev with small sizing.
 - No NAT Gateway in dev environment.
+- Private AWS API dependencies are reached through targeted interface endpoints where required.
 - No extra services unless they deliver clear MVP value.
 - One daily scheduler is preferred over per-tenant schedules to keep dev-stage operational cost and complexity low.
 

--- a/docs/security-baseline.md
+++ b/docs/security-baseline.md
@@ -134,6 +134,7 @@ Mitigations:
 - No secrets are stored in the Git repository, Terraform variables files committed to source control, or Lambda source code.
 - Runtime secrets are stored in AWS Systems Manager Parameter Store as `SecureString` values.
 - Lambda retrieves required secrets at runtime using IAM-scoped access.
+- When Lambda runs in private subnets without NAT, secret resolution must use private AWS service connectivity such as interface VPC endpoints for SSM and KMS.
 - Secrets must not be printed to logs, returned in API responses, or embedded in error messages.
 - Rotate secrets when exposure is suspected or when credentials change.
 
@@ -165,6 +166,7 @@ Examples of auditable events:
 
 - Amazon RDS PostgreSQL must not be publicly accessible.
 - Security groups must allow only required traffic paths between components.
+- Private runtimes that call AWS control-plane services must have an explicit private network path when no NAT Gateway is present.
 - IAM policies must follow least privilege for Lambda, Terraform execution, and any automation roles.
 - API access must be exposed only through HTTPS endpoints.
 - Infrastructure must be managed through Terraform to reduce drift and make security-relevant changes reviewable.

--- a/infra/modules/lambda_backend/.terraform.lock.hcl
+++ b/infra/modules/lambda_backend/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.39.0"
+  constraints = "~> 6.37"
+  hashes = [
+    "h1:QwtlSBjpxlw3Almi8cMWWlTkRj1Od5jBBEFYR+8XXcs=",
+    "h1:jweey4Iefm/DuuBg84saQ8vz5IO3vC6hDFTU/eGdmBI=",
+    "zh:00c3e3c38063ff629d6fdbce04e9ac2e241566e0f5ad5399c335f0abdefd7bff",
+    "zh:148f95b62791080537d926b9d2f5d8457cca45921d9b1019d03ceb3ab93bf9db",
+    "zh:203da629ed5191dd5d7aa3427a5d1d1a83eed5c1b0114166897206973f0d0fd0",
+    "zh:21923eedbc60b4f68c8d717b951d16b0b1bbf31d66330c7be228869bec18f7ce",
+    "zh:26226f02e3661b3d071c01601b654a308b29d21758b75692bec66f70c6f6b945",
+    "zh:271c7c6fadcd8ac7ed37c11e61c0f374773eaaa5293703499f8a0f75830060e0",
+    "zh:46e319a8888dc50ed8d26a1cbee9637f529112a88f5d44decc8f1d10ef968ffe",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a3c3ca09cdbf3b9a3f892a23c000ff04772bdf19f626959ea83d0803c8fd2350",
+    "zh:a5fa6515ffc3c815e0d2204d67e838f5bad8635009dab85211d166c7ae729d2c",
+    "zh:c0807566b4ddde8390f50c5475464103f066bc7f511a6c0be762d75cb6d1a078",
+    "zh:da754a529fd0e06ac372f62d88566f85a8c4bcec7ee9a231b65e0a0148165e63",
+    "zh:dcb768e48363a9f4dffaf2dc7d01f1877285528925ec50de6335286298e37e1d",
+    "zh:eac9de9d123c679ea3035199fb9c588a08cda281cbabf948dc696e2a1a1b9063",
+    "zh:fef276b6331c663ca0e60dc7f637b2b8244825b8c9bc721481957e58f74ffb4f",
+  ]
+}

--- a/infra/modules/lambda_backend/main.tf
+++ b/infra/modules/lambda_backend/main.tf
@@ -1,30 +1,12 @@
 data "aws_caller_identity" "current" {}
+data "aws_kms_alias" "ssm" {
+  name = "alias/aws/ssm"
+}
 data "aws_region" "current" {}
 
-resource "aws_iam_role" "this" {
-  name = "${var.name_prefix}-lambda-role"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Service = "lambda.amazonaws.com"
-        }
-        Action = "sts:AssumeRole"
-      }
-    ]
-  })
-
-  tags = merge(var.tags, { Name = "${var.name_prefix}-lambda-role" })
-}
-
-resource "aws_iam_role_policy" "this" {
-  name = "${var.name_prefix}-lambda-policy"
-  role = aws_iam_role.this.id
-
-  policy = jsonencode({
+locals {
+  db_password_parameter_arn = "arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter${var.db_password_ssm_param}"
+  lambda_policy = {
     Version = "2012-10-17"
     Statement = [
       {
@@ -49,10 +31,47 @@ resource "aws_iam_role_policy" "this" {
         Sid      = "ReadDbPasswordParameter"
         Effect   = "Allow"
         Action   = ["ssm:GetParameter"]
-        Resource = "arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter${var.db_password_ssm_param}"
+        Resource = local.db_password_parameter_arn
+      },
+      {
+        Sid      = "DecryptDbPasswordParameter"
+        Effect   = "Allow"
+        Action   = ["kms:Decrypt"]
+        Resource = data.aws_kms_alias.ssm.target_key_arn
+        Condition = {
+          StringEquals = {
+            "kms:EncryptionContext:PARAMETER_ARN" = local.db_password_parameter_arn
+          }
+        }
+      }
+    ]
+  }
+}
+
+resource "aws_iam_role" "this" {
+  name = "${var.name_prefix}-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
       }
     ]
   })
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-lambda-role" })
+}
+
+resource "aws_iam_role_policy" "this" {
+  name = "${var.name_prefix}-lambda-policy"
+  role = aws_iam_role.this.id
+
+  policy = jsonencode(local.lambda_policy)
 }
 
 resource "aws_cloudwatch_log_group" "this" {

--- a/infra/modules/lambda_backend/tests/defaults.tftest.hcl
+++ b/infra/modules/lambda_backend/tests/defaults.tftest.hcl
@@ -1,0 +1,67 @@
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+
+  mock_data "aws_region" {
+    defaults = {
+      region = "eu-north-1"
+    }
+  }
+
+  mock_data "aws_kms_alias" {
+    defaults = {
+      arn            = "arn:aws:kms:eu-north-1:123456789012:alias/aws/ssm"
+      name           = "alias/aws/ssm"
+      target_key_arn = "arn:aws:kms:eu-north-1:123456789012:key/11111111-2222-3333-4444-555555555555"
+    }
+  }
+}
+
+variables {
+  name_prefix              = "leaseflow-dev"
+  function_name            = "leaseflow-dev-backend"
+  package_file             = "main.tf"
+  private_subnet_ids       = ["subnet-11111111", "subnet-22222222"]
+  lambda_security_group_id = "sg-12345678"
+  environment              = "dev"
+  db_host                  = "leaseflow-dev-postgres.example.amazonaws.com"
+  db_port                  = 5432
+  db_name                  = "leaseflow"
+  db_user                  = "leaseflow_admin"
+  db_password_ssm_param    = "/leaseflow/dev/db/password"
+  tags = {
+    Project = "leaseflow"
+  }
+}
+
+run "scopes_runtime_secret_permissions_to_the_db_password_parameter" {
+  command = plan
+
+  assert {
+    condition     = local.lambda_policy.Statement[2].Action[0] == "ssm:GetParameter"
+    error_message = "Lambda policy should allow reading the DB password parameter from SSM."
+  }
+
+  assert {
+    condition     = local.lambda_policy.Statement[2].Resource == "arn:aws:ssm:eu-north-1:123456789012:parameter/leaseflow/dev/db/password"
+    error_message = "SSM access should be scoped to the DB password parameter ARN."
+  }
+
+  assert {
+    condition     = local.lambda_policy.Statement[3].Action[0] == "kms:Decrypt"
+    error_message = "Lambda policy should allow KMS decrypt for SecureString resolution."
+  }
+
+  assert {
+    condition     = local.lambda_policy.Statement[3].Resource == "arn:aws:kms:eu-north-1:123456789012:key/11111111-2222-3333-4444-555555555555"
+    error_message = "KMS decrypt should be scoped to the AWS-managed key backing alias/aws/ssm."
+  }
+
+  assert {
+    condition     = local.lambda_policy.Statement[3].Condition.StringEquals["kms:EncryptionContext:PARAMETER_ARN"] == "arn:aws:ssm:eu-north-1:123456789012:parameter/leaseflow/dev/db/password"
+    error_message = "KMS decrypt should be limited to the DB password parameter encryption context."
+  }
+}

--- a/infra/modules/lambda_backend/versions.tf
+++ b/infra/modules/lambda_backend/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.37"
+    }
+  }
+}

--- a/infra/modules/network/.terraform.lock.hcl
+++ b/infra/modules/network/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.39.0"
+  constraints = "~> 6.37"
+  hashes = [
+    "h1:QwtlSBjpxlw3Almi8cMWWlTkRj1Od5jBBEFYR+8XXcs=",
+    "h1:jweey4Iefm/DuuBg84saQ8vz5IO3vC6hDFTU/eGdmBI=",
+    "zh:00c3e3c38063ff629d6fdbce04e9ac2e241566e0f5ad5399c335f0abdefd7bff",
+    "zh:148f95b62791080537d926b9d2f5d8457cca45921d9b1019d03ceb3ab93bf9db",
+    "zh:203da629ed5191dd5d7aa3427a5d1d1a83eed5c1b0114166897206973f0d0fd0",
+    "zh:21923eedbc60b4f68c8d717b951d16b0b1bbf31d66330c7be228869bec18f7ce",
+    "zh:26226f02e3661b3d071c01601b654a308b29d21758b75692bec66f70c6f6b945",
+    "zh:271c7c6fadcd8ac7ed37c11e61c0f374773eaaa5293703499f8a0f75830060e0",
+    "zh:46e319a8888dc50ed8d26a1cbee9637f529112a88f5d44decc8f1d10ef968ffe",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a3c3ca09cdbf3b9a3f892a23c000ff04772bdf19f626959ea83d0803c8fd2350",
+    "zh:a5fa6515ffc3c815e0d2204d67e838f5bad8635009dab85211d166c7ae729d2c",
+    "zh:c0807566b4ddde8390f50c5475464103f066bc7f511a6c0be762d75cb6d1a078",
+    "zh:da754a529fd0e06ac372f62d88566f85a8c4bcec7ee9a231b65e0a0148165e63",
+    "zh:dcb768e48363a9f4dffaf2dc7d01f1877285528925ec50de6335286298e37e1d",
+    "zh:eac9de9d123c679ea3035199fb9c588a08cda281cbabf948dc696e2a1a1b9063",
+    "zh:fef276b6331c663ca0e60dc7f637b2b8244825b8c9bc721481957e58f74ffb4f",
+  ]
+}

--- a/infra/modules/network/main.tf
+++ b/infra/modules/network/main.tf
@@ -1,3 +1,5 @@
+data "aws_region" "current" {}
+
 data "aws_availability_zones" "available" {
   state = "available"
 }
@@ -58,6 +60,29 @@ resource "aws_security_group" "lambda" {
   tags = merge(var.tags, { Name = "${var.name_prefix}-lambda-sg" })
 }
 
+resource "aws_security_group" "private_service_endpoints" {
+  name        = "${var.name_prefix}-vpce-sg"
+  description = "LeaseFlow PrivateLink endpoints security group"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description     = "HTTPS from Lambda SG"
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    security_groups = [aws_security_group.lambda.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-vpce-sg" })
+}
+
 resource "aws_security_group" "rds" {
   name        = "${var.name_prefix}-rds-sg"
   description = "LeaseFlow RDS security group"
@@ -79,4 +104,26 @@ resource "aws_security_group" "rds" {
   }
 
   tags = merge(var.tags, { Name = "${var.name_prefix}-rds-sg" })
+}
+
+resource "aws_vpc_endpoint" "ssm" {
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ssm"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  subnet_ids          = aws_subnet.private[*].id
+  security_group_ids  = [aws_security_group.private_service_endpoints.id]
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-ssm-vpce" })
+}
+
+resource "aws_vpc_endpoint" "kms" {
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.kms"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  subnet_ids          = aws_subnet.private[*].id
+  security_group_ids  = [aws_security_group.private_service_endpoints.id]
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-kms-vpce" })
 }

--- a/infra/modules/network/outputs.tf
+++ b/infra/modules/network/outputs.tf
@@ -17,3 +17,18 @@ output "rds_security_group_id" {
   value       = aws_security_group.rds.id
   description = "RDS SG ID."
 }
+
+output "private_service_endpoints_security_group_id" {
+  value       = aws_security_group.private_service_endpoints.id
+  description = "Security group ID for interface VPC endpoints."
+}
+
+output "ssm_vpc_endpoint_id" {
+  value       = aws_vpc_endpoint.ssm.id
+  description = "SSM interface VPC endpoint ID."
+}
+
+output "kms_vpc_endpoint_id" {
+  value       = aws_vpc_endpoint.kms.id
+  description = "KMS interface VPC endpoint ID."
+}

--- a/infra/modules/network/tests/defaults.tftest.hcl
+++ b/infra/modules/network/tests/defaults.tftest.hcl
@@ -1,0 +1,78 @@
+mock_provider "aws" {
+  mock_data "aws_region" {
+    defaults = {
+      region = "eu-north-1"
+    }
+  }
+
+  mock_data "aws_availability_zones" {
+    defaults = {
+      names = ["eu-north-1a", "eu-north-1b"]
+    }
+  }
+}
+
+variables {
+  name_prefix          = "leaseflow-dev"
+  vpc_cidr             = "10.20.0.0/16"
+  private_subnet_cidrs = ["10.20.1.0/24", "10.20.2.0/24"]
+  tags = {
+    Project = "leaseflow"
+  }
+}
+
+run "creates_private_interface_endpoints_for_runtime_secrets" {
+  command = plan
+
+  assert {
+    condition     = aws_vpc_endpoint.ssm.vpc_endpoint_type == "Interface"
+    error_message = "SSM should use an interface VPC endpoint."
+  }
+
+  assert {
+    condition     = aws_vpc_endpoint.ssm.service_name == "com.amazonaws.eu-north-1.ssm"
+    error_message = "SSM endpoint should target the regional Systems Manager service."
+  }
+
+  assert {
+    condition     = aws_vpc_endpoint.ssm.private_dns_enabled == true
+    error_message = "SSM endpoint should enable private DNS."
+  }
+
+  assert {
+    condition     = length(aws_subnet.private) == 2
+    error_message = "Network module should create exactly two private subnets for interface endpoints."
+  }
+
+  assert {
+    condition     = aws_vpc_endpoint.kms.vpc_endpoint_type == "Interface"
+    error_message = "KMS should use an interface VPC endpoint."
+  }
+
+  assert {
+    condition     = aws_vpc_endpoint.kms.service_name == "com.amazonaws.eu-north-1.kms"
+    error_message = "KMS endpoint should target the regional KMS service."
+  }
+
+  assert {
+    condition     = aws_vpc_endpoint.kms.private_dns_enabled == true
+    error_message = "KMS endpoint should enable private DNS."
+  }
+
+  assert {
+    condition     = length(aws_subnet.private) == 2
+    error_message = "Network module should create exactly two private subnets for interface endpoints."
+  }
+
+  assert {
+    condition = length([
+      for rule in aws_security_group.private_service_endpoints.ingress : rule
+      if rule.description == "HTTPS from Lambda SG"
+      && rule.from_port == 443
+      && rule.to_port == 443
+      && rule.protocol == "tcp"
+      && length(rule.security_groups) == 1
+    ]) == 1
+    error_message = "Endpoint security group should allow one HTTPS ingress rule from the Lambda security group."
+  }
+}

--- a/infra/modules/network/versions.tf
+++ b/infra/modules/network/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.37"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Unblocks private Lambda access to the database password stored in SSM Parameter Store.

This PR adds:
- interface VPC endpoints for `ssm` and `kms`
- a dedicated security group for private service endpoints
- scoped `kms:Decrypt` permission for the backend Lambda when resolving the DB password `SecureString`
- Terraform test coverage for the `network` and `lambda_backend` modules
- small architecture and security documentation updates

## Why

The deployed dev environment existed in AWS, but database-backed Lambda flows still timed out.

Smoke testing showed that:
- the backend Lambda runs in private subnets
- the DB password is resolved from SSM Parameter Store at runtime
- there was no NAT Gateway and no private endpoint path to SSM or KMS

That meant the Lambda could not reliably resolve the DB secret from the private VPC path. This PR fixes that with the smallest cost-aware infrastructure change, while keeping RDS private and preserving the existing SSM secret model.

## Validation

- [ ] `make lint`
- [ ] `make test`
- [x] `make tf-fmt` (if `infra/` changed)
- [x] Other relevant checks were run when needed

Other checks run:
- [x] `terraform test` in `infra/modules/network`
- [x] `terraform test` in `infra/modules/lambda_backend`
- [x] `terraform validate` in `infra/environments/dev`
- [x] dev `terraform apply`
- [x] deployed Lambda smoke test for internal reminder scan
- [x] CloudWatch log verification that the old 15 s SSM timeout is gone

## Review Notes

- [ ] Tenant-scoped queries explicitly filter by `tenant_id` where applicable
- [ ] `tenant_id` comes from validated JWT claims, not client input
- [ ] Write flows keep domain changes and audit records in one transaction where required
- [ ] Structured logging or audit logging was updated if the change affects important write flows
- [x] Docs were updated if architecture, security, or MVP scope changed materially

## Deployment Notes

- Run `terraform apply` for the target environment to create the new `ssm` and `kms` interface endpoints and update the Lambda IAM policy.
- No application config changes are required.
- No HTTP API changes are included in this PR.
- After deploy, internal Lambda invocation should no longer fail with the previous secret-access timeout.
- A remaining fast database/schema error after deploy is acceptable for this PR and should be handled in a separate migration-path task.
