### PR TITLE
feat: add optional dev alarm email subscription

### DIFF
--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -44,7 +44,7 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
 - Secrets via SSM Parameter Store SecureString, not hardcoded values.
 - Private Lambda access to SSM and KMS uses interface VPC endpoints instead of a NAT path.
 - Baseline CloudWatch alarms cover backend Lambda errors, Lambda throttles, HTTP API 5xx responses, and scheduler target failures.
-- Baseline alarms publish alarm-state changes to an SNS topic; human subscriptions are intentionally out of scope for the current baseline.
+- Baseline alarms publish alarm-state changes to an SNS topic; dev can optionally add one email subscription that requires confirmation before delivery starts.
 - Structured JSON logging for traceability.
 
 ## Cost-Aware Decisions

--- a/docs/security-baseline.md
+++ b/docs/security-baseline.md
@@ -156,7 +156,7 @@ Mitigations:
 - Logs should include timestamp, severity, request ID, user ID when available, tenant ID when relevant, action name, and outcome.
 - Audit events should be stored in PostgreSQL for business and security traceability.
 - Baseline CloudWatch alarms should exist for backend Lambda errors, backend Lambda throttles, HTTP API 5xx responses, and reminder scheduler target failures.
-- Baseline alarms publish to an environment SNS topic, but no confirmed human subscription exists yet.
+- Baseline alarms publish to an environment SNS topic; optional dev email delivery starts only after the recipient confirms the SNS subscription email.
 
 Examples of auditable events:
 

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -91,6 +91,14 @@ resource "aws_sns_topic" "baseline_alarm_notifications" {
   tags = local.common_tags
 }
 
+resource "aws_sns_topic_subscription" "baseline_alarm_email" {
+  count = trimspace(var.baseline_alarm_notification_email) == "" ? 0 : 1
+
+  topic_arn = aws_sns_topic.baseline_alarm_notifications.arn
+  protocol  = "email"
+  endpoint  = trimspace(var.baseline_alarm_notification_email)
+}
+
 module "cloudwatch_alarms" {
   source = "../../modules/cloudwatch_alarms"
 

--- a/infra/environments/dev/outputs.tf
+++ b/infra/environments/dev/outputs.tf
@@ -47,3 +47,8 @@ output "baseline_alarm_notification_topic_arn" {
   description = "SNS topic ARN used as the baseline CloudWatch alarm action target."
   value       = aws_sns_topic.baseline_alarm_notifications.arn
 }
+
+output "baseline_alarm_email_subscription_configured" {
+  description = "Whether a dev baseline alarm email subscription is configured."
+  value       = length(aws_sns_topic_subscription.baseline_alarm_email) > 0
+}

--- a/infra/environments/dev/terraform.tfvars.example
+++ b/infra/environments/dev/terraform.tfvars.example
@@ -12,3 +12,6 @@ db_engine_version = "15.17"
 # Terraform generates the DB password and stores it in SSM SecureString at this path.
 lambda_package_file   = "../../../dist/leaseflow-backend.zip"
 db_password_ssm_param = "/leaseflow/dev/db/password"
+
+# Optional. AWS sends a confirmation email before SNS starts delivery.
+baseline_alarm_notification_email = ""

--- a/infra/environments/dev/tests/alarm_email_subscription.tftest.hcl
+++ b/infra/environments/dev/tests/alarm_email_subscription.tftest.hcl
@@ -1,0 +1,93 @@
+mock_provider "aws" {
+  mock_resource "aws_sns_topic" {
+    defaults = {
+      arn = "arn:aws:sns:eu-north-1:123456789012:leaseflow-dev-baseline-alarm-notifications"
+    }
+  }
+
+  mock_data "aws_availability_zones" {
+    defaults = {
+      names = ["eu-north-1a", "eu-north-1b"]
+    }
+  }
+
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+
+  mock_data "aws_kms_alias" {
+    defaults = {
+      arn            = "arn:aws:kms:eu-north-1:123456789012:alias/aws/ssm"
+      name           = "alias/aws/ssm"
+      target_key_arn = "arn:aws:kms:eu-north-1:123456789012:key/11111111-2222-3333-4444-555555555555"
+    }
+  }
+
+  mock_data "aws_region" {
+    defaults = {
+      region = "eu-north-1"
+    }
+  }
+}
+
+variables {
+  lambda_package_file = "../../modules/lambda_backend/main.tf"
+}
+
+run "omits_email_subscription_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(aws_sns_topic_subscription.baseline_alarm_email) == 0
+    error_message = "Dev alarm email subscription should be omitted by default."
+  }
+
+  assert {
+    condition     = output.baseline_alarm_email_subscription_configured == false
+    error_message = "Dev output should report no configured email subscription by default."
+  }
+}
+
+run "creates_email_subscription_when_address_supplied" {
+  command = plan
+
+  variables {
+    baseline_alarm_notification_email = "ops@example.com"
+  }
+
+  override_resource {
+    target          = aws_sns_topic.baseline_alarm_notifications
+    override_during = plan
+
+    values = {
+      arn = "arn:aws:sns:eu-north-1:123456789012:leaseflow-dev-baseline-alarm-notifications"
+    }
+  }
+
+  assert {
+    condition     = length(aws_sns_topic_subscription.baseline_alarm_email) == 1
+    error_message = "Dev alarm email subscription should be created when an email is supplied."
+  }
+
+  assert {
+    condition     = aws_sns_topic_subscription.baseline_alarm_email[0].protocol == "email"
+    error_message = "Dev alarm subscription should use the SNS email protocol."
+  }
+
+  assert {
+    condition     = aws_sns_topic_subscription.baseline_alarm_email[0].endpoint == "ops@example.com"
+    error_message = "Dev alarm subscription should target the supplied email address."
+  }
+
+  assert {
+    condition     = aws_sns_topic_subscription.baseline_alarm_email[0].topic_arn == aws_sns_topic.baseline_alarm_notifications.arn
+    error_message = "Dev alarm subscription should attach to the baseline alarm notification topic."
+  }
+
+  assert {
+    condition     = output.baseline_alarm_email_subscription_configured == true
+    error_message = "Dev output should report configured email subscription when an email is supplied."
+  }
+}

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -94,6 +94,12 @@ variable "reminder_scan_enabled" {
   default     = true
 }
 
+variable "baseline_alarm_notification_email" {
+  type        = string
+  description = "Optional email endpoint subscribed to dev baseline alarm SNS notifications."
+  default     = ""
+}
+
 variable "tags" {
   type        = map(string)
   description = "Extra tags."


### PR DESCRIPTION
## What Changed

Added an optional dev-only SNS email subscription for baseline CloudWatch alarm notifications.

The subscription is disabled by default and is created only when `baseline_alarm_notification_email` is set.

## Why

The existing baseline alarms publish to an SNS topic, but topic-only fan-out does not notify a human. This adds an explicit optional email delivery path for the dev environment while keeping personal email addresses out of committed configuration by default.

## Scope

- Added `baseline_alarm_notification_email` variable with default `""`.
- Added conditional `aws_sns_topic_subscription.baseline_alarm_email`.
- Added `baseline_alarm_email_subscription_configured` output.
- Updated `terraform.tfvars.example`.
- Added Terraform tests for default/no-subscription and email-configured paths.
- Updated architecture and security docs with SNS email confirmation behavior.

## Assumptions

- This is dev-only.
- Only one optional email endpoint is supported in this ticket.
- Email address is provided via local tfvars or CLI variable, not hardcoded in repo config.
- No Slack, PagerDuty, routing, or incident workflow is added.

## Security Validation

- No backend, authentication, authorization, or tenant data access changed.
- No `tenant_id` handling changed.
- Email endpoint is optional and not committed with a real address.

## Cost Validation

- Adds no resources by default.
- When configured, adds one SNS email subscription.
- Expected dev-scale SNS email delivery cost is negligible.

## Validation

- [x] `terraform fmt -recursive`
- [x] `terraform test` in `infra/environments/dev`: 2 passed, 0 failed
- [x] `terraform validate` in `infra/environments/dev`: configuration is valid

## Deployment Notes

Set the email only when applying dev infrastructure, for example:

```bash
terraform apply \
  -var db_engine_version=15.17 \
  -var baseline_alarm_notification_email=you@example.com
