### PR TITLE
feat: add baseline CloudWatch alarms for backend and scheduler failures

### DIFF
--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -14,7 +14,7 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
 - **Lambda (Python)**: backend request handling and domain logic.
 - **Cognito**: authentication and JWT issuance.
 - **RDS PostgreSQL (private)**: core relational data store.
-- **CloudWatch**: application logs and operational visibility.
+- **CloudWatch**: application logs, baseline alarms, and operational visibility.
 - **Terraform**: infrastructure provisioning and repeatability.
 - **EventBridge Scheduler**: daily invocation of the internal reminder scan workflow.
 
@@ -42,6 +42,7 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
 - Least-privilege IAM for EventBridge Scheduler to invoke the backend Lambda.
 - Secrets via SSM Parameter Store SecureString, not hardcoded values.
 - Private Lambda access to SSM and KMS uses interface VPC endpoints instead of a NAT path.
+- Baseline CloudWatch alarms cover backend Lambda errors, Lambda throttles, HTTP API 5xx responses, and scheduler target failures.
 - Structured JSON logging for traceability.
 
 ## Cost-Aware Decisions

--- a/docs/security-baseline.md
+++ b/docs/security-baseline.md
@@ -103,7 +103,7 @@ Mitigations:
 
 - Enable API Gateway throttling and request validation.
 - Apply application-level input validation to reject obviously invalid or abusive requests early.
-- Use CloudWatch metrics and alarms for latency, error rates, throttles, and unusual invocation spikes.
+- Use CloudWatch metrics and alarms for backend Lambda errors, Lambda throttles, HTTP API 5xx responses, scheduler target failures, and unusual invocation spikes.
 - Keep scheduled and event-driven tasks idempotent to reduce cascading retries.
 - Size the MVP conservatively and prefer simple protective limits over complex resilience features.
 
@@ -154,6 +154,7 @@ Mitigations:
 - Application logs must be structured and written to CloudWatch.
 - Logs should include timestamp, severity, request ID, user ID when available, tenant ID when relevant, action name, and outcome.
 - Audit events should be stored in PostgreSQL for business and security traceability.
+- Baseline CloudWatch alarms should exist for backend Lambda errors, backend Lambda throttles, HTTP API 5xx responses, and reminder scheduler target failures.
 
 Examples of auditable events:
 

--- a/infra/environments/dev/.terraform.lock.hcl
+++ b/infra/environments/dev/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 6.37, ~> 6.38"
   hashes = [
     "h1:QwtlSBjpxlw3Almi8cMWWlTkRj1Od5jBBEFYR+8XXcs=",
+    "h1:jweey4Iefm/DuuBg84saQ8vz5IO3vC6hDFTU/eGdmBI=",
     "zh:00c3e3c38063ff629d6fdbce04e9ac2e241566e0f5ad5399c335f0abdefd7bff",
     "zh:148f95b62791080537d926b9d2f5d8457cca45921d9b1019d03ceb3ab93bf9db",
     "zh:203da629ed5191dd5d7aa3427a5d1d1a83eed5c1b0114166897206973f0d0fd0",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.8.1"
   constraints = "~> 3.6"
   hashes = [
+    "h1:Eexl06+6J+s75uD46+WnZtpJZYRVUMB0AiuPBifK6Jc=",
     "h1:osH3aBqEARwOz3VBJKdpFKJJCNIdgRC6k8vPojkLmlY=",
     "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
     "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -85,6 +85,18 @@ module "reminder_scheduler" {
   tags                 = local.common_tags
 }
 
+module "cloudwatch_alarms" {
+  source = "../../modules/cloudwatch_alarms"
+
+  name_prefix          = local.name_prefix
+  lambda_function_name = module.lambda_backend.function_name
+  api_id               = module.api_http.api_id
+  api_stage_name       = var.environment
+  scheduler_group_name = "default"
+  scheduler_enabled    = var.reminder_scan_enabled
+  tags                 = local.common_tags
+}
+
 module "api_http" {
   source = "../../modules/api_http"
 

--- a/infra/environments/dev/outputs.tf
+++ b/infra/environments/dev/outputs.tf
@@ -27,3 +27,13 @@ output "reminder_scan_schedule_arn" {
   description = "Reminder scan schedule ARN."
   value       = module.reminder_scheduler.schedule_arn
 }
+
+output "baseline_alarm_names" {
+  description = "Baseline CloudWatch alarm names for the dev stack."
+  value = compact([
+    module.cloudwatch_alarms.lambda_errors_alarm_name,
+    module.cloudwatch_alarms.lambda_throttles_alarm_name,
+    module.cloudwatch_alarms.api_gateway_5xx_alarm_name,
+    module.cloudwatch_alarms.scheduler_target_errors_alarm_name
+  ])
+}

--- a/infra/modules/cloudwatch_alarms/.terraform.lock.hcl
+++ b/infra/modules/cloudwatch_alarms/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.38.0"
+  constraints = "~> 6.37"
+  hashes = [
+    "h1:7F3W4qGLTbr4aploSI8eIqE4AueoNe/Tq5Osuo0IgJ4=",
+    "h1:IMf41BcW9huOeVcrt6XjQqadYR2xD8zkUpGLLERJ4NM=",
+    "zh:143f118ae71059a7a7026c6b950da23fef04a06e2362ffa688bef75e43e869ed",
+    "zh:29ee220a017306effd877e1280f8b2934dc957e16e0e72ca0222e5514d0db522",
+    "zh:3a31baabf7aea7aa7669f5a3d76f3445e0e6cce5e9aea0279992765c0df12aee",
+    "zh:4c1908e62040dbc9901d4426ffb253f53e5dae9e3e1a9125311291ee265c8d8c",
+    "zh:550f4789f5f5b00e16118d4c17770be3ef4535d6b6928af1cf91ebd30f2c263b",
+    "zh:6537b7b70bf2c127771b0b84e4b726c834d10666b6104f017edae50c67ebae37",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:af2f9cea0c8bdf5b2a2391f2d179a946c117196f7c829b919673cae3b71d2943",
+    "zh:c53ffa685381aa4e73158fd9f529239f95938dea330e7aca0b32e7b2a1210432",
+    "zh:d0995e1d64a7ec8bbc79fc3fbec3749f989e07f211a318705c37cd6a7c7d19e4",
+    "zh:d2348ffcffc1282983d7a5838dd5d61f372152fe6c0d10868cd6473352318750",
+    "zh:e449312efb73e4747165e689302a68a1df8ba5755e7f59097069acf82c94f011",
+    "zh:ec3a538d264ef79380e56fdf107ffb6c0446814f07fc5890c36855fe1e03196b",
+    "zh:f441e69699b22e32c96a8cdd3bbe694ed302c0dcfe867cd9bd683a16df362714",
+    "zh:f6f8eaa605ff902234d7e9bdab4fda977185fce14f8576f7b622c914c7d98008",
+  ]
+}

--- a/infra/modules/cloudwatch_alarms/main.tf
+++ b/infra/modules/cloudwatch_alarms/main.tf
@@ -1,0 +1,82 @@
+resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
+  alarm_name          = "${var.name_prefix}-backend-errors"
+  alarm_description   = "Baseline alarm for backend Lambda errors."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  datapoints_to_alarm = 2
+  threshold           = 1
+  period              = 60
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    FunctionName = var.lambda_function_name
+  }
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
+  alarm_name          = "${var.name_prefix}-backend-throttles"
+  alarm_description   = "Baseline alarm for backend Lambda throttles."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = 1
+  period              = 60
+  namespace           = "AWS/Lambda"
+  metric_name         = "Throttles"
+  statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    FunctionName = var.lambda_function_name
+  }
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "api_gateway_5xx" {
+  alarm_name          = "${var.name_prefix}-http-api-5xx"
+  alarm_description   = "Baseline alarm for HTTP API 5xx responses."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  datapoints_to_alarm = 2
+  threshold           = 1
+  period              = 60
+  namespace           = "AWS/ApiGateway"
+  metric_name         = "5xx"
+  statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ApiId = var.api_id
+    Stage = var.api_stage_name
+  }
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "scheduler_target_errors" {
+  count = var.scheduler_enabled ? 1 : 0
+
+  alarm_name          = "${var.name_prefix}-reminder-scheduler-target-errors"
+  alarm_description   = "Baseline alarm for reminder scheduler target delivery failures."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = 1
+  period              = 300
+  namespace           = "AWS/Scheduler"
+  metric_name         = "TargetErrorCount"
+  statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ScheduleGroup = var.scheduler_group_name
+  }
+
+  tags = var.tags
+}

--- a/infra/modules/cloudwatch_alarms/outputs.tf
+++ b/infra/modules/cloudwatch_alarms/outputs.tf
@@ -1,0 +1,39 @@
+output "lambda_errors_alarm_name" {
+  description = "Lambda errors alarm name."
+  value       = aws_cloudwatch_metric_alarm.lambda_errors.alarm_name
+}
+
+output "lambda_errors_alarm_arn" {
+  description = "Lambda errors alarm ARN."
+  value       = aws_cloudwatch_metric_alarm.lambda_errors.arn
+}
+
+output "lambda_throttles_alarm_name" {
+  description = "Lambda throttles alarm name."
+  value       = aws_cloudwatch_metric_alarm.lambda_throttles.alarm_name
+}
+
+output "lambda_throttles_alarm_arn" {
+  description = "Lambda throttles alarm ARN."
+  value       = aws_cloudwatch_metric_alarm.lambda_throttles.arn
+}
+
+output "api_gateway_5xx_alarm_name" {
+  description = "API Gateway 5xx alarm name."
+  value       = aws_cloudwatch_metric_alarm.api_gateway_5xx.alarm_name
+}
+
+output "api_gateway_5xx_alarm_arn" {
+  description = "API Gateway 5xx alarm ARN."
+  value       = aws_cloudwatch_metric_alarm.api_gateway_5xx.arn
+}
+
+output "scheduler_target_errors_alarm_name" {
+  description = "Reminder scheduler target errors alarm name."
+  value       = try(aws_cloudwatch_metric_alarm.scheduler_target_errors[0].alarm_name, null)
+}
+
+output "scheduler_target_errors_alarm_arn" {
+  description = "Reminder scheduler target errors alarm ARN."
+  value       = try(aws_cloudwatch_metric_alarm.scheduler_target_errors[0].arn, null)
+}

--- a/infra/modules/cloudwatch_alarms/tests/defaults.tftest.hcl
+++ b/infra/modules/cloudwatch_alarms/tests/defaults.tftest.hcl
@@ -1,0 +1,115 @@
+mock_provider "aws" {}
+
+variables {
+  name_prefix          = "leaseflow-dev"
+  lambda_function_name = "leaseflow-dev-backend"
+  api_id               = "api123456"
+  api_stage_name       = "dev"
+  scheduler_group_name = "default"
+  scheduler_enabled    = true
+  tags = {
+    Project = "leaseflow"
+  }
+}
+
+run "creates_baseline_alarm_resources" {
+  command = plan
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.lambda_errors.alarm_name == "leaseflow-dev-backend-errors"
+    error_message = "Lambda errors alarm should use the expected name."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.lambda_errors.namespace == "AWS/Lambda"
+    error_message = "Lambda errors alarm should use the AWS/Lambda namespace."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.lambda_errors.metric_name == "Errors"
+    error_message = "Lambda errors alarm should track Lambda Errors."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.lambda_errors.dimensions.FunctionName == "leaseflow-dev-backend"
+    error_message = "Lambda errors alarm should scope to the backend function."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.lambda_errors.evaluation_periods == 2
+    error_message = "Lambda errors alarm should use balanced two-period evaluation."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.lambda_errors.datapoints_to_alarm == 2
+    error_message = "Lambda errors alarm should require two breaching datapoints."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.lambda_errors.treat_missing_data == "notBreaching"
+    error_message = "Lambda errors alarm should ignore missing datapoints."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.lambda_throttles.metric_name == "Throttles"
+    error_message = "Lambda throttles alarm should track Lambda Throttles."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.lambda_throttles.evaluation_periods == 1
+    error_message = "Lambda throttles alarm should trigger on a single period."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.api_gateway_5xx.namespace == "AWS/ApiGateway"
+    error_message = "API 5xx alarm should use the API Gateway namespace."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.api_gateway_5xx.metric_name == "5xx"
+    error_message = "API alarm should track HTTP API 5xx responses."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.api_gateway_5xx.dimensions.ApiId == "api123456"
+    error_message = "API alarm should scope to the HTTP API ID."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.api_gateway_5xx.dimensions.Stage == "dev"
+    error_message = "API alarm should scope to the deployment stage."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.scheduler_target_errors[0].namespace == "AWS/Scheduler"
+    error_message = "Scheduler alarm should use the AWS/Scheduler namespace."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.scheduler_target_errors[0].metric_name == "TargetErrorCount"
+    error_message = "Scheduler alarm should track target delivery failures."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.scheduler_target_errors[0].dimensions.ScheduleGroup == "default"
+    error_message = "Scheduler alarm should scope to the configured schedule group."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.scheduler_target_errors[0].period == 300
+    error_message = "Scheduler alarm should use a 5-minute period."
+  }
+}
+
+run "omits_scheduler_alarm_when_disabled" {
+  command = plan
+
+  variables {
+    scheduler_enabled = false
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.scheduler_target_errors) == 0
+    error_message = "Scheduler alarm should be omitted when the scheduler is disabled."
+  }
+}

--- a/infra/modules/cloudwatch_alarms/variables.tf
+++ b/infra/modules/cloudwatch_alarms/variables.tf
@@ -1,0 +1,35 @@
+variable "name_prefix" {
+  description = "Prefix used in alarm names."
+  type        = string
+}
+
+variable "lambda_function_name" {
+  description = "Backend Lambda function name."
+  type        = string
+}
+
+variable "api_id" {
+  description = "HTTP API ID."
+  type        = string
+}
+
+variable "api_stage_name" {
+  description = "HTTP API stage name."
+  type        = string
+}
+
+variable "scheduler_group_name" {
+  description = "EventBridge Scheduler schedule group name."
+  type        = string
+}
+
+variable "scheduler_enabled" {
+  description = "Whether the reminder scheduler alarm should be created."
+  type        = bool
+}
+
+variable "tags" {
+  description = "Tags applied to alarm resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/cloudwatch_alarms/versions.tf
+++ b/infra/modules/cloudwatch_alarms/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.37"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a reusable Terraform module for baseline CloudWatch alarms and wires it into the dev environment.

This PR introduces alarms for:
- backend Lambda errors
- backend Lambda throttles
- HTTP API 5xx responses
- reminder scheduler target failures

It also adds a compact dev output for alarm names and updates the architecture and security docs to make the baseline observability model explicit.

## Why

The deployed stack already had working backend, scheduler, and reminder flows, but it still lacked baseline failure visibility.

Without alarms:
- Lambda failures could go unnoticed
- API Gateway 5xx spikes required manual log inspection
- reminder scheduler target failures were harder to detect quickly
- the AWS portfolio story was weaker on Operational Excellence and Reliability

This PR adds the smallest useful alarm baseline without introducing SNS, dashboards, or broader incident-management scope.

## Validation

- [x] `make lint`
- [x] `make test`
- [x] `make tf-fmt` (if `infra/` changed)
- [x] Other relevant checks were run when needed

Other checks run:
- [x] `terraform test` in `infra/modules/cloudwatch_alarms`
- [x] `terraform validate` in `infra/environments/dev`
- [x] dev `terraform apply`
- [x] verified all 4 alarms exist in CloudWatch and start in `OK`
- [x] verified `leaseflow-dev-http-api-5xx` transitions `OK -> ALARM -> OK` from a controlled runtime failure

## Review Notes

- [x] Tenant-scoped queries explicitly filter by `tenant_id` where applicable
- [x] `tenant_id` comes from validated JWT claims, not client input
- [ ] Write flows keep domain changes and audit records in one transaction where required
- [ ] Structured logging or audit logging was updated if the change affects important write flows
- [x] Docs were updated if architecture, security, or MVP scope changed materially

## Deployment Notes

- Run `terraform apply` for the target environment to create the new CloudWatch alarms.
- This PR adds no alarm actions yet; alarms are console-visible baseline signals only.
- Expected alarm names in dev:
  - `leaseflow-dev-backend-errors`
  - `leaseflow-dev-backend-throttles`
  - `leaseflow-dev-http-api-5xx`
  - `leaseflow-dev-reminder-scheduler-target-errors`
- No application config changes are required.
- SNS or other notification targets are intentionally left to a follow-up ticket.

Closes #40