### PR TITLE
docs: add dev RDS restore validation runbook

### DIFF
--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -56,6 +56,10 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
 - No extra services unless they deliver clear MVP value.
 - One daily scheduler is preferred over per-tenant schedules to keep dev-stage operational cost and complexity low.
 
+## Operational Runbooks
+
+- Dev RDS restore validation is documented in `docs/runbooks/dev-rds-restore-validation.md`.
+
 ## Diagram Source
 
 The version-controlled source for the architecture diagram lives in:

--- a/docs/runbooks/dev-rds-restore-validation.md
+++ b/docs/runbooks/dev-rds-restore-validation.md
@@ -1,0 +1,215 @@
+# Dev RDS Restore Validation Runbook
+
+## Purpose
+
+Validate that the Terraform-managed dev RDS PostgreSQL instance can be restored from automated backups without making the database public or adding permanent infrastructure.
+
+This is an operator-run dev procedure, not an automated disaster recovery platform.
+
+## Current Dev Assumptions
+
+- Source DB instance: `leaseflow-dev-postgres`.
+- Engine: Amazon RDS for PostgreSQL.
+- Backup retention: `1` day in Terraform.
+- Storage encryption: enabled.
+- Public access: disabled.
+- Multi-AZ: disabled for dev cost control.
+- Final snapshot on destroy: disabled for dev cost control.
+
+## Guardrails
+
+- Run this only in dev.
+- Keep the restored DB private.
+- Use the same DB subnet group and RDS security group as the source DB.
+- Do not import the temporary restore DB into Terraform state.
+- Delete the restored DB after validation.
+- Do not copy tenant data outside AWS.
+
+## Preconditions
+
+- AWS CLI is authenticated with the Terraform/dev account.
+- `AWS_PROFILE=terraform` is set.
+- Region is `eu-north-1`.
+- The source DB status is `available`.
+- The source DB has a non-empty `LatestRestorableTime`.
+
+## Step 1: Capture Source Backup Readiness
+
+What it does: reads source RDS backup, networking, and encryption posture before restore.
+Target service: Amazon RDS dev DB instance `leaseflow-dev-postgres`.
+
+```bash
+export AWS_PROFILE=terraform
+export AWS_REGION=eu-north-1
+export SOURCE_DB=leaseflow-dev-postgres
+
+aws rds describe-db-instances \
+  --db-instance-identifier "$SOURCE_DB" \
+  --query 'DBInstances[0].{
+    Status:DBInstanceStatus,
+    BackupRetention:BackupRetentionPeriod,
+    LatestRestorableTime:LatestRestorableTime,
+    PubliclyAccessible:PubliclyAccessible,
+    StorageEncrypted:StorageEncrypted,
+    DBSubnetGroup:DBSubnetGroup.DBSubnetGroupName,
+    VpcSecurityGroupIds:VpcSecurityGroups[].VpcSecurityGroupId
+  }' \
+  --output table
+```
+
+Expected evidence:
+
+- `Status` is `available`.
+- `BackupRetention` is `1`.
+- `LatestRestorableTime` is populated.
+- `PubliclyAccessible` is `False`.
+- `StorageEncrypted` is `True`.
+
+## Step 2: Restore a Temporary DB
+
+What it does: restores the latest restorable point to a temporary private DB instance.
+Target service: Amazon RDS restore target in dev.
+
+```bash
+export RESTORE_DB="leaseflow-dev-postgres-restore-$(date -u +%Y%m%d%H%M)"
+
+export DB_SUBNET_GROUP=$(
+  aws rds describe-db-instances \
+    --db-instance-identifier "$SOURCE_DB" \
+    --query 'DBInstances[0].DBSubnetGroup.DBSubnetGroupName' \
+    --output text
+)
+
+export RDS_SG_IDS=$(
+  aws rds describe-db-instances \
+    --db-instance-identifier "$SOURCE_DB" \
+    --query 'DBInstances[0].VpcSecurityGroups[].VpcSecurityGroupId' \
+    --output text
+)
+
+aws rds restore-db-instance-to-point-in-time \
+  --source-db-instance-identifier "$SOURCE_DB" \
+  --target-db-instance-identifier "$RESTORE_DB" \
+  --use-latest-restorable-time \
+  --db-instance-class db.t3.micro \
+  --db-subnet-group-name "$DB_SUBNET_GROUP" \
+  --vpc-security-group-ids $RDS_SG_IDS \
+  --no-publicly-accessible \
+  --tags \
+    Key=Project,Value=leaseflow \
+    Key=Environment,Value=dev \
+    Key=ManagedBy,Value=manual-runbook \
+    Key=Purpose,Value=restore-validation
+```
+
+Expected evidence:
+
+- The command returns a new DB instance identifier matching `$RESTORE_DB`.
+- No public accessibility is requested.
+- The restore uses the source DB subnet group and security group.
+
+## Step 3: Wait for Restore Completion
+
+What it does: waits until the temporary restored DB is available.
+Target service: Amazon RDS restore target in dev.
+
+```bash
+aws rds wait db-instance-available \
+  --db-instance-identifier "$RESTORE_DB"
+```
+
+Expected evidence:
+
+- The waiter exits successfully.
+- Restore duration is recorded for portfolio evidence.
+
+## Step 4: Verify Restored DB Posture
+
+What it does: confirms the restored DB is available, encrypted, and private.
+Target service: Amazon RDS restore target in dev.
+
+```bash
+aws rds describe-db-instances \
+  --db-instance-identifier "$RESTORE_DB" \
+  --query 'DBInstances[0].{
+    Status:DBInstanceStatus,
+    Engine:Engine,
+    EngineVersion:EngineVersion,
+    PubliclyAccessible:PubliclyAccessible,
+    StorageEncrypted:StorageEncrypted,
+    DBSubnetGroup:DBSubnetGroup.DBSubnetGroupName,
+    VpcSecurityGroupIds:VpcSecurityGroups[].VpcSecurityGroupId,
+    Endpoint:Endpoint.Address
+  }' \
+  --output table
+```
+
+Expected evidence:
+
+- `Status` is `available`.
+- `PubliclyAccessible` is `False`.
+- `StorageEncrypted` is `True`.
+- DB subnet group and security group match the source DB.
+- Endpoint exists, but it remains private.
+
+Do not connect to the restored DB from a public laptop. Data-level validation requires a controlled private execution path and is out of scope for this runbook.
+
+## Step 5: Clean Up
+
+What it does: deletes the temporary restore DB and its automated backups.
+Target service: Amazon RDS restore target in dev.
+
+```bash
+aws rds delete-db-instance \
+  --db-instance-identifier "$RESTORE_DB" \
+  --skip-final-snapshot \
+  --delete-automated-backups
+
+aws rds wait db-instance-deleted \
+  --db-instance-identifier "$RESTORE_DB"
+```
+
+Expected evidence:
+
+- Delete command is accepted.
+- Waiter exits successfully.
+- The temporary DB is no longer returned by `describe-db-instances`.
+
+## Success Criteria
+
+- Source DB has automated backups enabled.
+- Temporary restore DB reaches `available`.
+- Restored DB remains private and encrypted.
+- Restore metadata is captured.
+- Temporary restore DB is deleted after validation.
+
+## Evidence to Capture
+
+- Date and operator.
+- Source DB identifier.
+- `LatestRestorableTime`.
+- Temporary restore DB identifier.
+- Restore start and completion time.
+- Source and restored DB posture output.
+- Cleanup confirmation.
+- Any errors and follow-up actions.
+
+## Cost Notes
+
+- The restore creates a temporary RDS instance and storage.
+- Delete it immediately after validation.
+- Do not leave restore validation instances running overnight.
+- Do not add Multi-AZ, cross-region replication, or AWS Backup plans in this dev runbook.
+
+## SAA-C03 Notes
+
+- Automated backups and point-in-time restore are different from manual snapshots.
+- A backup retention period of `0` disables automated backups.
+- A private restored DB still needs correct subnet group and security group settings.
+- Restore validation proves recoverability better than just enabling backups.
+
+## References
+
+- AWS Prescriptive Guidance: [Backup and recovery for Amazon RDS](https://docs.aws.amazon.com/prescriptive-guidance/latest/backup-recovery/rds.html).
+- AWS CLI Command Reference: [`restore-db-instance-to-point-in-time`](https://docs.aws.amazon.com/cli/latest/reference/rds/restore-db-instance-to-point-in-time.html).
+- AWS CLI Command Reference: [`delete-db-instance`](https://docs.aws.amazon.com/cli/latest/reference/rds/delete-db-instance.html).

--- a/docs/security-baseline.md
+++ b/docs/security-baseline.md
@@ -193,6 +193,7 @@ Examples of auditable events:
 - Expose the API only over HTTPS through API Gateway.
 - Minimize stored sensitive data to what the MVP actually needs.
 - Avoid copying production data into unsecured local or test environments.
+- Validate dev RDS restore readiness with `docs/runbooks/dev-rds-restore-validation.md` without making restored databases public.
 
 ## Incident Handling (MVP)
 
@@ -210,7 +211,7 @@ The MVP does not require a full incident management platform, but it does requir
 
 - PostgreSQL Row Level Security for defense-in-depth tenant enforcement
 - Cognito MFA rollout for higher-risk roles
-- Backup and restore validation for RDS
+- Periodic RDS restore validation cadence
 - Lightweight alerting for suspicious login or API abuse patterns
 - Periodic dependency and IAM permission review
 


### PR DESCRIPTION
## What Changed

Added a dev RDS restore validation runbook and linked it from the architecture and security baseline docs.

The runbook documents how to validate restore readiness for the Terraform-managed dev PostgreSQL RDS instance without making the restored database public or adding permanent infrastructure.

## Why

The dev RDS instance has automated backups enabled, but backup existence alone does not prove recovery readiness. This runbook adds a repeatable operator-driven restore validation workflow for the current MVP architecture.

## Scope

- Added `docs/runbooks/dev-rds-restore-validation.md`.
- Documented current dev RDS assumptions:
  - `backup_retention_period = 1`
  - encrypted storage
  - private RDS
  - single-AZ dev setup
  - no final snapshot on destroy
- Documented restore validation steps using AWS CLI.
- Documented expected evidence, success criteria, cleanup, and cost guardrails.
- Linked the runbook from `docs/architecture-v0.2.md`.
- Updated `docs/security-baseline.md` to reference restore validation.

## Assumptions

- This is a dev-only runbook.
- The process is manual/operator-driven.
- No new Terraform resources are added.
- No AWS Backup plan, cross-region replication, Multi-AZ, or automated DR workflow is introduced.
- Data-level validation from a private execution path is out of scope for this ticket.

## Security Validation

- The restored DB must remain private.
- The runbook explicitly uses the same DB subnet group and RDS security group as the source DB.
- The runbook states not to copy tenant data outside AWS.
- The temporary restore DB is not imported into Terraform state.
- Cleanup is required after validation.

## Cost Validation

- No resources are created by this PR.
- The runbook creates cost only when manually executed.
- The temporary restored RDS instance must be deleted after validation.
- The runbook explicitly avoids Multi-AZ, cross-region replication, and AWS Backup plans for dev.

## Validation

- [x] `git diff --check`
- [x] Checked runbook for trailing whitespace
- [x] AWS CLI command references included for restore and cleanup commands

## Deployment Notes

No deployment required. This is documentation-only.

To execute the runbook later, use:

```bash
docs/runbooks/dev-rds-restore-validation.md
