### PR TITLE
feat: add deployed Lambda migration path for private RDS

### DIFF
--- a/backend/src/app/handler.py
+++ b/backend/src/app/handler.py
@@ -8,6 +8,7 @@ from app.auth import AuthError
 from app.config import ConfigError, load_settings
 from app.db import Database
 from app.logging import get_logger, setup_logging
+from app.routes.db_migrations import run_db_migrations
 from app.routes.health import get_health
 from app.routes.lease_reminders import list_due_lease_reminders
 from app.routes.leases import create_lease, list_leases
@@ -66,6 +67,11 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
 
         settings = load_settings()
         setup_logging(settings.log_level)
+        if (
+            event.get("source") == "leaseflow.internal"
+            and event.get("detail-type") == "run_db_migrations"
+        ):
+            return _response(HTTPStatus.OK, run_db_migrations(settings))
         db = Database(settings)
         if (
             event.get("source") == "leaseflow.internal"

--- a/backend/src/app/routes/db_migrations.py
+++ b/backend/src/app/routes/db_migrations.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import quote_plus
+
+import psycopg
+from alembic import command
+from alembic.config import Config
+from psycopg.conninfo import conninfo_to_dict
+from psycopg.errors import UndefinedTable
+
+from app.config import Settings
+
+
+@dataclass(frozen=True, slots=True)
+class _MigrationPaths:
+    alembic_ini: Path
+    migrations_dir: Path
+
+
+def run_db_migrations(settings: Settings) -> dict[str, str | None]:
+    dsn = settings.db_dsn()
+    previous_revision = _current_revision(dsn)
+    _upgrade_to_head(sqlalchemy_url=_sqlalchemy_url(dsn), paths=_resolve_migration_paths())
+    current_revision = _current_revision(dsn)
+    if not current_revision:
+        raise RuntimeError("Alembic did not report a current revision after upgrade.")
+
+    return {
+        "target_revision": "head",
+        "previous_revision": previous_revision,
+        "current_revision": current_revision,
+    }
+
+
+def _resolve_migration_paths() -> _MigrationPaths:
+    current_file = Path(__file__).resolve()
+    candidates = [
+        current_file.parents[2],
+        current_file.parents[3],
+        Path.cwd(),
+    ]
+    for base_dir in candidates:
+        alembic_ini = base_dir / "alembic.ini"
+        migrations_dir = base_dir / "migrations"
+        if alembic_ini.is_file() and migrations_dir.is_dir():
+            return _MigrationPaths(
+                alembic_ini=alembic_ini,
+                migrations_dir=migrations_dir,
+            )
+
+    raise FileNotFoundError("Alembic assets not found. Expected alembic.ini and migrations/.")
+
+
+def _sqlalchemy_url(dsn: str) -> str:
+    conninfo = conninfo_to_dict(dsn)
+    user = quote_plus(str(conninfo["user"]))
+    password = quote_plus(str(conninfo["password"]))
+    host = str(conninfo["host"])
+    port = str(conninfo["port"])
+    dbname = quote_plus(str(conninfo["dbname"]))
+    return f"postgresql+psycopg://{user}:{password}@{host}:{port}/{dbname}"
+
+
+def _current_revision(dsn: str) -> str | None:
+    try:
+        with psycopg.connect(dsn) as conn:
+            row = conn.execute("SELECT version_num FROM alembic_version").fetchone()
+    except UndefinedTable:
+        return None
+
+    if not row:
+        return None
+    return str(row[0])
+
+
+def _upgrade_to_head(*, sqlalchemy_url: str, paths: _MigrationPaths) -> None:
+    config = Config(str(paths.alembic_ini))
+    config.set_main_option("script_location", str(paths.migrations_dir))
+    config.set_main_option("sqlalchemy.url", sqlalchemy_url)
+    command.upgrade(config, "head")

--- a/backend/tests/test_db_migrations_route.py
+++ b/backend/tests/test_db_migrations_route.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _db_migrations_module():
+    return importlib.import_module("app.routes.db_migrations")
+
+
+def test_run_db_migrations_returns_previous_and_current_revision(monkeypatch) -> None:
+    db_migrations = _db_migrations_module()
+    upgrade_calls: list[dict[str, object]] = []
+    revisions = iter(["20260310_0001", "20260407_0005"])
+    paths = SimpleNamespace(
+        alembic_ini=Path("/var/task/alembic.ini"),
+        migrations_dir=Path("/var/task/migrations"),
+    )
+
+    monkeypatch.setattr(db_migrations, "_resolve_migration_paths", lambda: paths)
+    monkeypatch.setattr(
+        db_migrations,
+        "_sqlalchemy_url",
+        lambda settings: "postgresql+psycopg://leaseflow_admin:secret@db:5432/leaseflow",
+    )
+    monkeypatch.setattr(db_migrations, "_current_revision", lambda dsn: next(revisions))
+
+    def _fake_upgrade(*, sqlalchemy_url: str, paths: object) -> None:
+        upgrade_calls.append({"sqlalchemy_url": sqlalchemy_url, "paths": paths})
+
+    monkeypatch.setattr(db_migrations, "_upgrade_to_head", _fake_upgrade)
+
+    payload = db_migrations.run_db_migrations(
+        SimpleNamespace(db_dsn=lambda: "host=db port=5432 dbname=leaseflow user=leaseflow_admin")
+    )
+
+    assert payload == {
+        "target_revision": "head",
+        "previous_revision": "20260310_0001",
+        "current_revision": "20260407_0005",
+    }
+    assert upgrade_calls == [
+        {
+            "sqlalchemy_url": "postgresql+psycopg://leaseflow_admin:secret@db:5432/leaseflow",
+            "paths": paths,
+        }
+    ]
+
+
+def test_run_db_migrations_reports_null_previous_revision_when_version_table_missing(
+    monkeypatch,
+) -> None:
+    db_migrations = _db_migrations_module()
+    revisions = iter([None, "20260407_0005"])
+
+    monkeypatch.setattr(
+        db_migrations,
+        "_resolve_migration_paths",
+        lambda: SimpleNamespace(
+            alembic_ini=Path("/var/task/alembic.ini"),
+            migrations_dir=Path("/var/task/migrations"),
+        ),
+    )
+    monkeypatch.setattr(
+        db_migrations,
+        "_sqlalchemy_url",
+        lambda settings: "postgresql+psycopg://leaseflow_admin:secret@db:5432/leaseflow",
+    )
+    monkeypatch.setattr(db_migrations, "_current_revision", lambda dsn: next(revisions))
+    monkeypatch.setattr(db_migrations, "_upgrade_to_head", lambda **kwargs: None)
+
+    payload = db_migrations.run_db_migrations(
+        SimpleNamespace(db_dsn=lambda: "host=db port=5432 dbname=leaseflow user=leaseflow_admin")
+    )
+
+    assert payload == {
+        "target_revision": "head",
+        "previous_revision": None,
+        "current_revision": "20260407_0005",
+    }

--- a/backend/tests/test_handler.py
+++ b/backend/tests/test_handler.py
@@ -236,3 +236,36 @@ def test_scan_due_lease_reminders_accepts_internal_event(monkeypatch) -> None:
         "created_count": 1,
         "duplicate_count": 0,
     }
+
+
+def test_run_db_migrations_accepts_internal_event(monkeypatch) -> None:
+    monkeypatch.setattr(
+        handler,
+        "load_settings",
+        lambda: SimpleNamespace(log_level="INFO"),
+    )
+    monkeypatch.setattr(
+        handler,
+        "run_db_migrations",
+        lambda settings: {
+            "target_revision": "head",
+            "previous_revision": None,
+            "current_revision": "20260407_0005",
+        },
+        raising=False,
+    )
+
+    event = {
+        "source": "leaseflow.internal",
+        "detail-type": "run_db_migrations",
+        "detail": {},
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 200
+    assert json.loads(response["body"]) == {
+        "target_revision": "head",
+        "previous_revision": None,
+        "current_revision": "20260407_0005",
+    }

--- a/infra/README.md
+++ b/infra/README.md
@@ -79,6 +79,8 @@ python3.12 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
 python -m pip install ./backend -t dist/lambda-build
+cp backend/alembic.ini dist/lambda-build/alembic.ini
+rsync -a backend/migrations/ dist/lambda-build/migrations/
 find dist/lambda-build -type d -name "__pycache__" -prune -exec rm -rf {} +
 (cd dist/lambda-build && zip -r ../leaseflow-backend.zip .)
 ```
@@ -92,6 +94,9 @@ Before running Terraform, verify that the zip exists and contains the backend pa
 ```bash
 cd ~/leaseflow-preflight
 test -f dist/leaseflow-backend.zip
+unzip -l dist/leaseflow-backend.zip | grep "alembic.ini"
+unzip -l dist/leaseflow-backend.zip | grep "migrations/env.py"
+unzip -l dist/leaseflow-backend.zip | grep "migrations/versions/"
 unzip -l dist/leaseflow-backend.zip | grep "app/"
 unzip -l dist/leaseflow-backend.zip | grep "boto3/"
 ```
@@ -178,3 +183,35 @@ For a real dev deployment, prefer saving the plan first:
 terraform plan -out=tfplan
 terraform apply tfplan
 ```
+
+## Run deployed DB migrations
+
+When the dev stack is already deployed but the private RDS schema is missing, use the backend Lambda's internal migration event.
+
+Build and deploy a fresh Lambda artifact first so the zip contains both `alembic.ini` and `migrations/`.
+
+Then invoke the migration path directly:
+
+```bash
+cd ~/leaseflow-preflight
+cat > migration-payload.json <<'JSON'
+{"source":"leaseflow.internal","detail-type":"run_db_migrations","detail":{}}
+JSON
+
+export AWS_PROFILE=terraform
+aws lambda invoke \
+  --region eu-north-1 \
+  --function-name leaseflow-dev-backend \
+  --cli-binary-format raw-in-base64-out \
+  --payload fileb://migration-payload.json \
+  migration-response.json
+
+cat migration-response.json
+aws logs tail /aws/lambda/leaseflow-dev-backend --since 10m --region eu-north-1 --format short
+```
+
+Expected result:
+
+- `statusCode` is `200`
+- response body includes `target_revision`, `previous_revision`, and `current_revision`
+- after a successful migration run, protected API smoke tests should no longer fail with missing table errors such as `relation "properties" does not exist`


### PR DESCRIPTION
## Summary

Adds a deployed migration path for the private RDS-backed dev environment by teaching the existing backend Lambda to run Alembic migrations through a new internal event.

This PR includes:
- a new `leaseflow.internal` `run_db_migrations` event handled by the backend Lambda
- Alembic packaging in the Lambda artifact so `alembic.ini` and `migrations/` are available at runtime
- a migration runner that uses the existing SSM-backed DB secret path
- backend tests for the migration runner and handler routing
- operator docs for the WSL/preflight packaging and invocation flow

## Why

The deployed dev stack could reach the backend and authenticate requests, but protected routes still failed with database schema errors because the RDS instance had not been migrated.

This PR closes that gap with the smallest operationally safe path:
- keep RDS private
- keep the existing Lambda and SSM secret model
- avoid adding a dedicated migration Lambda or public database access
- make deployed smoke tests possible end to end

## Validation

- [x] `make lint`
- [x] `make test`
- [x] `make tf-fmt` (if `infra/` changed)
- [x] Other relevant checks were run when needed

Other checks run:
- [x] `python -m pytest -q` in `backend/`
- [x] `python -m ruff check src tests migrations` in `backend/`
- [x] WSL/preflight Lambda zip sanity check
- [x] dev `terraform apply`
- [x] internal `run_db_migrations` Lambda invoke
- [x] protected API smoke test with a real Cognito ID token

## Review Notes

- [x] Tenant-scoped queries explicitly filter by `tenant_id` where applicable
- [x] `tenant_id` comes from validated JWT claims, not client input
- [x] Write flows keep domain changes and audit records in one transaction where required
- [x] Structured logging or audit logging was updated if the change affects important write flows
- [x] Docs were updated if architecture, security, or MVP scope changed materially

## Deployment Notes

- Rebuild the Lambda artifact in WSL so the zip contains `alembic.ini` and `migrations/`.
- Run `terraform apply` for the dev environment with the updated artifact.
- Invoke the internal migration event:
  - `source = "leaseflow.internal"`
  - `detail-type = "run_db_migrations"`
  - `detail = {}`
- After a successful migration run, protected routes should no longer fail with missing-table errors such as `relation "properties" does not exist`.