### PR TITLE
docs: capture dev RDS restore validation evidence

### DIFF
--- a/docs/runbooks/evidence/dev-rds-restore-validation-2026-04-14.md
+++ b/docs/runbooks/evidence/dev-rds-restore-validation-2026-04-14.md
@@ -1,0 +1,169 @@
+# Dev RDS Restore Validation Evidence - 2026-04-14
+
+## Summary
+
+The dev RDS restore validation runbook was executed successfully against the AWS dev environment.
+
+Result:
+
+- Source DB had automated backups enabled.
+- A temporary private RDS instance was restored from the latest restorable point.
+- The restored DB reached `available`.
+- The restored DB remained private and encrypted.
+- The temporary restored DB was deleted after validation.
+
+## Context
+
+- Date: 2026-04-14
+- Region: `eu-north-1`
+- Source DB: `leaseflow-dev-postgres`
+- Restore DB: `leaseflow-dev-postgres-restore-20260414-0630`
+- Runbook: `docs/runbooks/dev-rds-restore-validation.md`
+
+The dev stack had been destroyed before this validation to avoid ongoing AWS cost, so it was recreated with Terraform before running the restore test.
+
+Terraform apply result:
+
+```text
+Apply complete! Resources: 44 added, 0 changed, 0 destroyed.
+```
+
+## Source DB Backup Posture
+
+Captured before restore:
+
+```text
+DBInstanceIdentifier: leaseflow-dev-postgres
+Status:               available
+BackupRetention:      1
+LatestRestorableTime: 2026-04-14T06:20:05+00:00
+PubliclyAccessible:   False
+StorageEncrypted:     True
+DBSubnetGroup:        leaseflow-dev-db-subnet-group
+VpcSecurityGroupId:   sg-0f9c964ba30648df9
+Engine:               postgres
+EngineVersion:        15.17
+InstanceClass:        db.t3.micro
+```
+
+Captured after restore cleanup:
+
+```text
+DBInstanceIdentifier: leaseflow-dev-postgres
+Status:               available
+BackupRetention:      1
+LatestRestorableTime: 2026-04-14T06:39:30+00:00
+PubliclyAccessible:   False
+StorageEncrypted:     True
+```
+
+## Restore Execution
+
+Restore target:
+
+```text
+RESTORE_DB=leaseflow-dev-postgres-restore-20260414-0630
+RESTORE_START_UTC=2026-04-14T06:29:54Z
+```
+
+The restore was started with:
+
+- source DB: `leaseflow-dev-postgres`
+- target DB: `leaseflow-dev-postgres-restore-20260414-0630`
+- `--use-latest-restorable-time`
+- instance class: `db.t3.micro`
+- DB subnet group: `leaseflow-dev-db-subnet-group`
+- RDS security group: `sg-0f9c964ba30648df9`
+- `--no-publicly-accessible`
+
+Initial restore response confirmed:
+
+```text
+DBInstanceStatus:   creating
+PubliclyAccessible: false
+StorageEncrypted:   true
+MultiAZ:            false
+EngineVersion:      15.17
+```
+
+## Restore Completion
+
+Waiter timing:
+
+```text
+WAIT_START_UTC=2026-04-14T06:30:20Z
+WAIT_END_UTC=2026-04-14T06:38:25Z
+```
+
+Approximate restore wait duration: 8 minutes 5 seconds.
+
+## Restored DB Posture
+
+Captured after the restored DB reached `available`:
+
+```text
+DBInstanceIdentifier: leaseflow-dev-postgres-restore-20260414-0630
+Status:               available
+PubliclyAccessible:   False
+StorageEncrypted:     True
+DBSubnetGroup:        leaseflow-dev-db-subnet-group
+VpcSecurityGroupId:   sg-0f9c964ba30648df9
+Engine:               postgres
+EngineVersion:        15.17
+InstanceClass:        db.t3.micro
+Endpoint:             leaseflow-dev-postgres-restore-20260414-0630.cbmk8q0s6lce.eu-north-1.rds.amazonaws.com
+```
+
+Validation outcome:
+
+- Restored DB reached `available`.
+- Restored DB stayed private.
+- Restored DB stayed encrypted.
+- Restored DB used the expected DB subnet group.
+- Restored DB used the expected RDS security group.
+
+## Cleanup Evidence
+
+Delete timing:
+
+```text
+DELETE_START_UTC=2026-04-14T06:43:06Z
+DELETE_END_UTC=2026-04-14T06:44:40Z
+```
+
+Delete response:
+
+```text
+leaseflow-dev-postgres-restore-20260414-0630 deleting False True
+```
+
+Final cleanup verification:
+
+```text
+DBInstanceNotFound: DBInstance leaseflow-dev-postgres-restore-20260414-0630 not found.
+```
+
+Cleanup outcome:
+
+- Temporary restore DB was deleted.
+- No final snapshot was kept for the temporary restore DB.
+- Automated backups for the temporary restore DB were deleted.
+
+## Out of Scope
+
+Data-level SQL validation was not performed in this run.
+
+Reason:
+
+- The restored DB is private.
+- The runbook intentionally avoids connecting from a public laptop.
+- Private data-level validation is tracked separately in issue `#54`.
+
+## Follow-Up
+
+- Define a private data-level validation path for restored dev RDS.
+- Document restore validation cadence and backup retention review.
+
+## SAA-C03 Takeaway
+
+This validates more than backup configuration. It demonstrates that automated RDS backups can be restored into a private encrypted DB instance and cleaned up after validation.


### PR DESCRIPTION
## What Changed

Captured evidence from executing the dev RDS restore validation runbook against the AWS dev environment.

This PR documents that the Terraform-managed dev PostgreSQL RDS instance can be restored from automated backups into a temporary private and encrypted RDS instance.

## Why

The restore runbook existed, but restore readiness had not yet been demonstrated in AWS. This evidence closes that gap by showing that backup restore works end to end at the infrastructure level.

## Scope

- Recreated the dev stack with Terraform because it had previously been destroyed to avoid ongoing AWS cost.
- Captured source DB backup posture.
- Restored a temporary RDS instance from the latest restorable point.
- Verified the restored DB reached `available`.
- Verified the restored DB remained private and encrypted.
- Verified the restored DB used the expected DB subnet group and RDS security group.
- Deleted the temporary restore DB after validation.
- Added restore evidence under `docs/runbooks/evidence/`.

## Security Validation

- Restored DB was created with `--no-publicly-accessible`.
- Restored DB remained `PubliclyAccessible=False`.
- Restored DB remained `StorageEncrypted=True`.
- Restored DB used the same private DB subnet group as the source DB.
- Restored DB used the same RDS security group as the source DB.
- No tenant data, passwords, or connection secrets were captured in the evidence note.
- No public laptop SQL access was used.

## Cost Validation

- The temporary restore DB was deleted after validation.
- Cleanup was confirmed with `DBInstanceNotFound`.
- No final snapshot was kept for the temporary restore DB.
- Automated backups for the temporary restore DB were deleted.
- The dev stack remains running after this validation and should be destroyed when no longer needed to avoid ongoing cost.

## Validation Evidence

- Terraform apply recreated dev stack:
  - `44 added, 0 changed, 0 destroyed`
- Source DB:
  - `leaseflow-dev-postgres`
  - status `available`
  - backup retention `1`
  - private
  - encrypted
- Restore DB:
  - `leaseflow-dev-postgres-restore-20260414-0630`
  - reached `available`
  - private
  - encrypted
- Restore wait duration:
  - approximately 8 minutes 5 seconds
- Cleanup:
  - temporary restore DB deleted
  - final verification returned `DBInstanceNotFound`
- Terraform drift check:
  - `terraform plan -detailed-exitcode`
  - result: `No changes`
- Git whitespace check:
  - `git diff --check`

## Out of Scope

- Data-level SQL validation was not performed.
- The restored DB was not accessed from a public machine.
- No permanent restore infrastructure was added.
- No AWS Backup plan, cross-region replication, Multi-AZ change, or DR automation was introduced.

## Follow-Up

- #54: Define private data-level validation path for restored dev RDS.
- #55: Document RDS restore validation cadence and retention review.

## AWS SAA-C03 Note

Automated backups and restore readiness are different concepts. This PR demonstrates restore readiness by validating that an RDS automated backup can be restored into a private encrypted DB instance and safely cleaned up afterward.