### PR TITLE
feat: add Cognito tenant claim support for protected API auth

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -8,7 +8,7 @@ Python Lambda backend for LeaseFlow MVP.
 - `GET /health`
 - `POST /properties`
 - `GET /properties`
-- JWT claim extraction (`sub`, `custom:tenant_id`)
+- JWT claim extraction from Cognito ID tokens (`sub`, `custom:tenant_id`)
 - Tenant-scoped data access
 - Audit logging on property creation
 - Alembic migration setup

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -21,7 +21,8 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
 ## Multi-Tenant Design
 
 - `tenant_id` is mandatory in tenant-owned domain tables.
-- Backend extracts tenant context from JWT claim `custom:tenant_id`.
+- Backend extracts tenant context from Cognito JWT claim `custom:tenant_id`.
+- Protected HTTP API calls use a Cognito ID token so the tenant custom attribute is available to the backend.
 - Tenant context is never trusted from client-provided payload.
 - Query patterns are tenant-scoped by design.
 
@@ -35,6 +36,7 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
 ## Security Baseline Alignment
 
 - App-level tenant isolation with explicit auth checks.
+- Cognito user pool stores tenant membership in custom attribute `custom:tenant_id`.
 - Private RDS in VPC subnets, not publicly accessible.
 - Least-privilege IAM for Lambda and API integration.
 - Least-privilege IAM for EventBridge Scheduler to invoke the backend Lambda.

--- a/docs/security-baseline.md
+++ b/docs/security-baseline.md
@@ -51,6 +51,7 @@ Mitigations:
 - Use Amazon Cognito for authentication instead of custom password handling.
 - Validate JWT signature, issuer, audience, expiry, and required claims on every protected request.
 - Derive user identity and tenant context from validated token claims, not from client-supplied fields.
+- For tenant-scoped HTTP API calls, use the Cognito ID token so the backend receives `custom:tenant_id`.
 - Require strong password policy and support MFA in Cognito as the account base matures.
 - Use short-lived tokens and avoid long-lived static credentials for workloads.
 
@@ -123,6 +124,7 @@ Mitigations:
 
 - Every tenant-owned table must include `tenant_id`.
 - Tenant context must be extracted from validated JWT claims.
+- `custom:tenant_id` should come from a Cognito custom user attribute that is readable but not client-writable.
 - All queries that access tenant data must be explicitly tenant-scoped.
 - `tenant_id` provided by the client must never be trusted as the authorization source.
 - Service logic must verify that the authenticated user is allowed to act within the resolved tenant.

--- a/infra/modules/cognito/.terraform.lock.hcl
+++ b/infra/modules/cognito/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.38.0"
+  constraints = "~> 6.37"
+  hashes = [
+    "h1:7F3W4qGLTbr4aploSI8eIqE4AueoNe/Tq5Osuo0IgJ4=",
+    "h1:IMf41BcW9huOeVcrt6XjQqadYR2xD8zkUpGLLERJ4NM=",
+    "zh:143f118ae71059a7a7026c6b950da23fef04a06e2362ffa688bef75e43e869ed",
+    "zh:29ee220a017306effd877e1280f8b2934dc957e16e0e72ca0222e5514d0db522",
+    "zh:3a31baabf7aea7aa7669f5a3d76f3445e0e6cce5e9aea0279992765c0df12aee",
+    "zh:4c1908e62040dbc9901d4426ffb253f53e5dae9e3e1a9125311291ee265c8d8c",
+    "zh:550f4789f5f5b00e16118d4c17770be3ef4535d6b6928af1cf91ebd30f2c263b",
+    "zh:6537b7b70bf2c127771b0b84e4b726c834d10666b6104f017edae50c67ebae37",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:af2f9cea0c8bdf5b2a2391f2d179a946c117196f7c829b919673cae3b71d2943",
+    "zh:c53ffa685381aa4e73158fd9f529239f95938dea330e7aca0b32e7b2a1210432",
+    "zh:d0995e1d64a7ec8bbc79fc3fbec3749f989e07f211a318705c37cd6a7c7d19e4",
+    "zh:d2348ffcffc1282983d7a5838dd5d61f372152fe6c0d10868cd6473352318750",
+    "zh:e449312efb73e4747165e689302a68a1df8ba5755e7f59097069acf82c94f011",
+    "zh:ec3a538d264ef79380e56fdf107ffb6c0446814f07fc5890c36855fe1e03196b",
+    "zh:f441e69699b22e32c96a8cdd3bbe694ed302c0dcfe867cd9bd683a16df362714",
+    "zh:f6f8eaa605ff902234d7e9bdab4fda977185fce14f8576f7b622c914c7d98008",
+  ]
+}

--- a/infra/modules/cognito/main.tf
+++ b/infra/modules/cognito/main.tf
@@ -1,3 +1,20 @@
+locals {
+  app_client_explicit_auth_flows = [
+    "ALLOW_ADMIN_USER_PASSWORD_AUTH",
+    "ALLOW_CUSTOM_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH",
+    "ALLOW_USER_SRP_AUTH",
+  ]
+  app_client_read_attributes = [
+    "custom:tenant_id",
+    "email",
+    "email_verified",
+  ]
+  app_client_write_attributes = [
+    "email",
+  ]
+}
+
 resource "aws_cognito_user_pool" "this" {
   name = "${var.name_prefix}-user-pool"
 
@@ -13,6 +30,18 @@ resource "aws_cognito_user_pool" "this" {
 
   username_attributes = ["email"]
   tags                = merge(var.tags, { Name = "${var.name_prefix}-user-pool" })
+
+  schema {
+    name                = "tenant_id"
+    attribute_data_type = "String"
+    mutable             = true
+    required            = false
+
+    string_attribute_constraints {
+      min_length = 1
+      max_length = 64
+    }
+  }
 }
 
 resource "aws_cognito_user_pool_client" "this" {
@@ -23,4 +52,7 @@ resource "aws_cognito_user_pool_client" "this" {
   prevent_user_existence_errors        = "ENABLED"
   enable_token_revocation              = true
   allowed_oauth_flows_user_pool_client = false
+  explicit_auth_flows                  = local.app_client_explicit_auth_flows
+  read_attributes                      = local.app_client_read_attributes
+  write_attributes                     = local.app_client_write_attributes
 }

--- a/infra/modules/cognito/tests/defaults.tftest.hcl
+++ b/infra/modules/cognito/tests/defaults.tftest.hcl
@@ -1,0 +1,45 @@
+mock_provider "aws" {}
+
+variables {
+  name_prefix = "leaseflow-dev"
+  tags = {
+    Project = "leaseflow"
+  }
+}
+
+run "exposes_tenant_id_claim_for_api_auth" {
+  command = apply
+
+  assert {
+    condition = length([
+      for attribute in aws_cognito_user_pool.this.schema : attribute
+      if attribute.name == "tenant_id"
+      && attribute.attribute_data_type == "String"
+      && attribute.mutable == true
+      && attribute.required == false
+      && attribute.string_attribute_constraints[0].min_length == "1"
+      && attribute.string_attribute_constraints[0].max_length == "64"
+    ]) == 1
+    error_message = "User pool should define tenant_id as an optional mutable string custom attribute."
+  }
+
+  assert {
+    condition     = try(contains(aws_cognito_user_pool_client.this.explicit_auth_flows, "ALLOW_ADMIN_USER_PASSWORD_AUTH"), false)
+    error_message = "App client should allow ADMIN_USER_PASSWORD_AUTH for deployed smoke testing."
+  }
+
+  assert {
+    condition     = try(contains(aws_cognito_user_pool_client.this.read_attributes, "custom:tenant_id"), false)
+    error_message = "App client should expose custom:tenant_id as a readable attribute."
+  }
+
+  assert {
+    condition     = try(contains(aws_cognito_user_pool_client.this.read_attributes, "email"), false)
+    error_message = "App client should expose email as a readable attribute."
+  }
+
+  assert {
+    condition     = try(contains(aws_cognito_user_pool_client.this.write_attributes, "custom:tenant_id"), false) == false
+    error_message = "App client should not allow writing custom:tenant_id."
+  }
+}

--- a/infra/modules/cognito/versions.tf
+++ b/infra/modules/cognito/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.37"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds Cognito tenant claim support for protected API authentication.

This PR introduces:
- a custom Cognito user pool attribute for `tenant_id`
- explicit app client auth flows for repeatable admin-driven smoke testing
- app client read/write attribute permissions so `custom:tenant_id` is readable in tokens but not client-writable
- Terraform test coverage for the Cognito module
- documentation updates clarifying that protected API calls use a Cognito ID token carrying `custom:tenant_id`

## Why

The deployed backend already required JWT claims `sub` and `custom:tenant_id`, but the Cognito user pool did not define the tenant attribute at all.

That created a contract mismatch:
- protected API routes could not be smoke tested with real Cognito tokens
- authenticated requests would fail backend auth validation because `custom:tenant_id` was missing
- tenant isolation relied on a claim that the identity provider could not issue

This PR closes that gap with the smallest useful Cognito change and makes deployed JWT-based verification practical in dev.

## Validation

- [ ] `make lint`
- [ ] `make test`
- [x] `make tf-fmt` (if `infra/` changed)
- [x] Other relevant checks were run when needed

Other checks run:
- [x] `terraform test` in `infra/modules/cognito`
- [x] `terraform validate` in the dev environment
- [x] dev `terraform apply`
- [x] deployed Cognito smoke test using `ADMIN_USER_PASSWORD_AUTH`
- [x] verified the issued ID token contains `custom:tenant_id`
- [x] verified a protected API route now reaches Lambda instead of failing at the JWT claim boundary

## Review Notes

- [ ] Tenant-scoped queries explicitly filter by `tenant_id` where applicable
- [x] `tenant_id` comes from validated JWT claims, not client input
- [ ] Write flows keep domain changes and audit records in one transaction where required
- [ ] Structured logging or audit logging was updated if the change affects important write flows
- [x] Docs were updated if architecture, security, or MVP scope changed materially

## Deployment Notes

- Run `terraform apply` for the target environment to update the Cognito user pool schema and app client settings.
- Protected API requests should use a Cognito ID token so the backend receives `custom:tenant_id`.
- This PR enables admin-driven smoke testing with `ADMIN_USER_PASSWORD_AUTH`.
- No HTTP API route changes are included.
- No database migration is included.
- After deploy, a protected route may still fail with a fast database/schema error if the AWS DB schema has not been migrated yet; that is expected and outside this PR’s scope.