### PR TITLE
docs: sync MVP backend and infra documentation

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -6,12 +6,21 @@ Python Lambda backend for LeaseFlow MVP.
 
 - Lambda entry point with lightweight routing.
 - `GET /health`
-- `POST /properties`
 - `GET /properties`
+- `POST /properties`
+- `PATCH /properties/{property_id}`
+- `GET /leases`
+- `POST /leases`
+- `PATCH /leases/{lease_id}`
+- `GET /lease-reminders/due-soon`
+- `GET /notifications`
+- `PATCH /notifications/{notification_id}/read`
 - JWT claim extraction from Cognito ID tokens (`sub`, `custom:tenant_id`)
-- Tenant-scoped data access
-- Audit logging on property creation
-- Alembic migration setup
+- Tenant-scoped property, lease, reminder, and notification access.
+- Audit logging for property and lease write flows.
+- Alembic migration setup and internal migration event support.
+- Internal due-lease-reminder scan event support.
+- Local invoke helper for selected handler paths.
 
 ## Local setup
 
@@ -59,6 +68,8 @@ make test-local
 make test-integration-local
 make invoke-local-health
 make invoke-local-list-properties
+make invoke-local-list-due-lease-reminders
+make invoke-local-scan-due-lease-reminders
 make invoke-local-create-property
 ```
 
@@ -74,6 +85,8 @@ This local database is for development data only. Do not copy production or tena
 The local DB integration tests prove that `Database.create_property()` both writes the `properties` row plus the matching `audit_logs` row on the happy path and rolls the whole transaction back if audit logging fails. They are intentionally opt-in and run separately from the normal fast unit-test flow.
 
 The local invoke helper calls the existing Lambda handler directly with API Gateway v2-style events. That keeps local testing close to the deployed Lambda shape without introducing a separate local web framework.
+
+The helper currently covers health, property listing and creation, due lease reminder listing, notification read acknowledgement, and the internal reminder scan event. It does not cover every public route.
 
 You can override the sample create command values from the repo root in WSL:
 

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -30,8 +30,10 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
 ## Data and Persistence
 
 - PostgreSQL is chosen over DynamoDB to keep relational queries and schema evolution straightforward for this MVP.
-- Initial schema includes `properties` and `audit_logs`.
-- Audit records are written for critical state changes (property creation).
+- Current schema includes `properties`, `leases`, `notifications`, and `audit_logs`.
+- `properties`, `leases`, and `notifications` are tenant-owned domain tables.
+- `notifications` persists due-soon reminder records and uses nullable `read_at` for read acknowledgement.
+- Audit records are written for critical property and lease state changes.
 - Reminder notifications are persisted in PostgreSQL before any future external delivery step.
 
 ## Security Baseline Alignment

--- a/docs/mvp-scope.md
+++ b/docs/mvp-scope.md
@@ -5,11 +5,13 @@
 - Multi-tenant backend with strict application-layer tenant isolation.
 - API endpoints for:
   - `GET /health`
-  - `POST /properties`
   - `GET /properties`
-  - `POST /leases`
+  - `POST /properties`
+  - `PATCH /properties/{property_id}`
   - `GET /leases`
+  - `POST /leases`
   - `PATCH /leases/{lease_id}`
+  - `GET /lease-reminders/due-soon`
   - `GET /notifications`
   - `PATCH /notifications/{notification_id}/read`
 - Cognito JWT-based authentication and tenant claim extraction.
@@ -19,7 +21,7 @@
 - Infrastructure provisioning with Terraform modules.
 - Dev-focused deployment architecture on AWS Lambda + API Gateway.
 
-## Data Scope (Initial)
+## Data Scope (Current MVP)
 
 - `properties` table for tenant-owned rental units.
 - `leases` table for tenant-owned rental agreements linked to properties.


### PR DESCRIPTION
## What changed and why

Updated stale MVP/backend/architecture documentation so it matches the currently implemented backend and Terraform-managed dev infrastructure.

Changes include:
- listed all implemented public API routes in `docs/mvp-scope.md`
- updated `backend/README.md` with current property, lease, reminder, notification, update, audit, migration, and internal reminder capabilities
- clarified that the local invoke helper supports only selected handler paths
- updated `docs/architecture-v0.2.md` to describe the current tables: `properties`, `leases`, `notifications`, and `audit_logs`
- documented persisted reminder notifications and nullable `read_at`

## Assumptions

This PR is documentation-only. It does not change backend code, Terraform resources, AWS services, or the architecture diagram.

## Security validation

Tenant isolation wording was preserved: `tenant_id` comes from Cognito JWT claims, not client input. The docs still state that RDS remains private and tenant-owned rows require `tenant_id`.

## Cost validation

No AWS resources or services were added. No runtime cost impact.

## Remaining risks or TODOs

The architecture diagram still may need a separate update if we want the visual model to show every current table and route. That was intentionally left out of this ticket scope.

## Validation

- `git diff --check`
