### PR TITLE
feat: add tenant-safe notification read acknowledgment flow

### DIFF
--- a/backend/migrations/versions/20260409_0006_add_notification_read_at.py
+++ b/backend/migrations/versions/20260409_0006_add_notification_read_at.py
@@ -1,0 +1,23 @@
+"""Add read_at to notifications."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260409_0006"
+down_revision = "20260407_0005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "notifications",
+        sa.Column("read_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("notifications", "read_at")

--- a/backend/scripts/invoke_local.py
+++ b/backend/scripts/invoke_local.py
@@ -26,6 +26,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     reminders_parser.add_argument("--user-id", default="user-local")
     reminders_parser.add_argument("--days", type=int, default=7)
 
+    read_notification_parser = subparsers.add_parser(
+        "read-notification",
+        help="Invoke PATCH /notifications/{notification_id}/read.",
+    )
+    read_notification_parser.add_argument("--tenant-id", default="tenant-local")
+    read_notification_parser.add_argument("--user-id", default="user-local")
+    read_notification_parser.add_argument("--notification-id", required=True)
+
     scan_parser = subparsers.add_parser(
         "scan-due-lease-reminders",
         help="Invoke internal due lease reminder scan.",
@@ -60,6 +68,22 @@ def build_event(args: argparse.Namespace) -> dict[str, Any]:
             "source": "leaseflow.internal",
             "detail-type": "scan_due_lease_reminders",
             "detail": detail,
+        }
+
+    if args.command == "read-notification":
+        return {
+            "rawPath": f"/notifications/{args.notification_id}/read",
+            "requestContext": {
+                "http": {"method": "PATCH"},
+                "authorizer": {
+                    "jwt": {
+                        "claims": {
+                            "sub": args.user_id,
+                            "custom:tenant_id": args.tenant_id,
+                        }
+                    }
+                },
+            },
         }
 
     raw_path = (

--- a/backend/src/app/db.py
+++ b/backend/src/app/db.py
@@ -80,7 +80,8 @@ class Database:
                 title,
                 message,
                 due_date,
-                created_at
+                created_at,
+                read_at
             FROM notifications
             WHERE tenant_id = %s
             ORDER BY created_at DESC
@@ -88,6 +89,35 @@ class Database:
         with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
             rows = conn.execute(sql, (tenant_id,)).fetchall()
         return [self._row_to_notification(row) for row in rows]
+
+    def mark_notification_read(
+        self,
+        tenant_id: str,
+        notification_id: UUID,
+    ) -> Notification:
+        sql = """
+            UPDATE notifications
+            SET read_at = COALESCE(read_at, now())
+            WHERE tenant_id = %s AND notification_id = %s
+            RETURNING
+                notification_id,
+                tenant_id,
+                lease_id,
+                type,
+                title,
+                message,
+                due_date,
+                created_at,
+                read_at
+        """
+        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+            with conn.transaction():
+                row = conn.execute(sql, (tenant_id, notification_id)).fetchone()
+
+        if row is None:
+            raise LookupError("Notification not found for tenant.")
+
+        return self._row_to_notification(row)
 
     def list_due_lease_reminders(
         self,
@@ -322,7 +352,22 @@ class Database:
             message=row["message"],
             due_date=row["due_date"],
             created_at=row["created_at"],
+            read_at=row["read_at"],
         )
+
+
+def notification_to_dict(item: Notification) -> dict[str, Any]:
+    return {
+        "notification_id": str(item.notification_id),
+        "tenant_id": item.tenant_id,
+        "lease_id": str(item.lease_id),
+        "type": item.type,
+        "title": item.title,
+        "message": item.message,
+        "due_date": item.due_date.isoformat(),
+        "created_at": item.created_at.isoformat(),
+        "read_at": item.read_at.isoformat() if item.read_at else None,
+    }
 
 
 def properties_to_dict(items: Sequence[Property]) -> list[dict[str, Any]]:
@@ -370,19 +415,7 @@ def lease_reminders_to_dict(items: Sequence[LeaseReminderCandidate]) -> list[dic
 
 
 def notifications_to_dict(items: Sequence[Notification]) -> list[dict[str, Any]]:
-    return [
-        {
-            "notification_id": str(item.notification_id),
-            "tenant_id": item.tenant_id,
-            "lease_id": str(item.lease_id),
-            "type": item.type,
-            "title": item.title,
-            "message": item.message,
-            "due_date": item.due_date.isoformat(),
-            "created_at": item.created_at.isoformat(),
-        }
-        for item in items
-    ]
+    return [notification_to_dict(item) for item in items]
 
 
 def _next_due_date(as_of_date: date, due_day_of_month: int) -> date:

--- a/backend/src/app/handler.py
+++ b/backend/src/app/handler.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import re
 from http import HTTPStatus
 from typing import Any
+from uuid import UUID
 
 from app.auth import AuthError
 from app.config import ConfigError, load_settings
@@ -12,12 +14,13 @@ from app.routes.db_migrations import run_db_migrations
 from app.routes.health import get_health
 from app.routes.lease_reminders import list_due_lease_reminders
 from app.routes.leases import create_lease, list_leases
-from app.routes.notifications import list_notifications
+from app.routes.notifications import list_notifications, mark_notification_read
 from app.routes.properties import create_property, list_properties
 from app.routes.reminder_scans import scan_due_lease_reminders
 
 setup_logging()
 LOGGER = get_logger(__name__)
+_NOTIFICATION_READ_PATH = re.compile(r"^/notifications/(?P<notification_id>[^/]+)/read$")
 
 
 def _response(status: HTTPStatus, body: dict[str, Any]) -> dict[str, Any]:
@@ -52,6 +55,17 @@ def _route_path(event: dict[str, Any]) -> str:
     return raw_path
 
 
+def _notification_read_id(path: str) -> UUID | None:
+    match = _NOTIFICATION_READ_PATH.fullmatch(path)
+    if match is None:
+        return None
+
+    try:
+        return UUID(match.group("notification_id"))
+    except ValueError as exc:
+        raise ValueError("Invalid notification ID.") from exc
+
+
 def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     method = event.get("requestContext", {}).get("http", {}).get("method", "")
     path = _route_path(event)
@@ -65,6 +79,7 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         if method == "GET" and path == "/health":
             return _response(HTTPStatus.OK, get_health())
 
+        notification_id = _notification_read_id(path) if method == "PATCH" else None
         settings = load_settings()
         setup_logging(settings.log_level)
         if (
@@ -78,6 +93,8 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             and event.get("detail-type") == "scan_due_lease_reminders"
         ):
             return _response(HTTPStatus.OK, scan_due_lease_reminders(event, db))
+        if method == "PATCH" and notification_id is not None:
+            return _response(HTTPStatus.OK, mark_notification_read(event, db, notification_id))
         if method == "GET" and path == "/notifications":
             return _response(HTTPStatus.OK, list_notifications(event, db))
         if method == "GET" and path == "/lease-reminders/due-soon":
@@ -92,6 +109,9 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             return _response(HTTPStatus.CREATED, create_property(event, db, _json_body(event)))
 
         return _response(HTTPStatus.NOT_FOUND, {"error": "Route not found"})
+    except LookupError as exc:
+        LOGGER.warning("request_rejected", extra={"request_id": request_id})
+        return _response(HTTPStatus.NOT_FOUND, {"error": str(exc)})
     except (ValueError, AuthError, ConfigError) as exc:
         LOGGER.warning("request_rejected", extra={"request_id": request_id})
         return _response(HTTPStatus.BAD_REQUEST, {"error": str(exc)})

--- a/backend/src/app/models.py
+++ b/backend/src/app/models.py
@@ -57,6 +57,7 @@ class Notification:
     message: str
     due_date: date
     created_at: datetime
+    read_at: datetime | None
 
 
 @dataclass(slots=True)

--- a/backend/src/app/routes/notifications.py
+++ b/backend/src/app/routes/notifications.py
@@ -1,12 +1,26 @@
 from __future__ import annotations
 
 from typing import Any
+from uuid import UUID
 
 from app.auth import extract_auth_context
-from app.db import Database, notifications_to_dict
+from app.db import Database, notification_to_dict, notifications_to_dict
 
 
 def list_notifications(event: dict[str, Any], db: Database) -> dict[str, Any]:
     auth = extract_auth_context(event)
     items = db.list_notifications(tenant_id=auth.tenant_id)
     return {"items": notifications_to_dict(items)}
+
+
+def mark_notification_read(
+    event: dict[str, Any],
+    db: Database,
+    notification_id: UUID,
+) -> dict[str, Any]:
+    auth = extract_auth_context(event)
+    item = db.mark_notification_read(
+        tenant_id=auth.tenant_id,
+        notification_id=notification_id,
+    )
+    return notification_to_dict(item)

--- a/backend/tests/test_db_integration.py
+++ b/backend/tests/test_db_integration.py
@@ -603,6 +603,131 @@ def test_list_notifications_returns_only_requested_tenant_rows(
         assert listed[0].title == "Rent due soon"
         assert listed[0].message == "Rent is due in 2 days."
         assert listed[0].due_date == date(2026, 4, 5)
+        assert listed[0].read_at is None
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+        _cleanup_test_tenant(integration_settings, other_tenant_id)
+
+
+def test_mark_notification_read_sets_timestamp_once_and_is_idempotent(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+
+    try:
+        property_record = db.create_property(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Read HQ {uuid4().hex[:8]}",
+            address=f"Read Street {uuid4().hex[:8]}",
+        )
+        lease_record = db.create_lease(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=property_record.property_id,
+            resident_name=f"Read User {uuid4().hex[:8]}",
+            rent_due_day_of_month=5,
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+        )
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            with conn.transaction():
+                notification_id = conn.execute(
+                    """
+                    INSERT INTO notifications (
+                        tenant_id,
+                        lease_id,
+                        type,
+                        title,
+                        message,
+                        due_date
+                    ) VALUES (%s, %s, %s, %s, %s, %s)
+                    RETURNING notification_id
+                    """,
+                    (
+                        tenant_id,
+                        lease_record.lease_id,
+                        "rent_due_soon",
+                        "Rent due soon",
+                        "Rent is due in 2 days.",
+                        date(2026, 4, 5),
+                    ),
+                ).fetchone()["notification_id"]
+
+        first_read = db.mark_notification_read(
+            tenant_id=tenant_id,
+            notification_id=notification_id,
+        )
+        second_read = db.mark_notification_read(
+            tenant_id=tenant_id,
+            notification_id=notification_id,
+        )
+
+        assert first_read.notification_id == notification_id
+        assert first_read.read_at is not None
+        assert second_read.notification_id == notification_id
+        assert second_read.read_at == first_read.read_at
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+
+
+def test_mark_notification_read_rejects_cross_tenant_access(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    other_tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+
+    try:
+        other_property = db.create_property(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Other Read HQ {uuid4().hex[:8]}",
+            address=f"Other Read Street {uuid4().hex[:8]}",
+        )
+        other_lease = db.create_lease(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=other_property.property_id,
+            resident_name=f"Other Read User {uuid4().hex[:8]}",
+            rent_due_day_of_month=5,
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+        )
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            with conn.transaction():
+                notification_id = conn.execute(
+                    """
+                    INSERT INTO notifications (
+                        tenant_id,
+                        lease_id,
+                        type,
+                        title,
+                        message,
+                        due_date
+                    ) VALUES (%s, %s, %s, %s, %s, %s)
+                    RETURNING notification_id
+                    """,
+                    (
+                        other_tenant_id,
+                        other_lease.lease_id,
+                        "rent_due_soon",
+                        "Rent due soon",
+                        "Rent is due in 2 days.",
+                        date(2026, 4, 5),
+                    ),
+                ).fetchone()["notification_id"]
+
+        with pytest.raises(LookupError, match="Notification not found for tenant."):
+            db.mark_notification_read(
+                tenant_id=tenant_id,
+                notification_id=notification_id,
+            )
     finally:
         _cleanup_test_tenant(integration_settings, tenant_id)
         _cleanup_test_tenant(integration_settings, other_tenant_id)

--- a/backend/tests/test_handler.py
+++ b/backend/tests/test_handler.py
@@ -209,6 +209,117 @@ def test_list_notifications_accepts_stage_prefixed_raw_path(monkeypatch) -> None
     assert json.loads(response["body"]) == {"items": []}
 
 
+def test_mark_notification_read_accepts_stage_prefixed_raw_path(monkeypatch) -> None:
+    monkeypatch.setattr(
+        handler,
+        "load_settings",
+        lambda: SimpleNamespace(log_level="INFO"),
+    )
+    monkeypatch.setattr(handler, "Database", lambda settings: object())
+    monkeypatch.setattr(
+        handler,
+        "mark_notification_read",
+        lambda event, db, notification_id: {
+            "notification_id": str(notification_id),
+            "read_at": "2026-04-09T10:00:00+00:00",
+        },
+        raising=False,
+    )
+
+    event = {
+        "rawPath": "/dev/notifications/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb/read",
+        "requestContext": {
+            "stage": "dev",
+            "http": {"method": "PATCH"},
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": "user-123",
+                        "custom:tenant_id": "tenant-123",
+                    }
+                }
+            },
+        },
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 200
+    assert json.loads(response["body"]) == {
+        "notification_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        "read_at": "2026-04-09T10:00:00+00:00",
+    }
+
+
+def test_mark_notification_read_rejects_invalid_notification_uuid(monkeypatch) -> None:
+    monkeypatch.setattr(
+        handler,
+        "load_settings",
+        lambda: SimpleNamespace(log_level="INFO"),
+    )
+
+    event = {
+        "rawPath": "/dev/notifications/not-a-uuid/read",
+        "requestContext": {
+            "stage": "dev",
+            "http": {"method": "PATCH"},
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": "user-123",
+                        "custom:tenant_id": "tenant-123",
+                    }
+                }
+            },
+        },
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 400
+    assert json.loads(response["body"]) == {"error": "Invalid notification ID."}
+
+
+def test_mark_notification_read_maps_missing_notification_to_not_found(monkeypatch) -> None:
+    monkeypatch.setattr(
+        handler,
+        "load_settings",
+        lambda: SimpleNamespace(log_level="INFO"),
+    )
+    monkeypatch.setattr(handler, "Database", lambda settings: object())
+
+    def _raise_lookup_error(event, db, notification_id):
+        raise LookupError("Notification not found for tenant.")
+
+    monkeypatch.setattr(
+        handler,
+        "mark_notification_read",
+        _raise_lookup_error,
+        raising=False,
+    )
+
+    event = {
+        "rawPath": "/dev/notifications/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb/read",
+        "requestContext": {
+            "stage": "dev",
+            "http": {"method": "PATCH"},
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": "user-123",
+                        "custom:tenant_id": "tenant-123",
+                    }
+                }
+            },
+        },
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 404
+    assert json.loads(response["body"]) == {"error": "Notification not found for tenant."}
+
+
 def test_scan_due_lease_reminders_accepts_internal_event(monkeypatch) -> None:
     monkeypatch.setattr(
         handler,

--- a/backend/tests/test_invoke_local.py
+++ b/backend/tests/test_invoke_local.py
@@ -96,6 +96,37 @@ def test_build_event_for_list_due_lease_reminders_uses_query_and_jwt_claims() ->
     }
 
 
+def test_build_event_for_read_notification_uses_patch_and_jwt_claims() -> None:
+    args = invoke_local.parse_args(
+        [
+            "read-notification",
+            "--tenant-id",
+            "tenant-local",
+            "--user-id",
+            "user-local",
+            "--notification-id",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        ]
+    )
+
+    event = invoke_local.build_event(args)
+
+    assert event == {
+        "rawPath": "/notifications/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb/read",
+        "requestContext": {
+            "http": {"method": "PATCH"},
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": "user-local",
+                        "custom:tenant_id": "tenant-local",
+                    }
+                }
+            },
+        },
+    }
+
+
 def test_build_event_for_scan_due_lease_reminders_uses_internal_detail() -> None:
     args = invoke_local.parse_args(
         [

--- a/backend/tests/test_notifications_route.py
+++ b/backend/tests/test_notifications_route.py
@@ -24,11 +24,13 @@ class _NotificationRecord:
     message: str
     due_date: date
     created_at: datetime
+    read_at: datetime | None
 
 
 class _FakeDb:
     def __init__(self) -> None:
         self.list_calls: list[str] = []
+        self.read_calls: list[tuple[str, UUID]] = []
 
     def list_notifications(self, tenant_id: str) -> list[_NotificationRecord]:
         self.list_calls.append(tenant_id)
@@ -42,8 +44,27 @@ class _FakeDb:
                 message="Rent is due in 2 days.",
                 due_date=date(2026, 4, 9),
                 created_at=datetime(2026, 4, 7, tzinfo=UTC),
+                read_at=None,
             )
         ]
+
+    def mark_notification_read(
+        self,
+        tenant_id: str,
+        notification_id: UUID,
+    ) -> _NotificationRecord:
+        self.read_calls.append((tenant_id, notification_id))
+        return _NotificationRecord(
+            notification_id=notification_id,
+            tenant_id=tenant_id,
+            lease_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            type="rent_due_soon",
+            title="Rent due soon",
+            message="Rent is due in 2 days.",
+            due_date=date(2026, 4, 9),
+            created_at=datetime(2026, 4, 7, tzinfo=UTC),
+            read_at=datetime(2026, 4, 8, 10, 30, tzinfo=UTC),
+        )
 
 
 def _event_with_auth(*, tenant_id: str = "tenant-from-token", user_id: str = "user-123") -> dict:
@@ -81,6 +102,7 @@ def test_list_notifications_uses_auth_tenant_not_client_input() -> None:
                 "message": "Rent is due in 2 days.",
                 "due_date": "2026-04-09",
                 "created_at": "2026-04-07T00:00:00+00:00",
+                "read_at": None,
             }
         ]
     }
@@ -92,3 +114,38 @@ def test_list_notifications_requires_jwt_claims() -> None:
 
     with pytest.raises(AuthError, match="Missing JWT claims."):
         notifications.list_notifications({}, db)
+
+
+def test_mark_notification_read_uses_auth_tenant_and_returns_updated_record() -> None:
+    notifications = _notifications_module()
+    db = _FakeDb()
+    notification_id = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    event = _event_with_auth(tenant_id="tenant-auth", user_id="user-auth")
+    event["queryStringParameters"] = {"tenant_id": "tenant-from-client-should-be-ignored"}
+
+    payload = notifications.mark_notification_read(event, db, notification_id)
+
+    assert db.read_calls == [("tenant-auth", notification_id)]
+    assert payload == {
+        "notification_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        "tenant_id": "tenant-auth",
+        "lease_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "type": "rent_due_soon",
+        "title": "Rent due soon",
+        "message": "Rent is due in 2 days.",
+        "due_date": "2026-04-09",
+        "created_at": "2026-04-07T00:00:00+00:00",
+        "read_at": "2026-04-08T10:30:00+00:00",
+    }
+
+
+def test_mark_notification_read_requires_jwt_claims() -> None:
+    notifications = _notifications_module()
+    db = _FakeDb()
+
+    with pytest.raises(AuthError, match="Missing JWT claims."):
+        notifications.mark_notification_read(
+            {},
+            db,
+            UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+        )

--- a/docs/mvp-scope.md
+++ b/docs/mvp-scope.md
@@ -10,6 +10,7 @@
   - `POST /leases`
   - `GET /leases`
   - `GET /notifications`
+  - `PATCH /notifications/{notification_id}/read`
 - Cognito JWT-based authentication and tenant claim extraction.
 - PostgreSQL persistence for domain data and audit logs.
 - Internal reminder scan flow for creating due-soon notification records.
@@ -22,7 +23,7 @@
 - `properties` table for tenant-owned rental units.
 - `leases` table for tenant-owned rental agreements linked to properties.
 - lease contract data includes explicit `rent_due_day_of_month` for future reminder workflows.
-- `notifications` table for tenant-owned reminder records.
+- `notifications` table for tenant-owned reminder records, including nullable `read_at` for read acknowledgment.
 - `audit_logs` table for basic traceability of critical actions.
 - `tenant_id` enforced in all tenant-owned rows.
 

--- a/infra/modules/api_http/defaults.tftest.hcl
+++ b/infra/modules/api_http/defaults.tftest.hcl
@@ -32,6 +32,11 @@ run "exposes_backend_route_parity" {
   }
 
   assert {
+    condition     = aws_apigatewayv2_route.mark_notification_read.route_key == "PATCH /notifications/{notification_id}/read"
+    error_message = "API module should expose PATCH /notifications/{notification_id}/read."
+  }
+
+  assert {
     condition     = aws_apigatewayv2_route.list_due_lease_reminders.route_key == "GET /lease-reminders/due-soon"
     error_message = "API module should expose GET /lease-reminders/due-soon."
   }
@@ -44,5 +49,10 @@ run "exposes_backend_route_parity" {
   assert {
     condition     = aws_apigatewayv2_route.list_notifications.authorization_type == "JWT"
     error_message = "Notification route should require JWT auth."
+  }
+
+  assert {
+    condition     = aws_apigatewayv2_route.mark_notification_read.authorization_type == "JWT"
+    error_message = "Notification read route should require JWT auth."
   }
 }

--- a/infra/modules/api_http/main.tf
+++ b/infra/modules/api_http/main.tf
@@ -69,6 +69,14 @@ resource "aws_apigatewayv2_route" "list_notifications" {
   authorizer_id      = aws_apigatewayv2_authorizer.jwt.id
 }
 
+resource "aws_apigatewayv2_route" "mark_notification_read" {
+  api_id             = aws_apigatewayv2_api.this.id
+  route_key          = "PATCH /notifications/{notification_id}/read"
+  target             = "integrations/${aws_apigatewayv2_integration.backend.id}"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.jwt.id
+}
+
 resource "aws_apigatewayv2_route" "list_due_lease_reminders" {
   api_id             = aws_apigatewayv2_api.this.id
   route_key          = "GET /lease-reminders/due-soon"


### PR DESCRIPTION
## Summary

Adds a tenant-safe notification read acknowledgment flow.

This PR introduces:
- nullable `read_at` on notification records
- `PATCH /notifications/{notification_id}/read`
- idempotent backend logic for marking a notification as read
- updated `GET /notifications` responses that now include `read_at`
- API Gateway route parity for the new PATCH endpoint
- local invoke support and test coverage for the new flow

## Why

The reminder pipeline could already generate, persist, and list notifications, but notifications were still read-only from the tenant point of view.

That left a practical MVP gap:
- users could not mark notifications as handled
- the system could not distinguish unread notifications from reviewed ones
- the notification model stopped one step before a usable state transition

This PR closes that gap with the smallest useful state mutation while preserving strict tenant isolation and keeping the flow idempotent.

## Validation

- [x] `make lint`
- [x] `make test`
- [x] `make tf-fmt` (if `infra/` changed)
- [x] Other relevant checks were run when needed

Other checks run:
- [x] `terraform test` in `infra/modules/api_http`
- [x] `python -m alembic upgrade head`
- [x] `LEASEFLOW_RUN_DB_INTEGRATION=1 python -m pytest -q tests/test_db_integration.py`

## Review Notes

- [x] Tenant-scoped queries explicitly filter by `tenant_id` where applicable
- [x] `tenant_id` comes from validated JWT claims, not client input
- [ ] Write flows keep domain changes and audit records in one transaction where required
- [ ] Structured logging or audit logging was updated if the change affects important write flows
- [x] Docs were updated if architecture, security, or MVP scope changed materially

## Deployment Notes

- Run Alembic migrations to head before using the new notification read flow.
- This PR adds one schema change to `notifications`:
  - nullable `read_at`
- Run `terraform apply` for environments that should expose `PATCH /notifications/{notification_id}/read` through API Gateway.
- No new AWS services or config values are required.
