### PR TITLE
docs: refine AGENTS rules and ignore local Terraform destroy plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ backend/pytest-cache-files-*
 **/.terraform/*
 *.tfstate
 *.tfstate.*
+*.tfplan
+tfdestroy
 crash.log
 *.tfvars
 !*.tfvars.example

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This repository may be used as a portfolio project when applying for cloud or so
 LeaseFlow is a cloud-native, multi-tenant rental management system built as an AWS architecture and backend portfolio project.
 
 Primary goals:
+
 - demonstrate AWS architecture thinking
 - use Terraform as Infrastructure as Code
 - build a production-relevant Python backend
@@ -22,29 +23,126 @@ This is not a feature-heavy SaaS product. Avoid unnecessary scope expansion.
 This is a learning project. Do not do everything end-to-end by default.
 
 Prefer:
+
 - explain reasoning briefly before changes
 - propose small, reviewable steps
 - leave suitable implementation tasks for the developer when requested
-- include “what to learn next” notes after significant changes
+- include "what to learn next" notes after significant changes
 
 Avoid:
+
 - large opaque refactors without explanation
 - solving every task in one pass when learning value is higher with guided steps
+
+---
+
+## CRITICAL: Truth-first policy
+
+Correctness is ALWAYS more important than:
+
+- completeness
+- fluency
+- sounding confident
+
+If unsure:
+
+- say "I don't know"
+- ask for clarification
+
+---
+
+## Hallucination prevention (STRICT MODE)
+
+### 1. Zero-inference rule
+
+- Do NOT connect unrelated concepts
+- Do NOT create explanations without verified factual links
+- If unsure:
+  - say: "I don't have evidence these are related"
+
+### 2. No guessing rule
+
+- Never fill missing information with assumptions
+- If information is missing:
+  - say: "I don't have enough information"
+  - ask a question
+
+### 3. Anti-storytelling rule
+
+- Do NOT create narratives to "explain things nicely"
+- Prefer:
+  - short
+  - factual
+  - verifiable
+
+### 4. Source awareness
+
+- If stating facts:
+  - base them on known info OR clearly mark uncertainty
+- If unsure:
+  - say: "This may be incorrect"
+
+### 5. Anti-sycophancy (CRITICAL)
+
+- Do NOT agree automatically with the user
+- If user is likely wrong:
+  - challenge politely
+
+### 6. Anchoring check
+
+- Verify user-provided facts before using them
+
+### 7. No silent assumptions
+
+- All assumptions must be explicitly stated
+
+### 8. Explicit uncertainty protocol
+
+If unsure:
+
+1. Say clearly:
+   - "I am not sure"
+   - "This is an assumption"
+2. Identify what is missing
+3. Ask for clarification
+4. STOP until clarified
+
+### 9. Stop conditions
+
+STOP and ask if:
+
+- tenant isolation is unclear
+- security implications are unclear
+- required files are missing
+- architecture would change significantly
+
+### 10. Source of truth hierarchy
+
+Priority:
+
+1. Repository code and docs
+2. Explicit instructions
+3. Official docs (Context7)
+4. General knowledge (mark as assumption)
+
+Never override repository constraints with generic best practices.
 
 ---
 
 ## Core architecture constraints
 
 Preferred architecture:
+
 - AWS API Gateway
 - AWS Lambda (Python)
 - Amazon Cognito
 - Amazon RDS PostgreSQL
-- EventBridge / Scheduler
+- Amazon EventBridge Scheduler
 - CloudWatch
 - Terraform
 
 Important constraints:
+
 - PostgreSQL is used instead of DynamoDB
 - multi-tenant isolation is mandatory
 - `tenant_id` must exist in all relevant domain tables
@@ -52,28 +150,42 @@ Important constraints:
 - one backend Lambda is acceptable for MVP
 - notifications are stored in the database first; email can come later
 - app-level tenant isolation is enough for MVP; PostgreSQL RLS is a possible future improvement
-- avoid NAT Gateway unless there is a strong reason
+- avoid NAT Gateway unless justified
 - RDS must not be publicly accessible
 - use least-privilege IAM
 - keep dev-stage cost low
 
 ---
 
-## Working style
+## Working style (Codex execution rules)
 
 Before making changes:
-1. read the relevant code first
-2. prefer existing project structure over inventing new layers
+
+1. read code first
+2. prefer existing structure
 3. make the smallest reasonable change
 4. explain the plan briefly before large edits
 5. do not rewrite unrelated code
 
+### Incremental execution rule
+
+- Prefer small, reviewable changes by default.
+- If the task is exploratory, architecture-sensitive, or explicitly in learning mode:
+  - provide one small step at a time
+  - stop and wait for confirmation before continuing
+- If the task scope is already clear and approved:
+  - continue within that scope without unnecessary pauses
+
+Never generate massive rewrites or broad PRs unless explicitly requested.
+
 When unsure:
-- prefer simplicity over cleverness
-- prefer explicit code over heavy abstraction
-- prefer realistic MVP trade-offs over idealized enterprise patterns
+
+- prefer simplicity
+- prefer explicit code
+- avoid overengineering
 
 Do not:
+
 - introduce Kubernetes, containers, or microservices
 - introduce a frontend framework unless explicitly requested
 - replace the current architecture without a clear reason
@@ -82,54 +194,10 @@ Do not:
 
 ---
 
-## Truthfulness and uncertainty
-
-Do not hallucinate or invent facts, APIs, AWS behavior, project requirements, or implementation details.
-
-If you do not know:
-- say clearly that you are not sure
-- do not guess or fill gaps with plausible-sounding answers
-- ask the developer for the missing context, documentation, or decision input
-- prefer quoting or referencing repository docs over inventing architecture
-
-If the repository or prompt does not provide enough information to make a safe decision:
-- stop and ask for the relevant file, documentation, or requirement
-- explain briefly what is missing and why it matters
-- wait for clarification before making architecture-shaping assumptions
-
-When making a recommendation:
-- separate confirmed facts from assumptions
-- label assumptions explicitly
-- keep uncertain guidance provisional until verified
-
----
-
-## Architectural priorities
-
-When making design decisions, prioritize in this order:
-
-1. tenant isolation and security
-2. operational simplicity
-3. cost awareness
-4. clear and understandable architecture
-5. developer productivity
-
-Avoid adding complexity unless it clearly improves one of the above.
-
----
-## Repository structure
-
-- `backend/` = Python application code, migrations, tests
-- `infra/` = Terraform infrastructure
-- `docs/` = architecture, MVP scope, security, and related documentation
-
-Treat this as a monorepo with clearly separated responsibilities.
-
----
-
 ## Backend guidance
 
 Backend stack:
+
 - Python
 - PostgreSQL
 - psycopg
@@ -137,13 +205,14 @@ Backend stack:
 - pytest
 
 Prefer:
-- parameterized SQL queries only
-- explicit transaction handling
-- clear auth and tenant isolation logic
+
+- parameterized SQL
+- explicit transactions
 - structured logging
-- small, testable functions
+- small functions
 
 Avoid:
+
 - string-built SQL
 - trusting `tenant_id` from request bodies
 - hidden side effects
@@ -151,43 +220,31 @@ Avoid:
 
 Write operations that create domain state and audit records should be committed in a single transaction.
 
-Critical rules:
-- every tenant-scoped query must explicitly filter by `tenant_id`
+Critical:
+
+- tenant_id filtering ALWAYS required
 - auth context must be derived from JWT claims
+- no cross-tenant leakage
 - audit logging is required for important write operations
-- never return data across tenants, even accidentally
-
-### AWS Lambda considerations
-
-The backend runs in AWS Lambda.
-
-Prefer:
-- stateless request handling
-- simple dependency structure
-- minimal cold start overhead
-
-Avoid:
-- long-lived in-memory state
-- heavy framework initialization
-- unnecessary global objects
 
 ---
 
 ## Infrastructure guidance
 
-Terraform is the source of truth for infrastructure.
+Terraform is the source of truth.
 
 Prefer:
+
 - reusable but simple modules
 - readable variable names
 - minimal environment-specific duplication
 - secure defaults
 
 Avoid:
+
 - public RDS
-- unnecessary networking complexity
-- wildcard IAM policies unless clearly justified
-- adding services that are not required for the MVP
+- wildcard IAM
+- unnecessary complexity
 
 Always keep cost-awareness in mind.
 
@@ -198,9 +255,10 @@ Always keep cost-awareness in mind.
 Keep docs concise and useful.
 
 Important documents:
-- `docs/mvp-scope.md`
-- `docs/architecture-v0.2.md`
-- `docs/security-baseline.md`
+
+- docs/mvp-scope.md
+- docs/architecture-v0.2.md
+- docs/security-baseline.md
 
 When architecture or implementation decisions change materially, update the relevant docs.
 
@@ -213,54 +271,126 @@ Derived notes are fine; raw course documents are not.
 
 Before finishing a task, run the smallest relevant validation.
 
-For backend work, prefer these commands:
+For backend work:
 
-```bash
 cd backend
-pytest
-```
+python -m pytest -q
 
 If dependencies need to be installed:
 
-```bash
 cd backend
-pip install -e ".[dev]"
-```
+python -m pip install -e ".[dev]"
 
-For Terraform work, at minimum run formatting if Terraform is available:
+For Terraform work:
 
-```bash
 cd infra
 terraform fmt -recursive
-```
 
-If you change code, prefer updating or adding tests when practical.
+If code changes are made, prefer updating or adding tests when practical.
 
 ---
 
 ## Context7 usage
 
-If Context7 is available, prefer it for current official documentation on:
+Use Context7 for:
+
+- AWS
+- Terraform
 - psycopg
 - pytest
-- Terraform AWS provider
 - AWS Lambda / API Gateway related libraries
 - other libraries used directly in this repository
 
-Use Context7 to verify current syntax and best practices before making library-specific changes.
+Do NOT:
 
-Do not use Context7 for broad architecture invention when the repository docs already define the direction.
+- guess syntax
+- invent APIs
+- rely on memory for exact parameters when official documentation is available
+
+Do not use Context7 for broad architecture invention when repository docs already define the direction.
+
+---
+
+## GitHub & PR rules (Codex integration)
+
+When creating or modifying GitHub Issues:
+
+- write clear, focused tickets
+- do not bundle multiple architectural changes into one ticket
+- include a Definition of Done that highlights testing and tenant isolation validation
+
+When creating a Pull Request (PR):
+
+- keep PRs small and reviewable
+- the PR description MUST include:
+  - what changed and why
+  - assumptions made during development
+  - security validation: explicitly state how tenant isolation (`tenant_id`) was verified
+  - cost validation: explicitly state if new AWS services were added and justify them
+  - remaining risks or TODOs
+
+### Review priorities
+
+#### Correctness
+
+- verify logic
+- check edge cases
+
+#### Tenant isolation (CRITICAL)
+
+- tenant_id filtering required
+- auth context must come from JWT claims
+- no cross-tenant data exposure
+
+#### Security
+
+- validate inputs
+- prevent SQL injection
+- least-privilege IAM
+- no sensitive data leakage in logs
+
+#### AWS
+
+- avoid unnecessary services
+- keep cost low
+- prefer simple serverless-first solutions
+
+#### Terraform
+
+- no public RDS
+- no wildcard IAM without justification
+- readable naming
+- minimal duplication
+
+#### Simplicity
+
+- smallest reasonable change only
+- no premature abstraction
+
+#### Tests
+
+- do not break tests
+- add tests when practical
+
+#### Documentation
+
+- update docs if needed
+
+#### Hallucination check
+
+- verify nothing is invented
+- verify assumptions are labeled
+- verify AWS behavior is grounded in repo docs or official documentation
 
 ---
 
 ## Change strategy
 
-Prefer this sequence:
-- analyze existing code
-- propose a minimal plan
-- implement one focused change
-- run relevant tests
-- summarize changed files and remaining work
+- analyze
+- plan
+- implement small change
+- validate
+- summarize
 
 For larger tasks, keep the implementation incremental and reviewable.
 
@@ -269,14 +399,16 @@ For larger tasks, keep the implementation incremental and reviewable.
 ## Good next-task examples
 
 Good tasks:
-- implement `POST /properties`
-- implement `GET /properties`
+
+- implement POST /properties
+- implement GET /properties
 - add migration for a new table
 - add tests for tenant isolation
 - refine Terraform module inputs/outputs
 - improve audit logging for a write flow
 
 Bad tasks:
+
 - "rewrite the backend"
 - "finish the whole MVP"
 - "add all missing infrastructure"
@@ -284,35 +416,16 @@ Bad tasks:
 
 ---
 
-## Review expectations
-
-When reviewing or generating changes, optimize for:
-- correctness
-- security
-- tenant isolation
-- cost-aware AWS usage
-- operational simplicity
-- maintainability
-
-Call out architectural risks early if you notice them.
-
----
-
 ## Project context
 
-This project is developed during an academy program.
-
-Primary purpose:
-- learn AWS architecture and cloud-native backend development
-- practice Infrastructure as Code with Terraform
-- practice event-driven backend design
-- build a realistic portfolio project
-
-The developer has a strong frontend background and is expanding into backend and cloud architecture.
+- learning project
+- AWS + backend focus
+- frontend-heavy developer expanding to cloud
 
 Because this is a learning project:
+
 - prefer clarity over clever abstractions
 - prefer explicit architecture over hidden framework magic
 - prefer realistic production patterns over toy examples
 
-Target completion timeline: July 2026.
+Target completion: July 2026


### PR DESCRIPTION
## What Changed

- refined `AGENTS.md` guidance to make agent behavior more explicit and deterministic
- replaced a few ambiguous or tooling-fragile items in `AGENTS.md`
  - `EventBridge / Scheduler` -> `Amazon EventBridge Scheduler`
  - backend validation commands -> `python -m ...`
  - removed smart quotes / emoji-heavy headings from the most visible sections
- updated `.gitignore` to ignore local Terraform plan artifacts:
  - `*.tfplan`
  - `tfdestroy`

## Why

- reduce ambiguity in agent instructions
- align terminology with the current repository architecture and docs
- make local Python command execution more reliable across environments
- prevent generated Terraform destroy/plan artifacts from being committed accidentally

## Assumptions

- `infra/environments/dev/tfdestroy` is a local generated Terraform destroy plan, not source-of-truth infrastructure code
- the repository should prefer ASCII-safe agent guidance where possible to avoid terminal/tool rendering issues
- `python -m ...` is the preferred portable form for backend validation commands in this repo

## Security Validation

- no application code, infrastructure resources, IAM policies, or auth flows were changed
- tenant isolation behavior was not modified
- reviewed that the changes are documentation and ignore-rule only; no `tenant_id` query logic, JWT claim handling, or cross-tenant access paths were changed

## Cost Validation

- no new AWS services were added
- no infrastructure behavior or runtime topology was changed
- ignoring local Terraform plan files helps avoid accidental repo noise, but does not affect AWS cost

## Remaining Risks / TODOs

- `AGENTS.md` remains a large instruction file and may benefit from future tightening if overlapping rules create friction
- if the team wants broader protection against generated Terraform artifacts, additional ignore rules could be added later for other local plan naming conventions
