### PR TITLE
feat: add property update flow with audit logging

### DIFF
--- a/backend/src/app/db.py
+++ b/backend/src/app/db.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import calendar
+import json
 from collections.abc import Sequence
 from datetime import date, timedelta
 from typing import Any
@@ -8,6 +9,7 @@ from uuid import UUID
 
 import psycopg
 from psycopg.rows import dict_row
+from psycopg.sql import SQL, Identifier
 
 from app.config import Settings
 from app.models import Lease, LeaseReminderCandidate, Notification, Property, ReminderScanResult
@@ -282,6 +284,69 @@ class Database:
                     ),
                 )
         return self._row_to_lease(lease_row)
+
+    def update_property(
+        self,
+        tenant_id: str,
+        actor_user_id: str,
+        property_id: UUID,
+        updates: dict[str, str],
+    ) -> Property:
+        property_sql = """
+            SELECT property_id, tenant_id, name, address, created_at
+            FROM properties
+            WHERE tenant_id = %s AND property_id = %s
+            FOR UPDATE
+        """
+        audit_sql = """
+            INSERT INTO audit_logs (
+                tenant_id, actor_user_id, action, entity_type, entity_id, metadata
+            ) VALUES (%s, %s, %s, %s, %s, %s::jsonb)
+        """
+        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+            with conn.transaction():
+                property_row = conn.execute(property_sql, (tenant_id, property_id)).fetchone()
+                if property_row is None:
+                    raise LookupError("Property not found for tenant.")
+
+                changed_fields = [
+                    field
+                    for field in ("name", "address")
+                    if field in updates and updates[field] != property_row[field]
+                ]
+                if not changed_fields:
+                    return self._row_to_property(property_row)
+
+                assignments = SQL(", ").join(
+                    SQL("{} = %s").format(Identifier(field)) for field in changed_fields
+                )
+                update_sql = SQL("""
+                    UPDATE properties
+                    SET {assignments}
+                    WHERE tenant_id = %s AND property_id = %s
+                    RETURNING property_id, tenant_id, name, address, created_at
+                """).format(assignments=assignments)
+                update_params = tuple(updates[field] for field in changed_fields) + (
+                    tenant_id,
+                    property_id,
+                )
+                property_row = conn.execute(update_sql, update_params).fetchone()
+                conn.execute(
+                    audit_sql,
+                    (
+                        tenant_id,
+                        actor_user_id,
+                        "property.update",
+                        "property",
+                        property_id,
+                        json.dumps({"source": "api", "changed_fields": changed_fields}),
+                    ),
+                )
+
+        if property_row is None:
+            raise RuntimeError("Failed to update property.")
+
+        return self._row_to_property(property_row)
 
     def create_property(
         self,

--- a/backend/src/app/handler.py
+++ b/backend/src/app/handler.py
@@ -15,12 +15,13 @@ from app.routes.health import get_health
 from app.routes.lease_reminders import list_due_lease_reminders
 from app.routes.leases import create_lease, list_leases
 from app.routes.notifications import list_notifications, mark_notification_read
-from app.routes.properties import create_property, list_properties
+from app.routes.properties import create_property, list_properties, update_property
 from app.routes.reminder_scans import scan_due_lease_reminders
 
 setup_logging()
 LOGGER = get_logger(__name__)
 _NOTIFICATION_READ_PATH = re.compile(r"^/notifications/(?P<notification_id>[^/]+)/read$")
+_PROPERTY_PATH = re.compile(r"^/properties/(?P<property_id>[^/]+)$")
 
 
 def _response(status: HTTPStatus, body: dict[str, Any]) -> dict[str, Any]:
@@ -66,6 +67,17 @@ def _notification_read_id(path: str) -> UUID | None:
         raise ValueError("Invalid notification ID.") from exc
 
 
+def _property_id(path: str) -> UUID | None:
+    match = _PROPERTY_PATH.fullmatch(path)
+    if match is None:
+        return None
+
+    try:
+        return UUID(match.group("property_id"))
+    except ValueError as exc:
+        raise ValueError("Invalid property ID.") from exc
+
+
 def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     method = event.get("requestContext", {}).get("http", {}).get("method", "")
     path = _route_path(event)
@@ -80,6 +92,7 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             return _response(HTTPStatus.OK, get_health())
 
         notification_id = _notification_read_id(path) if method == "PATCH" else None
+        property_id = _property_id(path) if method == "PATCH" else None
         settings = load_settings()
         setup_logging(settings.log_level)
         if (
@@ -95,6 +108,8 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             return _response(HTTPStatus.OK, scan_due_lease_reminders(event, db))
         if method == "PATCH" and notification_id is not None:
             return _response(HTTPStatus.OK, mark_notification_read(event, db, notification_id))
+        if method == "PATCH" and property_id is not None:
+            return _response(HTTPStatus.OK, update_property(event, db, property_id))
         if method == "GET" and path == "/notifications":
             return _response(HTTPStatus.OK, list_notifications(event, db))
         if method == "GET" and path == "/lease-reminders/due-soon":

--- a/backend/src/app/routes/properties.py
+++ b/backend/src/app/routes/properties.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import json
 from typing import Any
+from uuid import UUID
 
 from app.auth import extract_auth_context
 from app.db import Database, properties_to_dict
+
+_MUTABLE_FIELDS = ("name", "address")
 
 
 def list_properties(event: dict[str, Any], db: Database) -> dict[str, Any]:
@@ -34,3 +38,55 @@ def create_property(event: dict[str, Any], db: Database, body: dict[str, Any]) -
         "address": created.address,
         "created_at": created.created_at.isoformat(),
     }
+
+
+def update_property(event: dict[str, Any], db: Database, property_id: UUID) -> dict[str, Any]:
+    auth = extract_auth_context(event)
+    updated = db.update_property(
+        tenant_id=auth.tenant_id,
+        actor_user_id=auth.user_id,
+        property_id=property_id,
+        updates=_property_update_body(event),
+    )
+    return properties_to_dict([updated])[0]
+
+
+def _property_update_body(event: dict[str, Any]) -> dict[str, str]:
+    body = _json_body(event)
+    if not body:
+        raise ValueError("At least one of 'name' or 'address' is required.")
+
+    unsupported_fields = set(body) - set(_MUTABLE_FIELDS)
+    if unsupported_fields:
+        raise ValueError("Only fields 'name' and 'address' can be updated.")
+
+    updates: dict[str, str] = {}
+    for field in _MUTABLE_FIELDS:
+        if field not in body:
+            continue
+
+        value = str(body[field]).strip()
+        if not value:
+            raise ValueError(f"Field '{field}' must not be empty.")
+        updates[field] = value
+
+    if not updates:
+        raise ValueError("At least one of 'name' or 'address' is required.")
+
+    return updates
+
+
+def _json_body(event: dict[str, Any]) -> dict[str, Any]:
+    raw = event.get("body")
+    if raw in (None, ""):
+        return {}
+
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Invalid JSON request body.") from exc
+
+    if not isinstance(body, dict):
+        raise ValueError("JSON body must be an object.")
+
+    return body

--- a/backend/tests/test_db_integration.py
+++ b/backend/tests/test_db_integration.py
@@ -188,6 +188,221 @@ def test_list_properties_returns_only_requested_tenant_rows(
         _cleanup_test_tenant(integration_settings, other_tenant_id)
 
 
+def test_update_property_writes_property_change_and_audit_log(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+
+    try:
+        created = db.create_property(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Original HQ {uuid4().hex[:8]}",
+            address=f"Original Street {uuid4().hex[:8]}",
+        )
+
+        updated = db.update_property(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=created.property_id,
+            updates={"name": "Updated HQ", "address": "Updated Street 2"},
+        )
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            property_rows = conn.execute(
+                """
+                SELECT property_id, tenant_id, name, address
+                FROM properties
+                WHERE tenant_id = %s AND property_id = %s
+                """,
+                (tenant_id, created.property_id),
+            ).fetchall()
+            audit_rows = conn.execute(
+                """
+                SELECT tenant_id, actor_user_id, action, entity_type, entity_id, metadata
+                FROM audit_logs
+                WHERE tenant_id = %s AND entity_id = %s AND action = 'property.update'
+                """,
+                (tenant_id, created.property_id),
+            ).fetchall()
+
+        assert updated.property_id == created.property_id
+        assert updated.tenant_id == tenant_id
+        assert updated.name == "Updated HQ"
+        assert updated.address == "Updated Street 2"
+
+        assert len(property_rows) == 1
+        assert property_rows[0]["name"] == "Updated HQ"
+        assert property_rows[0]["address"] == "Updated Street 2"
+
+        assert len(audit_rows) == 1
+        assert audit_rows[0]["tenant_id"] == tenant_id
+        assert audit_rows[0]["actor_user_id"] == actor_user_id
+        assert audit_rows[0]["action"] == "property.update"
+        assert audit_rows[0]["entity_type"] == "property"
+        assert audit_rows[0]["entity_id"] == created.property_id
+        assert audit_rows[0]["metadata"] == {
+            "source": "api",
+            "changed_fields": ["name", "address"],
+        }
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+
+
+def test_update_property_rejects_cross_tenant_access(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    other_tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+
+    try:
+        created = db.create_property(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Other HQ {uuid4().hex[:8]}",
+            address=f"Other Street {uuid4().hex[:8]}",
+        )
+
+        with pytest.raises(LookupError, match="Property not found for tenant."):
+            db.update_property(
+                tenant_id=tenant_id,
+                actor_user_id=actor_user_id,
+                property_id=created.property_id,
+                updates={"name": "Updated HQ"},
+            )
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+        _cleanup_test_tenant(integration_settings, other_tenant_id)
+
+
+def test_update_property_is_idempotent_when_values_are_unchanged(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+    name = f"Stable HQ {uuid4().hex[:8]}"
+    address = f"Stable Street {uuid4().hex[:8]}"
+
+    try:
+        created = db.create_property(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            name=name,
+            address=address,
+        )
+
+        updated = db.update_property(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=created.property_id,
+            updates={"name": name, "address": address},
+        )
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            property_rows = conn.execute(
+                """
+                SELECT property_id, name, address
+                FROM properties
+                WHERE tenant_id = %s AND property_id = %s
+                """,
+                (tenant_id, created.property_id),
+            ).fetchall()
+            audit_rows = conn.execute(
+                """
+                SELECT audit_id
+                FROM audit_logs
+                WHERE tenant_id = %s AND entity_id = %s AND action = 'property.update'
+                """,
+                (tenant_id, created.property_id),
+            ).fetchall()
+
+        assert updated.property_id == created.property_id
+        assert updated.name == name
+        assert updated.address == address
+        assert len(property_rows) == 1
+        assert property_rows[0]["name"] == name
+        assert property_rows[0]["address"] == address
+        assert audit_rows == []
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+
+
+def test_update_property_rolls_back_when_audit_log_write_fails(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+    constraint_name = f"audit_logs_reject_{uuid4().hex[:12]}"
+
+    try:
+        created = db.create_property(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Rollback Update HQ {uuid4().hex[:8]}",
+            address=f"Rollback Update Street {uuid4().hex[:8]}",
+        )
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            with conn.transaction():
+                conn.execute(
+                    SQL(
+                        """
+                        ALTER TABLE audit_logs
+                        ADD CONSTRAINT {constraint_name}
+                        CHECK (action <> 'property.update' OR tenant_id <> {tenant_id})
+                        """
+                    ).format(
+                        constraint_name=Identifier(constraint_name),
+                        tenant_id=Literal(tenant_id),
+                    )
+                )
+
+        with pytest.raises(psycopg.Error):
+            db.update_property(
+                tenant_id=tenant_id,
+                actor_user_id=actor_user_id,
+                property_id=created.property_id,
+                updates={"name": "Broken Update"},
+            )
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            property_rows = conn.execute(
+                """
+                SELECT property_id, name, address
+                FROM properties
+                WHERE tenant_id = %s AND property_id = %s
+                """,
+                (tenant_id, created.property_id),
+            ).fetchall()
+            audit_rows = conn.execute(
+                """
+                SELECT audit_id
+                FROM audit_logs
+                WHERE tenant_id = %s AND entity_id = %s AND action = 'property.update'
+                """,
+                (tenant_id, created.property_id),
+            ).fetchall()
+
+        assert len(property_rows) == 1
+        assert property_rows[0]["name"] == created.name
+        assert property_rows[0]["address"] == created.address
+        assert audit_rows == []
+    finally:
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            with conn.transaction():
+                conn.execute(
+                    SQL(
+                        "ALTER TABLE audit_logs DROP CONSTRAINT IF EXISTS {constraint_name}"
+                    ).format(constraint_name=Identifier(constraint_name))
+                )
+        _cleanup_test_tenant(integration_settings, tenant_id)
+
+
 def test_create_lease_writes_lease_and_audit_log(integration_settings: Settings) -> None:
     db = Database(integration_settings)
     tenant_id = f"test-local-{uuid4().hex}"

--- a/backend/tests/test_handler.py
+++ b/backend/tests/test_handler.py
@@ -280,6 +280,126 @@ def test_mark_notification_read_rejects_invalid_notification_uuid(monkeypatch) -
     assert json.loads(response["body"]) == {"error": "Invalid notification ID."}
 
 
+def test_update_property_accepts_stage_prefixed_raw_path(monkeypatch) -> None:
+    monkeypatch.setattr(
+        handler,
+        "load_settings",
+        lambda: SimpleNamespace(log_level="INFO"),
+    )
+    monkeypatch.setattr(handler, "Database", lambda settings: object())
+    monkeypatch.setattr(
+        handler,
+        "update_property",
+        lambda event, db, property_id: {
+            "property_id": str(property_id),
+            "tenant_id": "tenant-123",
+            "name": "Updated HQ",
+            "address": "Updated Street 1",
+            "created_at": "2026-03-12T00:00:00+00:00",
+        },
+        raising=False,
+    )
+
+    event = {
+        "rawPath": "/dev/properties/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "body": json.dumps({"name": "Updated HQ"}),
+        "requestContext": {
+            "stage": "dev",
+            "http": {"method": "PATCH"},
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": "user-123",
+                        "custom:tenant_id": "tenant-123",
+                    }
+                }
+            },
+        },
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 200
+    assert json.loads(response["body"]) == {
+        "property_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "tenant_id": "tenant-123",
+        "name": "Updated HQ",
+        "address": "Updated Street 1",
+        "created_at": "2026-03-12T00:00:00+00:00",
+    }
+
+
+def test_update_property_rejects_invalid_property_uuid(monkeypatch) -> None:
+    monkeypatch.setattr(
+        handler,
+        "load_settings",
+        lambda: SimpleNamespace(log_level="INFO"),
+    )
+
+    event = {
+        "rawPath": "/dev/properties/not-a-uuid",
+        "body": json.dumps({"name": "Updated HQ"}),
+        "requestContext": {
+            "stage": "dev",
+            "http": {"method": "PATCH"},
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": "user-123",
+                        "custom:tenant_id": "tenant-123",
+                    }
+                }
+            },
+        },
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 400
+    assert json.loads(response["body"]) == {"error": "Invalid property ID."}
+
+
+def test_update_property_maps_missing_property_to_not_found(monkeypatch) -> None:
+    monkeypatch.setattr(
+        handler,
+        "load_settings",
+        lambda: SimpleNamespace(log_level="INFO"),
+    )
+    monkeypatch.setattr(handler, "Database", lambda settings: object())
+
+    def _raise_lookup_error(event, db, property_id):
+        raise LookupError("Property not found for tenant.")
+
+    monkeypatch.setattr(
+        handler,
+        "update_property",
+        _raise_lookup_error,
+        raising=False,
+    )
+
+    event = {
+        "rawPath": "/dev/properties/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "body": json.dumps({"name": "Updated HQ"}),
+        "requestContext": {
+            "stage": "dev",
+            "http": {"method": "PATCH"},
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": "user-123",
+                        "custom:tenant_id": "tenant-123",
+                    }
+                }
+            },
+        },
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 404
+    assert json.loads(response["body"]) == {"error": "Property not found for tenant."}
+
+
 def test_mark_notification_read_maps_missing_notification_to_not_found(monkeypatch) -> None:
     monkeypatch.setattr(
         handler,

--- a/backend/tests/test_properties_route.py
+++ b/backend/tests/test_properties_route.py
@@ -7,13 +7,14 @@ import pytest
 
 from app.auth import AuthError
 from app.models import Property
-from app.routes.properties import create_property, list_properties
+from app.routes.properties import create_property, list_properties, update_property
 
 
 class _FakeDb:
     def __init__(self) -> None:
         self.calls: list[dict[str, str]] = []
         self.list_calls: list[str] = []
+        self.update_calls: list[dict[str, object]] = []
 
     def create_property(
         self,
@@ -56,6 +57,29 @@ class _FakeDb:
                 created_at=datetime(2026, 3, 11, tzinfo=UTC),
             ),
         ]
+
+    def update_property(
+        self,
+        tenant_id: str,
+        actor_user_id: str,
+        property_id: UUID,
+        updates: dict[str, str],
+    ) -> Property:
+        self.update_calls.append(
+            {
+                "tenant_id": tenant_id,
+                "actor_user_id": actor_user_id,
+                "property_id": property_id,
+                "updates": updates,
+            }
+        )
+        return Property(
+            property_id=property_id,
+            tenant_id=tenant_id,
+            name=updates.get("name", "HQ"),
+            address=updates.get("address", "Main Street 1"),
+            created_at=datetime(2026, 3, 12, tzinfo=UTC),
+        )
 
 
 def _event_with_auth(*, tenant_id: str = "tenant-from-token", user_id: str = "user-123") -> dict:
@@ -147,3 +171,104 @@ def test_create_property_requires_name_and_address() -> None:
 
     with pytest.raises(ValueError, match="Fields 'name' and 'address' are required."):
         create_property(event, db, {"name": "only-name"})
+
+
+def test_update_property_uses_auth_tenant_not_client_input() -> None:
+    db = _FakeDb()
+    event = _event_with_auth(tenant_id="tenant-auth", user_id="user-auth")
+    event["body"] = '{"name":"Renamed HQ"}'
+
+    payload = update_property(
+        event,
+        db,
+        UUID("33333333-3333-3333-3333-333333333333"),
+    )
+
+    assert db.update_calls == [
+        {
+            "tenant_id": "tenant-auth",
+            "actor_user_id": "user-auth",
+            "property_id": UUID("33333333-3333-3333-3333-333333333333"),
+            "updates": {"name": "Renamed HQ"},
+        }
+    ]
+    assert payload == {
+        "property_id": "33333333-3333-3333-3333-333333333333",
+        "tenant_id": "tenant-auth",
+        "name": "Renamed HQ",
+        "address": "Main Street 1",
+        "created_at": "2026-03-12T00:00:00+00:00",
+    }
+
+
+def test_update_property_supports_address_only_patch() -> None:
+    db = _FakeDb()
+    event = _event_with_auth()
+    event["body"] = '{"address":"Updated Street 2"}'
+
+    payload = update_property(
+        event,
+        db,
+        UUID("44444444-4444-4444-4444-444444444444"),
+    )
+
+    assert db.update_calls[0]["updates"] == {"address": "Updated Street 2"}
+    assert payload["address"] == "Updated Street 2"
+    assert payload["name"] == "HQ"
+
+
+def test_update_property_supports_name_and_address_patch() -> None:
+    db = _FakeDb()
+    event = _event_with_auth()
+    event["body"] = '{"name":"Updated HQ","address":"Updated Street 3"}'
+
+    payload = update_property(
+        event,
+        db,
+        UUID("55555555-5555-5555-5555-555555555555"),
+    )
+
+    assert db.update_calls[0]["updates"] == {
+        "name": "Updated HQ",
+        "address": "Updated Street 3",
+    }
+    assert payload["name"] == "Updated HQ"
+    assert payload["address"] == "Updated Street 3"
+
+
+def test_update_property_rejects_empty_patch_body() -> None:
+    db = _FakeDb()
+    event = _event_with_auth()
+    event["body"] = "{}"
+
+    with pytest.raises(ValueError, match="At least one of 'name' or 'address' is required."):
+        update_property(event, db, UUID("66666666-6666-6666-6666-666666666666"))
+
+
+def test_update_property_rejects_unsupported_fields() -> None:
+    db = _FakeDb()
+    event = _event_with_auth()
+    event["body"] = '{"tenant_id":"tenant-from-client"}'
+
+    with pytest.raises(ValueError, match="Only fields 'name' and 'address' can be updated."):
+        update_property(event, db, UUID("77777777-7777-7777-7777-777777777777"))
+
+
+def test_update_property_rejects_blank_trimmed_values() -> None:
+    db = _FakeDb()
+    event = _event_with_auth()
+    event["body"] = '{"name":"   "}'
+
+    with pytest.raises(ValueError, match="Field 'name' must not be empty."):
+        update_property(event, db, UUID("88888888-8888-8888-8888-888888888888"))
+
+
+def test_update_property_requires_jwt_claims() -> None:
+    db = _FakeDb()
+
+    with pytest.raises(AuthError, match="Missing JWT claims."):
+        update_property(
+            {"body": '{"name":"Renamed HQ"}'},
+            db,
+            UUID("99999999-9999-9999-9999-999999999999"),
+        )

--- a/infra/modules/api_http/defaults.tftest.hcl
+++ b/infra/modules/api_http/defaults.tftest.hcl
@@ -37,6 +37,11 @@ run "exposes_backend_route_parity" {
   }
 
   assert {
+    condition     = aws_apigatewayv2_route.update_property.route_key == "PATCH /properties/{property_id}"
+    error_message = "API module should expose PATCH /properties/{property_id}."
+  }
+
+  assert {
     condition     = aws_apigatewayv2_route.list_due_lease_reminders.route_key == "GET /lease-reminders/due-soon"
     error_message = "API module should expose GET /lease-reminders/due-soon."
   }
@@ -54,5 +59,10 @@ run "exposes_backend_route_parity" {
   assert {
     condition     = aws_apigatewayv2_route.mark_notification_read.authorization_type == "JWT"
     error_message = "Notification read route should require JWT auth."
+  }
+
+  assert {
+    condition     = aws_apigatewayv2_route.update_property.authorization_type == "JWT"
+    error_message = "Property update route should require JWT auth."
   }
 }

--- a/infra/modules/api_http/main.tf
+++ b/infra/modules/api_http/main.tf
@@ -45,6 +45,14 @@ resource "aws_apigatewayv2_route" "create_property" {
   authorizer_id      = aws_apigatewayv2_authorizer.jwt.id
 }
 
+resource "aws_apigatewayv2_route" "update_property" {
+  api_id             = aws_apigatewayv2_api.this.id
+  route_key          = "PATCH /properties/{property_id}"
+  target             = "integrations/${aws_apigatewayv2_integration.backend.id}"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.jwt.id
+}
+
 resource "aws_apigatewayv2_route" "list_leases" {
   api_id             = aws_apigatewayv2_api.this.id
   route_key          = "GET /leases"


### PR DESCRIPTION
## Summary
- add `PATCH /properties/{property_id}` as a tenant-safe partial update flow
- allow updates only for `name` and `address`
- write `property.update` audit logs with `source` and `changed_fields` metadata
- add the matching JWT-protected API Gateway route in Terraform

## Why
This closes the main CRUD gap for properties in the MVP and keeps write behavior aligned with the existing audit logging and tenant isolation rules.

Closes #44.

## Assumptions
- mutable property fields remain limited to `name` and `address`
- no schema change is needed for this ticket
- unchanged values should be idempotent and must not create audit rows
- local invoke helper changes are out of scope for this ticket

## Security Validation
- `tenant_id` is derived only from JWT claims, not trusted from the request body
- unsupported fields, including `tenant_id`, are rejected with `400`
- DB updates filter by both `tenant_id` and `property_id`
- cross-tenant updates return `404` via `LookupError("Property not found for tenant.")`
- property update and audit log insert run in the same transaction

## Cost Validation
- no new AWS services were added
- API Gateway change is one additional route on the existing HTTP API module
- cost impact is effectively negligible for the MVP

## Validation
- `python -m pytest -q backend/tests/test_properties_route.py backend/tests/test_handler.py`
- `terraform test` in `infra/modules/api_http`
- WSL local DB validation: `python -m alembic upgrade head` and `python -m pytest -q tests/test_db_integration.py -k update_property`

## Remaining Risks / TODOs
- full backend regression suite was not rerun in this PR, only the property-update-focused tests
- no `updated_at` field exists yet, so update timestamps remain out of scope
- reminder recalculation remains a separate concern for lease updates, not property updates