### PR TITLE
feat: add SNS alarm actions for baseline CloudWatch alarms

### DIFF
--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -15,6 +15,7 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
 - **Cognito**: authentication and JWT issuance.
 - **RDS PostgreSQL (private)**: core relational data store.
 - **CloudWatch**: application logs, baseline alarms, and operational visibility.
+- **SNS**: baseline alarm action topic for AWS-native alert fan-out.
 - **Terraform**: infrastructure provisioning and repeatability.
 - **EventBridge Scheduler**: daily invocation of the internal reminder scan workflow.
 
@@ -43,6 +44,7 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
 - Secrets via SSM Parameter Store SecureString, not hardcoded values.
 - Private Lambda access to SSM and KMS uses interface VPC endpoints instead of a NAT path.
 - Baseline CloudWatch alarms cover backend Lambda errors, Lambda throttles, HTTP API 5xx responses, and scheduler target failures.
+- Baseline alarms publish alarm-state changes to an SNS topic; human subscriptions are intentionally out of scope for the current baseline.
 - Structured JSON logging for traceability.
 
 ## Cost-Aware Decisions

--- a/docs/security-baseline.md
+++ b/docs/security-baseline.md
@@ -104,6 +104,7 @@ Mitigations:
 - Enable API Gateway throttling and request validation.
 - Apply application-level input validation to reject obviously invalid or abusive requests early.
 - Use CloudWatch metrics and alarms for backend Lambda errors, Lambda throttles, HTTP API 5xx responses, scheduler target failures, and unusual invocation spikes.
+- Publish baseline alarm-state changes to the environment SNS alarm topic for AWS-native notification fan-out.
 - Keep scheduled and event-driven tasks idempotent to reduce cascading retries.
 - Size the MVP conservatively and prefer simple protective limits over complex resilience features.
 
@@ -155,6 +156,7 @@ Mitigations:
 - Logs should include timestamp, severity, request ID, user ID when available, tenant ID when relevant, action name, and outcome.
 - Audit events should be stored in PostgreSQL for business and security traceability.
 - Baseline CloudWatch alarms should exist for backend Lambda errors, backend Lambda throttles, HTTP API 5xx responses, and reminder scheduler target failures.
+- Baseline alarms publish to an environment SNS topic, but no confirmed human subscription exists yet.
 
 Examples of auditable events:
 

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -85,6 +85,12 @@ module "reminder_scheduler" {
   tags                 = local.common_tags
 }
 
+resource "aws_sns_topic" "baseline_alarm_notifications" {
+  name = "${local.name_prefix}-baseline-alarm-notifications"
+
+  tags = local.common_tags
+}
+
 module "cloudwatch_alarms" {
   source = "../../modules/cloudwatch_alarms"
 
@@ -94,6 +100,7 @@ module "cloudwatch_alarms" {
   api_stage_name       = var.environment
   scheduler_group_name = "default"
   scheduler_enabled    = var.reminder_scan_enabled
+  alarm_action_arns    = [aws_sns_topic.baseline_alarm_notifications.arn]
   tags                 = local.common_tags
 }
 

--- a/infra/environments/dev/outputs.tf
+++ b/infra/environments/dev/outputs.tf
@@ -37,3 +37,13 @@ output "baseline_alarm_names" {
     module.cloudwatch_alarms.scheduler_target_errors_alarm_name
   ])
 }
+
+output "baseline_alarm_notification_topic_name" {
+  description = "SNS topic name used as the baseline CloudWatch alarm action target."
+  value       = aws_sns_topic.baseline_alarm_notifications.name
+}
+
+output "baseline_alarm_notification_topic_arn" {
+  description = "SNS topic ARN used as the baseline CloudWatch alarm action target."
+  value       = aws_sns_topic.baseline_alarm_notifications.arn
+}

--- a/infra/modules/cloudwatch_alarms/main.tf
+++ b/infra/modules/cloudwatch_alarms/main.tf
@@ -10,6 +10,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
   metric_name         = "Errors"
   statistic           = "Sum"
   treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_action_arns
 
   dimensions = {
     FunctionName = var.lambda_function_name
@@ -30,6 +31,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   metric_name         = "Throttles"
   statistic           = "Sum"
   treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_action_arns
 
   dimensions = {
     FunctionName = var.lambda_function_name
@@ -50,6 +52,7 @@ resource "aws_cloudwatch_metric_alarm" "api_gateway_5xx" {
   metric_name         = "5xx"
   statistic           = "Sum"
   treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_action_arns
 
   dimensions = {
     ApiId = var.api_id
@@ -73,6 +76,7 @@ resource "aws_cloudwatch_metric_alarm" "scheduler_target_errors" {
   metric_name         = "TargetErrorCount"
   statistic           = "Sum"
   treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_action_arns
 
   dimensions = {
     ScheduleGroup = var.scheduler_group_name

--- a/infra/modules/cloudwatch_alarms/tests/defaults.tftest.hcl
+++ b/infra/modules/cloudwatch_alarms/tests/defaults.tftest.hcl
@@ -51,6 +51,11 @@ run "creates_baseline_alarm_resources" {
   }
 
   assert {
+    condition     = length(coalesce(aws_cloudwatch_metric_alarm.lambda_errors.alarm_actions, [])) == 0
+    error_message = "Lambda errors alarm should have no actions by default."
+  }
+
+  assert {
     condition     = aws_cloudwatch_metric_alarm.lambda_throttles.metric_name == "Throttles"
     error_message = "Lambda throttles alarm should track Lambda Throttles."
   }
@@ -98,6 +103,48 @@ run "creates_baseline_alarm_resources" {
   assert {
     condition     = aws_cloudwatch_metric_alarm.scheduler_target_errors[0].period == 300
     error_message = "Scheduler alarm should use a 5-minute period."
+  }
+}
+
+run "attaches_alarm_actions_when_supplied" {
+  command = plan
+
+  variables {
+    alarm_action_arns = [
+      "arn:aws:sns:eu-north-1:123456789012:leaseflow-dev-baseline-alarm-notifications"
+    ]
+  }
+
+  assert {
+    condition = length(aws_cloudwatch_metric_alarm.lambda_errors.alarm_actions) == 1 && contains(
+      aws_cloudwatch_metric_alarm.lambda_errors.alarm_actions,
+      "arn:aws:sns:eu-north-1:123456789012:leaseflow-dev-baseline-alarm-notifications"
+    )
+    error_message = "Lambda errors alarm should publish to the supplied action ARN."
+  }
+
+  assert {
+    condition = length(aws_cloudwatch_metric_alarm.lambda_throttles.alarm_actions) == 1 && contains(
+      aws_cloudwatch_metric_alarm.lambda_throttles.alarm_actions,
+      "arn:aws:sns:eu-north-1:123456789012:leaseflow-dev-baseline-alarm-notifications"
+    )
+    error_message = "Lambda throttles alarm should publish to the supplied action ARN."
+  }
+
+  assert {
+    condition = length(aws_cloudwatch_metric_alarm.api_gateway_5xx.alarm_actions) == 1 && contains(
+      aws_cloudwatch_metric_alarm.api_gateway_5xx.alarm_actions,
+      "arn:aws:sns:eu-north-1:123456789012:leaseflow-dev-baseline-alarm-notifications"
+    )
+    error_message = "API 5xx alarm should publish to the supplied action ARN."
+  }
+
+  assert {
+    condition = length(aws_cloudwatch_metric_alarm.scheduler_target_errors[0].alarm_actions) == 1 && contains(
+      aws_cloudwatch_metric_alarm.scheduler_target_errors[0].alarm_actions,
+      "arn:aws:sns:eu-north-1:123456789012:leaseflow-dev-baseline-alarm-notifications"
+    )
+    error_message = "Scheduler target errors alarm should publish to the supplied action ARN."
   }
 }
 

--- a/infra/modules/cloudwatch_alarms/variables.tf
+++ b/infra/modules/cloudwatch_alarms/variables.tf
@@ -28,6 +28,12 @@ variable "scheduler_enabled" {
   type        = bool
 }
 
+variable "alarm_action_arns" {
+  description = "Alarm action ARNs for baseline CloudWatch alarms."
+  type        = list(string)
+  default     = []
+}
+
 variable "tags" {
   description = "Tags applied to alarm resources."
   type        = map(string)


### PR DESCRIPTION
## What Changed

Added a dev-scoped SNS topic for baseline CloudWatch alarm notifications and wired the existing CloudWatch alarm module to accept external alarm action ARNs.

This keeps the alarm module reusable while allowing the dev stack to publish alarm-state changes to an AWS-native fan-out target.

## Why

This improves Operational Excellence by giving the baseline alarms a concrete alarm action target. The scope is intentionally limited to topic-only fan-out; human delivery is a later ticket.

## Scope

- Added `alarm_action_arns` input to `infra/modules/cloudwatch_alarms` with default `[]`.
- Set `alarm_actions` on Lambda errors, Lambda throttles, API Gateway 5xx, and scheduler target error alarms.
- Added `aws_sns_topic.baseline_alarm_notifications` in the dev environment.
- Passed the SNS topic ARN into the dev `cloudwatch_alarms` module.
- Added dev outputs for the SNS topic name and ARN.
- Updated architecture and security docs to state that alarms publish to SNS, but no human subscription exists yet.

## Assumptions

- Topic-only notification fan-out is intentional for this ticket.
- Email, Slack, PagerDuty, routing rules, and incident workflow are out of scope.
- No SNS topic policy is added because this is same-account CloudWatch alarm action publishing unless AWS validation later proves otherwise.

## Security Validation

- No backend, tenant model, or authentication code changed.
- No tenant-scoped data access was introduced or modified.
- The change is infrastructure-only and does not alter `tenant_id` handling.

## Cost Validation

- Adds one dev SNS topic only.
- No subscriptions or delivery integrations are added.
- Expected dev-scale publish volume is negligible.

## Validation

- [x] `terraform test` in `infra/modules/cloudwatch_alarms`: 3 passed, 0 failed.
- [x] `terraform validate` in `infra/environments/dev`: configuration is valid.

## Deployment Notes

After apply, verify the topic and alarm actions with:

```bash
aws sns list-topics
aws cloudwatch describe-alarms --alarm-names \
  leaseflow-dev-backend-errors \
  leaseflow-dev-backend-throttles \
  leaseflow-dev-http-api-5xx \
  leaseflow-dev-reminder-scheduler-target-errors \
  --query 'MetricAlarms[].{Name:AlarmName,Actions:AlarmActions}'
```

## Remaining Risks / TODOs

- SNS topic without a confirmed subscription is not human notification delivery.
- A later ticket should add an explicit subscription or downstream notification target if operator delivery is required.

## AWS SAA-C03 Note

SNS can fan out alarm events, but a topic alone does not notify a human. For exam scenarios, distinguish between creating an SNS topic and adding confirmed subscriptions or downstream targets.
