### PR TITLE
docs: define RDS restore validation cadence

### DIFF
--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -59,6 +59,8 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
 ## Operational Runbooks
 
 - Dev RDS restore validation is documented in `docs/runbooks/dev-rds-restore-validation.md`.
+- The restore validation runbook defines the quarterly MVP cadence, event-driven
+  rerun triggers, evidence retention, and backup retention review triggers.
 
 ## Diagram Source
 

--- a/docs/runbooks/dev-rds-restore-validation.md
+++ b/docs/runbooks/dev-rds-restore-validation.md
@@ -33,6 +33,33 @@ This is an operator-run dev procedure, not an automated disaster recovery platfo
 - The source DB status is `available`.
 - The source DB has a non-empty `LatestRestorableTime`.
 
+## Cadence and Retention Review
+
+Restore validation cadence:
+
+- Run this validation quarterly during MVP development.
+- Rerun it after meaningful DB schema, RDS module, backup retention, or migration
+  workflow changes.
+- Rerun it before important portfolio or demo milestones when the dev database
+  state matters.
+
+Backup retention review triggers:
+
+- Revisit `backup_retention_period` when dev data becomes difficult to recreate.
+- Revisit it when demo data becomes important enough to justify a wider restore
+  window.
+- Revisit it before introducing a pre-prod or prod-like environment.
+- Revisit it when recovery expectations exceed the current one-day dev restore
+  window.
+
+Current decision:
+
+- Keep dev `backup_retention_period = 1` for cost control.
+- Do not add Multi-AZ, cross-region replication, AWS Backup, or production DR
+  automation in this dev runbook.
+- Increase retention only when the recoverability benefit is explicitly accepted
+  against the added storage cost.
+
 ## Step 1: Capture Source Backup Readiness
 
 What it does: reads source RDS backup, networking, and encryption posture before restore.
@@ -187,7 +214,7 @@ Expected evidence:
 
 ## Evidence to Capture
 
-- Date and operator.
+- Date, operator, and cadence trigger.
 - Source DB identifier.
 - `LatestRestorableTime`.
 - Temporary restore DB identifier.
@@ -196,17 +223,26 @@ Expected evidence:
 - Cleanup confirmation.
 - Any errors and follow-up actions.
 
+Keep one evidence note per successful validation run under
+`docs/runbooks/evidence/`.
+
+Do not capture tenant data values, secrets, JWTs, passwords, SSM parameter
+values, or full connection strings.
+
 ## Cost Notes
 
 - The restore creates a temporary RDS instance and storage.
 - Delete it immediately after validation.
 - Do not leave restore validation instances running overnight.
 - Do not add Multi-AZ, cross-region replication, or AWS Backup plans in this dev runbook.
+- A longer backup retention window can improve recoverability but may increase
+  storage cost. Keep the dev default minimal unless the tradeoff is explicit.
 
 ## SAA-C03 Notes
 
 - Automated backups and point-in-time restore are different from manual snapshots.
 - A backup retention period of `0` disables automated backups.
+- Backup retention defines the restore window.
 - A private restored DB still needs correct subnet group and security group settings.
 - Restore validation proves recoverability better than just enabling backups.
 

--- a/docs/security-baseline.md
+++ b/docs/security-baseline.md
@@ -195,6 +195,7 @@ Examples of auditable events:
 - Avoid copying production data into unsecured local or test environments.
 - Validate dev RDS restore readiness with `docs/runbooks/dev-rds-restore-validation.md` without making restored databases public.
 - Run restored RDS data-level checks only through a private execution path and capture aggregate evidence only.
+- Repeat dev RDS restore validation quarterly and after meaningful DB, RDS, backup, or migration workflow changes.
 
 ## Incident Handling (MVP)
 
@@ -212,7 +213,7 @@ The MVP does not require a full incident management platform, but it does requir
 
 - PostgreSQL Row Level Security for defense-in-depth tenant enforcement
 - Cognito MFA rollout for higher-risk roles
-- Periodic RDS restore validation cadence
+- Backup retention review when recovery expectations outgrow the one-day dev window
 - Lightweight alerting for suspicious login or API abuse patterns
 - Periodic dependency and IAM permission review
 


### PR DESCRIPTION
## What changed

- Documented the dev RDS restore validation cadence.
- Added backup retention review triggers for the current one-day dev restore window.
- Added evidence retention guidance for repeated restore validation runs.
- Updated architecture and security docs to reference the cadence and retention review policy.

## Why

The project had a successful restore validation run, but no documented operational loop for repeating it. This keeps the MVP realistic and cost-aware while making the recoverability story explicit.

## Assumptions

- This PR is documentation-only.
- Dev RDS keeps `backup_retention_period = 1` for cost control.
- Restore validation should run quarterly during MVP development and after meaningful DB, RDS, backup, or migration workflow changes.
- Production DR automation, AWS Backup, Multi-AZ, and cross-region replication remain out of scope.

## Security validation

- No public RDS access is introduced.
- The restore runbook continues to require private, encrypted restored DB instances.
- Evidence guidance explicitly forbids tenant data values, secrets, JWTs, passwords, SSM parameter values, and full connection strings.
- Tenant isolation is protected by limiting evidence to posture metadata and aggregate validation outputs, not tenant-level records.

## Cost validation

- No new AWS services or Terraform resources were added.
- The current dev retention remains one day.
- Longer retention is documented as a deliberate cost/recoverability tradeoff, not a default change.

## Validation

- `git diff --check`

## Remaining risks / TODOs

- This PR documents the cadence, but does not automate reminders or scheduling.
- Backup retention should be revisited when data becomes harder to recreate, demo data becomes important, or a pre-prod/prod-like environment is introduced.
