### PR TITLE
feat: add lease update flow with reminder recalculation

### DIFF
--- a/backend/src/app/db.py
+++ b/backend/src/app/db.py
@@ -285,6 +285,124 @@ class Database:
                 )
         return self._row_to_lease(lease_row)
 
+    def update_lease(
+        self,
+        tenant_id: str,
+        actor_user_id: str,
+        lease_id: UUID,
+        updates: dict[str, object],
+    ) -> Lease:
+        lease_sql = """
+            SELECT
+                lease_id,
+                tenant_id,
+                property_id,
+                resident_name,
+                rent_due_day_of_month,
+                start_date,
+                end_date,
+                created_at
+            FROM leases
+            WHERE tenant_id = %s AND lease_id = %s
+            FOR UPDATE
+        """
+        delete_notifications_sql = """
+            DELETE FROM notifications
+            WHERE tenant_id = %s
+              AND lease_id = %s
+              AND type = 'rent_due_soon'
+              AND read_at IS NULL
+              AND due_date >= %s
+        """
+        audit_sql = """
+            INSERT INTO audit_logs (
+                tenant_id, actor_user_id, action, entity_type, entity_id, metadata
+            ) VALUES (%s, %s, %s, %s, %s, %s::jsonb)
+        """
+        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+            with conn.transaction():
+                lease_row = conn.execute(lease_sql, (tenant_id, lease_id)).fetchone()
+                if lease_row is None:
+                    raise LookupError("Lease not found for tenant.")
+
+                start_date = updates.get("start_date", lease_row["start_date"])
+                end_date = updates.get("end_date", lease_row["end_date"])
+                if end_date < start_date:
+                    raise ValueError("'end_date' must be on or after 'start_date'.")
+
+                changed_fields = [
+                    field
+                    for field in (
+                        "resident_name",
+                        "rent_due_day_of_month",
+                        "start_date",
+                        "end_date",
+                    )
+                    if field in updates and updates[field] != lease_row[field]
+                ]
+                if not changed_fields:
+                    return self._row_to_lease(lease_row)
+
+                assignments = SQL(", ").join(
+                    SQL("{} = %s").format(Identifier(field)) for field in changed_fields
+                )
+                update_sql = SQL("""
+                    UPDATE leases
+                    SET {assignments}
+                    WHERE tenant_id = %s AND lease_id = %s
+                    RETURNING
+                        lease_id,
+                        tenant_id,
+                        property_id,
+                        resident_name,
+                        rent_due_day_of_month,
+                        start_date,
+                        end_date,
+                        created_at
+                """).format(assignments=assignments)
+                update_params = tuple(updates[field] for field in changed_fields) + (
+                    tenant_id,
+                    lease_id,
+                )
+                lease_row = conn.execute(update_sql, update_params).fetchone()
+
+                reminder_fields_changed = any(
+                    field in {"rent_due_day_of_month", "start_date", "end_date"}
+                    for field in changed_fields
+                )
+                deleted_notification_count = 0
+                if reminder_fields_changed:
+                    deleted_notification_count = (
+                        conn.execute(
+                            delete_notifications_sql,
+                            (tenant_id, lease_id, date.today()),
+                        ).rowcount
+                        or 0
+                    )
+
+                conn.execute(
+                    audit_sql,
+                    (
+                        tenant_id,
+                        actor_user_id,
+                        "lease.update",
+                        "lease",
+                        lease_id,
+                        json.dumps(
+                            {
+                                "source": "api",
+                                "changed_fields": changed_fields,
+                                "deleted_notification_count": deleted_notification_count,
+                            }
+                        ),
+                    ),
+                )
+
+        if lease_row is None:
+            raise RuntimeError("Failed to update lease.")
+
+        return self._row_to_lease(lease_row)
+
     def update_property(
         self,
         tenant_id: str,

--- a/backend/src/app/handler.py
+++ b/backend/src/app/handler.py
@@ -13,13 +13,14 @@ from app.logging import get_logger, setup_logging
 from app.routes.db_migrations import run_db_migrations
 from app.routes.health import get_health
 from app.routes.lease_reminders import list_due_lease_reminders
-from app.routes.leases import create_lease, list_leases
+from app.routes.leases import create_lease, list_leases, update_lease
 from app.routes.notifications import list_notifications, mark_notification_read
 from app.routes.properties import create_property, list_properties, update_property
 from app.routes.reminder_scans import scan_due_lease_reminders
 
 setup_logging()
 LOGGER = get_logger(__name__)
+_LEASE_PATH = re.compile(r"^/leases/(?P<lease_id>[^/]+)$")
 _NOTIFICATION_READ_PATH = re.compile(r"^/notifications/(?P<notification_id>[^/]+)/read$")
 _PROPERTY_PATH = re.compile(r"^/properties/(?P<property_id>[^/]+)$")
 
@@ -78,6 +79,17 @@ def _property_id(path: str) -> UUID | None:
         raise ValueError("Invalid property ID.") from exc
 
 
+def _lease_id(path: str) -> UUID | None:
+    match = _LEASE_PATH.fullmatch(path)
+    if match is None:
+        return None
+
+    try:
+        return UUID(match.group("lease_id"))
+    except ValueError as exc:
+        raise ValueError("Invalid lease ID.") from exc
+
+
 def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     method = event.get("requestContext", {}).get("http", {}).get("method", "")
     path = _route_path(event)
@@ -91,6 +103,7 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         if method == "GET" and path == "/health":
             return _response(HTTPStatus.OK, get_health())
 
+        lease_id = _lease_id(path) if method == "PATCH" else None
         notification_id = _notification_read_id(path) if method == "PATCH" else None
         property_id = _property_id(path) if method == "PATCH" else None
         settings = load_settings()
@@ -110,6 +123,8 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             return _response(HTTPStatus.OK, mark_notification_read(event, db, notification_id))
         if method == "PATCH" and property_id is not None:
             return _response(HTTPStatus.OK, update_property(event, db, property_id))
+        if method == "PATCH" and lease_id is not None:
+            return _response(HTTPStatus.OK, update_lease(event, db, lease_id))
         if method == "GET" and path == "/notifications":
             return _response(HTTPStatus.OK, list_notifications(event, db))
         if method == "GET" and path == "/lease-reminders/due-soon":

--- a/backend/src/app/routes/leases.py
+++ b/backend/src/app/routes/leases.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import json
 from datetime import date
 from typing import Any
 from uuid import UUID
 
 from app.auth import extract_auth_context
 from app.db import Database, leases_to_dict
+
+_MUTABLE_FIELDS = ("resident_name", "rent_due_day_of_month", "start_date", "end_date")
 
 
 def list_leases(event: dict[str, Any], db: Database) -> dict[str, Any]:
@@ -57,6 +60,60 @@ def create_lease(event: dict[str, Any], db: Database, body: dict[str, Any]) -> d
     return leases_to_dict([created])[0]
 
 
+def update_lease(event: dict[str, Any], db: Database, lease_id: UUID) -> dict[str, Any]:
+    auth = extract_auth_context(event)
+    updated = db.update_lease(
+        tenant_id=auth.tenant_id,
+        actor_user_id=auth.user_id,
+        lease_id=lease_id,
+        updates=_lease_update_body(event),
+    )
+    return leases_to_dict([updated])[0]
+
+
+def _lease_update_body(event: dict[str, Any]) -> dict[str, object]:
+    body = _json_body(event)
+    if not body:
+        raise ValueError(
+            "At least one of 'resident_name', 'rent_due_day_of_month', 'start_date', or 'end_date' is required."
+        )
+
+    unsupported_fields = set(body) - set(_MUTABLE_FIELDS)
+    if unsupported_fields:
+        raise ValueError(
+            "Only fields 'resident_name', 'rent_due_day_of_month', 'start_date', and 'end_date' can be updated."
+        )
+
+    updates: dict[str, object] = {}
+    if "resident_name" in body:
+        resident_name = str(body["resident_name"]).strip()
+        if not resident_name:
+            raise ValueError("Field 'resident_name' must not be empty.")
+        updates["resident_name"] = resident_name
+    if "rent_due_day_of_month" in body:
+        updates["rent_due_day_of_month"] = _parse_rent_due_day_of_month(
+            body["rent_due_day_of_month"]
+        )
+    if "start_date" in body:
+        updates["start_date"] = _parse_date(str(body["start_date"]).strip())
+    if "end_date" in body:
+        updates["end_date"] = _parse_date(str(body["end_date"]).strip())
+
+    if (
+        "start_date" in updates
+        and "end_date" in updates
+        and updates["end_date"] < updates["start_date"]
+    ):
+        raise ValueError("'end_date' must be on or after 'start_date'.")
+
+    if not updates:
+        raise ValueError(
+            "At least one of 'resident_name', 'rent_due_day_of_month', 'start_date', or 'end_date' is required."
+        )
+
+    return updates
+
+
 def _parse_dates(start_date_raw: str, end_date_raw: str) -> tuple[date, date]:
     try:
         return date.fromisoformat(start_date_raw), date.fromisoformat(end_date_raw)
@@ -79,3 +136,26 @@ def _parse_rent_due_day_of_month(value: Any) -> int:
         raise ValueError("Field 'rent_due_day_of_month' must be an integer between 1 and 31.")
 
     return parsed
+
+
+def _parse_date(value: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError("Fields 'start_date' and 'end_date' must use YYYY-MM-DD.") from exc
+
+
+def _json_body(event: dict[str, Any]) -> dict[str, Any]:
+    raw = event.get("body")
+    if raw in (None, ""):
+        return {}
+
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Invalid JSON request body.") from exc
+
+    if not isinstance(body, dict):
+        raise ValueError("JSON body must be an object.")
+
+    return body

--- a/backend/src/app/routes/leases.py
+++ b/backend/src/app/routes/leases.py
@@ -9,6 +9,14 @@ from app.auth import extract_auth_context
 from app.db import Database, leases_to_dict
 
 _MUTABLE_FIELDS = ("resident_name", "rent_due_day_of_month", "start_date", "end_date")
+_UPDATE_REQUIRED_FIELDS_ERROR = (
+    "At least one of 'resident_name', 'rent_due_day_of_month', "
+    "'start_date', or 'end_date' is required."
+)
+_UPDATE_SUPPORTED_FIELDS_ERROR = (
+    "Only fields 'resident_name', 'rent_due_day_of_month', "
+    "'start_date', and 'end_date' can be updated."
+)
 
 
 def list_leases(event: dict[str, Any], db: Database) -> dict[str, Any]:
@@ -74,15 +82,11 @@ def update_lease(event: dict[str, Any], db: Database, lease_id: UUID) -> dict[st
 def _lease_update_body(event: dict[str, Any]) -> dict[str, object]:
     body = _json_body(event)
     if not body:
-        raise ValueError(
-            "At least one of 'resident_name', 'rent_due_day_of_month', 'start_date', or 'end_date' is required."
-        )
+        raise ValueError(_UPDATE_REQUIRED_FIELDS_ERROR)
 
     unsupported_fields = set(body) - set(_MUTABLE_FIELDS)
     if unsupported_fields:
-        raise ValueError(
-            "Only fields 'resident_name', 'rent_due_day_of_month', 'start_date', and 'end_date' can be updated."
-        )
+        raise ValueError(_UPDATE_SUPPORTED_FIELDS_ERROR)
 
     updates: dict[str, object] = {}
     if "resident_name" in body:
@@ -107,9 +111,7 @@ def _lease_update_body(event: dict[str, Any]) -> dict[str, object]:
         raise ValueError("'end_date' must be on or after 'start_date'.")
 
     if not updates:
-        raise ValueError(
-            "At least one of 'resident_name', 'rent_due_day_of_month', 'start_date', or 'end_date' is required."
-        )
+        raise ValueError(_UPDATE_REQUIRED_FIELDS_ERROR)
 
     return updates
 

--- a/backend/tests/test_db_integration.py
+++ b/backend/tests/test_db_integration.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from datetime import date
+from datetime import date, timedelta
 from uuid import uuid4
 
 import psycopg
@@ -645,6 +645,490 @@ def test_list_leases_returns_only_requested_tenant_rows(integration_settings: Se
     finally:
         _cleanup_test_tenant(integration_settings, tenant_id)
         _cleanup_test_tenant(integration_settings, other_tenant_id)
+
+
+def test_update_lease_writes_change_audit_and_deletes_future_unread_reminders(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+    today = date.today()
+    next_year = today.replace(year=today.year + 1)
+
+    try:
+        property_record = db.create_property(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Lease Update HQ {uuid4().hex[:8]}",
+            address=f"Lease Update Street {uuid4().hex[:8]}",
+        )
+        created = db.create_lease(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=property_record.property_id,
+            resident_name=f"Original Resident {uuid4().hex[:8]}",
+            rent_due_day_of_month=5,
+            start_date=today,
+            end_date=next_year,
+        )
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            with conn.transaction():
+                conn.execute(
+                    """
+                    INSERT INTO notifications (
+                        tenant_id,
+                        lease_id,
+                        type,
+                        title,
+                        message,
+                        due_date
+                    ) VALUES (%s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        tenant_id,
+                        created.lease_id,
+                        "rent_due_soon",
+                        "Rent due soon",
+                        "Rent is due soon.",
+                        today,
+                    ),
+                )
+                conn.execute(
+                    """
+                    INSERT INTO notifications (
+                        tenant_id,
+                        lease_id,
+                        type,
+                        title,
+                        message,
+                        due_date,
+                        read_at
+                    ) VALUES (%s, %s, %s, %s, %s, %s, now())
+                    """,
+                    (
+                        tenant_id,
+                        created.lease_id,
+                        "rent_due_soon",
+                        "Read reminder",
+                        "Already read.",
+                        today + timedelta(days=1),
+                    ),
+                )
+                conn.execute(
+                    """
+                    INSERT INTO notifications (
+                        tenant_id,
+                        lease_id,
+                        type,
+                        title,
+                        message,
+                        due_date
+                    ) VALUES (%s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        tenant_id,
+                        created.lease_id,
+                        "rent_due_soon",
+                        "Past reminder",
+                        "Past due reminder.",
+                        today - timedelta(days=1),
+                    ),
+                )
+
+        updated = db.update_lease(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            lease_id=created.lease_id,
+            updates={
+                "rent_due_day_of_month": 9,
+                "start_date": today + timedelta(days=2),
+                "end_date": next_year,
+            },
+        )
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            lease_rows = conn.execute(
+                """
+                SELECT resident_name, rent_due_day_of_month, start_date, end_date
+                FROM leases
+                WHERE tenant_id = %s AND lease_id = %s
+                """,
+                (tenant_id, created.lease_id),
+            ).fetchall()
+            audit_rows = conn.execute(
+                """
+                SELECT metadata
+                FROM audit_logs
+                WHERE tenant_id = %s AND entity_id = %s AND action = 'lease.update'
+                """,
+                (tenant_id, created.lease_id),
+            ).fetchall()
+            notification_rows = conn.execute(
+                """
+                SELECT title, due_date, read_at
+                FROM notifications
+                WHERE tenant_id = %s AND lease_id = %s
+                ORDER BY due_date
+                """,
+                (tenant_id, created.lease_id),
+            ).fetchall()
+
+        assert updated.lease_id == created.lease_id
+        assert updated.rent_due_day_of_month == 9
+        assert updated.start_date == today + timedelta(days=2)
+        assert len(lease_rows) == 1
+        assert lease_rows[0]["rent_due_day_of_month"] == 9
+        assert len(audit_rows) == 1
+        assert audit_rows[0]["metadata"] == {
+            "source": "api",
+            "changed_fields": ["rent_due_day_of_month", "start_date"],
+            "deleted_notification_count": 1,
+        }
+        assert len(notification_rows) == 2
+        assert notification_rows[0]["title"] == "Past reminder"
+        assert notification_rows[1]["title"] == "Read reminder"
+        assert notification_rows[1]["read_at"] is not None
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+
+
+def test_update_lease_rejects_cross_tenant_access(integration_settings: Settings) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    other_tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+    today = date.today()
+    next_year = today.replace(year=today.year + 1)
+
+    try:
+        property_record = db.create_property(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Other Lease HQ {uuid4().hex[:8]}",
+            address=f"Other Lease Street {uuid4().hex[:8]}",
+        )
+        created = db.create_lease(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=property_record.property_id,
+            resident_name=f"Other Resident {uuid4().hex[:8]}",
+            rent_due_day_of_month=5,
+            start_date=today,
+            end_date=next_year,
+        )
+
+        with pytest.raises(LookupError, match="Lease not found for tenant."):
+            db.update_lease(
+                tenant_id=tenant_id,
+                actor_user_id=actor_user_id,
+                lease_id=created.lease_id,
+                updates={"resident_name": "Updated Resident"},
+            )
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+        _cleanup_test_tenant(integration_settings, other_tenant_id)
+
+
+def test_update_lease_is_idempotent_when_values_are_unchanged(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+    today = date.today()
+    next_year = today.replace(year=today.year + 1)
+
+    try:
+        property_record = db.create_property(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Stable Lease HQ {uuid4().hex[:8]}",
+            address=f"Stable Lease Street {uuid4().hex[:8]}",
+        )
+        created = db.create_lease(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=property_record.property_id,
+            resident_name="Stable Resident",
+            rent_due_day_of_month=5,
+            start_date=today,
+            end_date=next_year,
+        )
+
+        updated = db.update_lease(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            lease_id=created.lease_id,
+            updates={
+                "resident_name": "Stable Resident",
+                "rent_due_day_of_month": 5,
+                "start_date": today,
+                "end_date": next_year,
+            },
+        )
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            audit_rows = conn.execute(
+                """
+                SELECT audit_id
+                FROM audit_logs
+                WHERE tenant_id = %s AND entity_id = %s AND action = 'lease.update'
+                """,
+                (tenant_id, created.lease_id),
+            ).fetchall()
+
+        assert updated.lease_id == created.lease_id
+        assert updated.resident_name == "Stable Resident"
+        assert audit_rows == []
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+
+
+def test_update_lease_resident_name_only_keeps_future_unread_reminders(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+    today = date.today()
+    next_year = today.replace(year=today.year + 1)
+
+    try:
+        property_record = db.create_property(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Resident Lease HQ {uuid4().hex[:8]}",
+            address=f"Resident Lease Street {uuid4().hex[:8]}",
+        )
+        created = db.create_lease(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=property_record.property_id,
+            resident_name="Original Resident",
+            rent_due_day_of_month=5,
+            start_date=today,
+            end_date=next_year,
+        )
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            with conn.transaction():
+                conn.execute(
+                    """
+                    INSERT INTO notifications (
+                        tenant_id,
+                        lease_id,
+                        type,
+                        title,
+                        message,
+                        due_date
+                    ) VALUES (%s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        tenant_id,
+                        created.lease_id,
+                        "rent_due_soon",
+                        "Rent due soon",
+                        "Rent is due soon.",
+                        today + timedelta(days=1),
+                    ),
+                )
+
+        updated = db.update_lease(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            lease_id=created.lease_id,
+            updates={"resident_name": "Updated Resident"},
+        )
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            audit_rows = conn.execute(
+                """
+                SELECT metadata
+                FROM audit_logs
+                WHERE tenant_id = %s AND entity_id = %s AND action = 'lease.update'
+                """,
+                (tenant_id, created.lease_id),
+            ).fetchall()
+            notification_rows = conn.execute(
+                """
+                SELECT notification_id
+                FROM notifications
+                WHERE tenant_id = %s AND lease_id = %s
+                """,
+                (tenant_id, created.lease_id),
+            ).fetchall()
+
+        assert updated.resident_name == "Updated Resident"
+        assert len(notification_rows) == 1
+        assert audit_rows[0]["metadata"] == {
+            "source": "api",
+            "changed_fields": ["resident_name"],
+            "deleted_notification_count": 0,
+        }
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+
+
+def test_update_lease_changes_due_reminder_candidates(integration_settings: Settings) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+    today = date.today()
+    next_year = today.replace(year=today.year + 1)
+    original_due_day = today.day + 10 if today.day <= 18 else 28
+
+    try:
+        property_record = db.create_property(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Reminder Candidate HQ {uuid4().hex[:8]}",
+            address=f"Reminder Candidate Street {uuid4().hex[:8]}",
+        )
+        created = db.create_lease(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=property_record.property_id,
+            resident_name="Reminder Candidate Resident",
+            rent_due_day_of_month=original_due_day,
+            start_date=today,
+            end_date=next_year,
+        )
+
+        before = db.list_due_lease_reminders(
+            tenant_id=tenant_id,
+            as_of_date=today,
+            days=7,
+        )
+
+        db.update_lease(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            lease_id=created.lease_id,
+            updates={"rent_due_day_of_month": today.day},
+        )
+
+        after = db.list_due_lease_reminders(
+            tenant_id=tenant_id,
+            as_of_date=today,
+            days=7,
+        )
+
+        assert before == []
+        assert len(after) == 1
+        assert after[0].lease_id == created.lease_id
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+
+
+def test_update_lease_rolls_back_when_audit_log_write_fails(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+    constraint_name = f"audit_logs_reject_{uuid4().hex[:12]}"
+    today = date.today()
+    next_year = today.replace(year=today.year + 1)
+
+    try:
+        property_record = db.create_property(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Rollback Lease HQ {uuid4().hex[:8]}",
+            address=f"Rollback Lease Street {uuid4().hex[:8]}",
+        )
+        created = db.create_lease(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=property_record.property_id,
+            resident_name="Rollback Resident",
+            rent_due_day_of_month=5,
+            start_date=today,
+            end_date=next_year,
+        )
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            with conn.transaction():
+                conn.execute(
+                    """
+                    INSERT INTO notifications (
+                        tenant_id,
+                        lease_id,
+                        type,
+                        title,
+                        message,
+                        due_date
+                    ) VALUES (%s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        tenant_id,
+                        created.lease_id,
+                        "rent_due_soon",
+                        "Future unread",
+                        "Future unread.",
+                        today + timedelta(days=1),
+                    ),
+                )
+                conn.execute(
+                    SQL(
+                        """
+                        ALTER TABLE audit_logs
+                        ADD CONSTRAINT {constraint_name}
+                        CHECK (action <> 'lease.update' OR tenant_id <> {tenant_id})
+                        """
+                    ).format(
+                        constraint_name=Identifier(constraint_name),
+                        tenant_id=Literal(tenant_id),
+                    )
+                )
+
+        with pytest.raises(psycopg.Error):
+            db.update_lease(
+                tenant_id=tenant_id,
+                actor_user_id=actor_user_id,
+                lease_id=created.lease_id,
+                updates={"rent_due_day_of_month": 9},
+            )
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            lease_rows = conn.execute(
+                """
+                SELECT rent_due_day_of_month
+                FROM leases
+                WHERE tenant_id = %s AND lease_id = %s
+                """,
+                (tenant_id, created.lease_id),
+            ).fetchall()
+            audit_rows = conn.execute(
+                """
+                SELECT audit_id
+                FROM audit_logs
+                WHERE tenant_id = %s AND entity_id = %s AND action = 'lease.update'
+                """,
+                (tenant_id, created.lease_id),
+            ).fetchall()
+            notification_rows = conn.execute(
+                """
+                SELECT notification_id
+                FROM notifications
+                WHERE tenant_id = %s AND lease_id = %s
+                """,
+                (tenant_id, created.lease_id),
+            ).fetchall()
+
+        assert lease_rows[0]["rent_due_day_of_month"] == 5
+        assert audit_rows == []
+        assert len(notification_rows) == 1
+    finally:
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            with conn.transaction():
+                conn.execute(
+                    SQL(
+                        "ALTER TABLE audit_logs DROP CONSTRAINT IF EXISTS {constraint_name}"
+                    ).format(constraint_name=Identifier(constraint_name))
+                )
+        _cleanup_test_tenant(integration_settings, tenant_id)
 
 
 def test_list_due_lease_reminders_returns_only_due_active_tenant_leases(

--- a/backend/tests/test_handler.py
+++ b/backend/tests/test_handler.py
@@ -400,6 +400,132 @@ def test_update_property_maps_missing_property_to_not_found(monkeypatch) -> None
     assert json.loads(response["body"]) == {"error": "Property not found for tenant."}
 
 
+def test_update_lease_accepts_stage_prefixed_raw_path(monkeypatch) -> None:
+    monkeypatch.setattr(
+        handler,
+        "load_settings",
+        lambda: SimpleNamespace(log_level="INFO"),
+    )
+    monkeypatch.setattr(handler, "Database", lambda settings: object())
+    monkeypatch.setattr(
+        handler,
+        "update_lease",
+        lambda event, db, lease_id: {
+            "lease_id": str(lease_id),
+            "tenant_id": "tenant-123",
+            "property_id": "11111111-1111-1111-1111-111111111111",
+            "resident_name": "Alice Updated",
+            "rent_due_day_of_month": 7,
+            "start_date": "2026-06-01",
+            "end_date": "2027-05-31",
+            "created_at": "2026-04-07T00:00:00+00:00",
+        },
+        raising=False,
+    )
+
+    event = {
+        "rawPath": "/dev/leases/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "body": json.dumps({"resident_name": "Alice Updated"}),
+        "requestContext": {
+            "stage": "dev",
+            "http": {"method": "PATCH"},
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": "user-123",
+                        "custom:tenant_id": "tenant-123",
+                    }
+                }
+            },
+        },
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 200
+    assert json.loads(response["body"]) == {
+        "lease_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "tenant_id": "tenant-123",
+        "property_id": "11111111-1111-1111-1111-111111111111",
+        "resident_name": "Alice Updated",
+        "rent_due_day_of_month": 7,
+        "start_date": "2026-06-01",
+        "end_date": "2027-05-31",
+        "created_at": "2026-04-07T00:00:00+00:00",
+    }
+
+
+def test_update_lease_rejects_invalid_lease_uuid(monkeypatch) -> None:
+    monkeypatch.setattr(
+        handler,
+        "load_settings",
+        lambda: SimpleNamespace(log_level="INFO"),
+    )
+
+    event = {
+        "rawPath": "/dev/leases/not-a-uuid",
+        "body": json.dumps({"resident_name": "Alice Updated"}),
+        "requestContext": {
+            "stage": "dev",
+            "http": {"method": "PATCH"},
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": "user-123",
+                        "custom:tenant_id": "tenant-123",
+                    }
+                }
+            },
+        },
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 400
+    assert json.loads(response["body"]) == {"error": "Invalid lease ID."}
+
+
+def test_update_lease_maps_missing_lease_to_not_found(monkeypatch) -> None:
+    monkeypatch.setattr(
+        handler,
+        "load_settings",
+        lambda: SimpleNamespace(log_level="INFO"),
+    )
+    monkeypatch.setattr(handler, "Database", lambda settings: object())
+
+    def _raise_lookup_error(event, db, lease_id):
+        raise LookupError("Lease not found for tenant.")
+
+    monkeypatch.setattr(
+        handler,
+        "update_lease",
+        _raise_lookup_error,
+        raising=False,
+    )
+
+    event = {
+        "rawPath": "/dev/leases/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "body": json.dumps({"resident_name": "Alice Updated"}),
+        "requestContext": {
+            "stage": "dev",
+            "http": {"method": "PATCH"},
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": "user-123",
+                        "custom:tenant_id": "tenant-123",
+                    }
+                }
+            },
+        },
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 404
+    assert json.loads(response["body"]) == {"error": "Lease not found for tenant."}
+
+
 def test_mark_notification_read_maps_missing_notification_to_not_found(monkeypatch) -> None:
     monkeypatch.setattr(
         handler,

--- a/backend/tests/test_leases_route.py
+++ b/backend/tests/test_leases_route.py
@@ -30,6 +30,7 @@ class _FakeDb:
     def __init__(self) -> None:
         self.create_calls: list[dict[str, object]] = []
         self.list_calls: list[str] = []
+        self.update_calls: list[dict[str, object]] = []
 
     def create_lease(
         self,
@@ -77,6 +78,32 @@ class _FakeDb:
                 created_at=datetime(2026, 4, 7, tzinfo=UTC),
             )
         ]
+
+    def update_lease(
+        self,
+        tenant_id: str,
+        actor_user_id: str,
+        lease_id: UUID,
+        updates: dict[str, object],
+    ) -> _LeaseRecord:
+        self.update_calls.append(
+            {
+                "tenant_id": tenant_id,
+                "actor_user_id": actor_user_id,
+                "lease_id": lease_id,
+                "updates": updates,
+            }
+        )
+        return _LeaseRecord(
+            lease_id=lease_id,
+            tenant_id=tenant_id,
+            property_id=UUID("11111111-1111-1111-1111-111111111111"),
+            resident_name=str(updates.get("resident_name", "Alice Example")),
+            rent_due_day_of_month=int(updates.get("rent_due_day_of_month", 5)),
+            start_date=updates.get("start_date", date(2026, 5, 1)),
+            end_date=updates.get("end_date", date(2027, 4, 30)),
+            created_at=datetime(2026, 4, 7, tzinfo=UTC),
+        )
 
 
 def _event_with_auth(*, tenant_id: str = "tenant-from-token", user_id: str = "user-123") -> dict:
@@ -260,3 +287,263 @@ def test_create_lease_rejects_invalid_rent_due_day_of_month() -> None:
         )
 
     assert db.create_calls == []
+
+
+def test_update_lease_uses_auth_tenant_not_body_input() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+    event = _event_with_auth(tenant_id="tenant-auth", user_id="user-auth")
+    lease_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+    payload = leases.update_lease(
+        {
+            **event,
+            "body": '{"resident_name":"  Alice Updated  "}',
+        },
+        db,
+        lease_id,
+    )
+
+    assert db.update_calls == [
+        {
+            "tenant_id": "tenant-auth",
+            "actor_user_id": "user-auth",
+            "lease_id": lease_id,
+            "updates": {"resident_name": "Alice Updated"},
+        }
+    ]
+    assert payload == {
+        "lease_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "tenant_id": "tenant-auth",
+        "property_id": "11111111-1111-1111-1111-111111111111",
+        "resident_name": "Alice Updated",
+        "rent_due_day_of_month": 5,
+        "start_date": "2026-05-01",
+        "end_date": "2027-04-30",
+        "created_at": "2026-04-07T00:00:00+00:00",
+    }
+
+
+def test_update_lease_supports_rent_due_day_only_patch() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+    lease_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+    payload = leases.update_lease(
+        {
+            **event,
+            "body": '{"rent_due_day_of_month": 7}',
+        },
+        db,
+        lease_id,
+    )
+
+    assert db.update_calls == [
+        {
+            "tenant_id": "tenant-from-token",
+            "actor_user_id": "user-123",
+            "lease_id": lease_id,
+            "updates": {"rent_due_day_of_month": 7},
+        }
+    ]
+    assert payload["rent_due_day_of_month"] == 7
+
+
+def test_update_lease_supports_start_and_end_date_patch() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+    lease_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+    payload = leases.update_lease(
+        {
+            **event,
+            "body": '{"start_date":"2026-06-01","end_date":"2027-05-31"}',
+        },
+        db,
+        lease_id,
+    )
+
+    assert db.update_calls == [
+        {
+            "tenant_id": "tenant-from-token",
+            "actor_user_id": "user-123",
+            "lease_id": lease_id,
+            "updates": {
+                "start_date": date(2026, 6, 1),
+                "end_date": date(2027, 5, 31),
+            },
+        }
+    ]
+    assert payload["start_date"] == "2026-06-01"
+    assert payload["end_date"] == "2027-05-31"
+
+
+def test_update_lease_supports_multiple_fields() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+    lease_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+    payload = leases.update_lease(
+        {
+            **event,
+            "body": (
+                '{"resident_name":" Bob Updated ","rent_due_day_of_month":"9","start_date":"2026-07-01"}'
+            ),
+        },
+        db,
+        lease_id,
+    )
+
+    assert db.update_calls == [
+        {
+            "tenant_id": "tenant-from-token",
+            "actor_user_id": "user-123",
+            "lease_id": lease_id,
+            "updates": {
+                "resident_name": "Bob Updated",
+                "rent_due_day_of_month": 9,
+                "start_date": date(2026, 7, 1),
+            },
+        }
+    ]
+    assert payload["resident_name"] == "Bob Updated"
+    assert payload["rent_due_day_of_month"] == 9
+    assert payload["start_date"] == "2026-07-01"
+
+
+def test_update_lease_rejects_empty_patch_body() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "At least one of 'resident_name', 'rent_due_day_of_month', "
+            "'start_date', or 'end_date' is required."
+        ),
+    ):
+        leases.update_lease(
+            {**event, "body": "{}"}, db, UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        )
+
+    assert db.update_calls == []
+
+
+def test_update_lease_rejects_unsupported_fields() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Only fields 'resident_name', 'rent_due_day_of_month', "
+            "'start_date', and 'end_date' can be updated."
+        ),
+    ):
+        leases.update_lease(
+            {
+                **event,
+                "body": '{"property_id":"11111111-1111-1111-1111-111111111111"}',
+            },
+            db,
+            UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        )
+
+    assert db.update_calls == []
+
+
+def test_update_lease_rejects_blank_trimmed_resident_name() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+
+    with pytest.raises(ValueError, match="Field 'resident_name' must not be empty."):
+        leases.update_lease(
+            {
+                **event,
+                "body": '{"resident_name":"   "}',
+            },
+            db,
+            UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        )
+
+    assert db.update_calls == []
+
+
+def test_update_lease_rejects_invalid_rent_due_day() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+
+    with pytest.raises(
+        ValueError,
+        match="Field 'rent_due_day_of_month' must be an integer between 1 and 31.",
+    ):
+        leases.update_lease(
+            {
+                **event,
+                "body": '{"rent_due_day_of_month": 32}',
+            },
+            db,
+            UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        )
+
+    assert db.update_calls == []
+
+
+def test_update_lease_rejects_invalid_date_format() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+
+    with pytest.raises(
+        ValueError,
+        match="Fields 'start_date' and 'end_date' must use YYYY-MM-DD.",
+    ):
+        leases.update_lease(
+            {
+                **event,
+                "body": '{"start_date":"06/01/2026"}',
+            },
+            db,
+            UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        )
+
+    assert db.update_calls == []
+
+
+def test_update_lease_rejects_invalid_combined_date_range() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+
+    with pytest.raises(ValueError, match="'end_date' must be on or after 'start_date'."):
+        leases.update_lease(
+            {
+                **event,
+                "body": '{"start_date":"2028-01-01","end_date":"2027-12-31"}',
+            },
+            db,
+            UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        )
+
+    assert db.update_calls == []
+
+
+def test_update_lease_requires_jwt_claims() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+
+    with pytest.raises(AuthError, match="Missing JWT claims."):
+        leases.update_lease(
+            {
+                "body": '{"resident_name":"Alice Updated"}',
+            },
+            db,
+            UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        )

--- a/backend/tests/test_leases_route.py
+++ b/backend/tests/test_leases_route.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from uuid import UUID
@@ -389,8 +390,12 @@ def test_update_lease_supports_multiple_fields() -> None:
     payload = leases.update_lease(
         {
             **event,
-            "body": (
-                '{"resident_name":" Bob Updated ","rent_due_day_of_month":"9","start_date":"2026-07-01"}'
+            "body": json.dumps(
+                {
+                    "resident_name": " Bob Updated ",
+                    "rent_due_day_of_month": "9",
+                    "start_date": "2026-07-01",
+                }
             ),
         },
         db,

--- a/docs/mvp-scope.md
+++ b/docs/mvp-scope.md
@@ -9,6 +9,7 @@
   - `GET /properties`
   - `POST /leases`
   - `GET /leases`
+  - `PATCH /leases/{lease_id}`
   - `GET /notifications`
   - `PATCH /notifications/{notification_id}/read`
 - Cognito JWT-based authentication and tenant claim extraction.

--- a/infra/modules/api_http/defaults.tftest.hcl
+++ b/infra/modules/api_http/defaults.tftest.hcl
@@ -27,6 +27,11 @@ run "exposes_backend_route_parity" {
   }
 
   assert {
+    condition     = aws_apigatewayv2_route.update_lease.route_key == "PATCH /leases/{lease_id}"
+    error_message = "API module should expose PATCH /leases/{lease_id}."
+  }
+
+  assert {
     condition     = aws_apigatewayv2_route.list_notifications.route_key == "GET /notifications"
     error_message = "API module should expose GET /notifications."
   }
@@ -54,6 +59,11 @@ run "exposes_backend_route_parity" {
   assert {
     condition     = aws_apigatewayv2_route.list_notifications.authorization_type == "JWT"
     error_message = "Notification route should require JWT auth."
+  }
+
+  assert {
+    condition     = aws_apigatewayv2_route.update_lease.authorization_type == "JWT"
+    error_message = "Lease update route should require JWT auth."
   }
 
   assert {

--- a/infra/modules/api_http/main.tf
+++ b/infra/modules/api_http/main.tf
@@ -69,6 +69,14 @@ resource "aws_apigatewayv2_route" "create_lease" {
   authorizer_id      = aws_apigatewayv2_authorizer.jwt.id
 }
 
+resource "aws_apigatewayv2_route" "update_lease" {
+  api_id             = aws_apigatewayv2_api.this.id
+  route_key          = "PATCH /leases/{lease_id}"
+  target             = "integrations/${aws_apigatewayv2_integration.backend.id}"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.jwt.id
+}
+
 resource "aws_apigatewayv2_route" "list_notifications" {
   api_id             = aws_apigatewayv2_api.this.id
   route_key          = "GET /notifications"


### PR DESCRIPTION
## Summary
- add `PATCH /leases/{lease_id}` as a tenant-safe partial update flow
- allow updates only for `resident_name`, `rent_due_day_of_month`, `start_date`, and `end_date`
- delete future unread `rent_due_soon` notifications when reminder-driving lease fields change
- write `lease.update` audit logs with `source`, `changed_fields`, and `deleted_notification_count`
- add the matching JWT-protected API Gateway route and update MVP endpoint docs

## Why
This closes the next important CRUD gap in the lease lifecycle and keeps reminder behavior correct when lease terms change.

Closes #45.

## Assumptions
- lease schema stays unchanged in this PR
- `property_id`, `tenant_id`, and any new rent/status fields remain out of scope
- unchanged values are idempotent and do not create audit rows or delete notifications
- reminder recreation stays in the existing scan flow rather than the PATCH handler

## Security Validation
- `tenant_id` is derived only from JWT claims, not from request body fields
- unsupported fields, including `tenant_id` and `property_id`, are rejected with `400`
- DB updates filter by both `tenant_id` and `lease_id`
- cross-tenant lease updates return `404` via `LookupError("Lease not found for tenant.")`
- lease update, reminder cleanup, and audit log insert run in one transaction
- read reminder notifications are preserved during cleanup

## Cost Validation
- no new AWS services were added
- API Gateway change is one additional route on the existing HTTP API module
- reminder cleanup reuses the existing database and scan flow
- cost impact is effectively negligible for the MVP

## Validation
- `python -m pytest -q backend/tests/test_leases_route.py backend/tests/test_handler.py`
- `terraform test` in `infra/modules/api_http`
- WSL local DB validation: `python -m alembic upgrade head` and `python -m pytest -q tests/test_db_integration.py -k update_lease`

## Remaining Risks / TODOs
- full backend regression suite was not rerun in this PR, only lease-update-focused tests
- no `updated_at` field exists yet, so update timestamps remain out of scope
- deleted reminder notifications are recreated only by later reminder scans, not synchronously in the PATCH flow