### PR TITLE
ci: add terraform validation and module tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: make test
 
   terraform:
-    name: Terraform formatting
+    name: Terraform checks
     runs-on: ubuntu-latest
 
     steps:
@@ -47,3 +47,41 @@ jobs:
 
       - name: Check Terraform formatting
         run: terraform fmt -check -recursive infra
+
+      - name: Initialize dev environment
+        working-directory: infra/environments/dev
+        run: terraform init -backend=false
+
+      - name: Validate dev environment
+        working-directory: infra/environments/dev
+        run: terraform validate
+
+  terraform-module-tests:
+    name: Terraform module tests (${{ matrix.module }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - infra/modules/api_http
+          - infra/modules/cloudwatch_alarms
+          - infra/modules/cognito
+          - infra/modules/lambda_backend
+          - infra/modules/network
+          - infra/modules/reminder_scheduler
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v4
+
+      - name: Initialize module
+        working-directory: ${{ matrix.module }}
+        run: terraform init -backend=false
+
+      - name: Test module
+        working-directory: ${{ matrix.module }}
+        run: terraform test

--- a/infra/README.md
+++ b/infra/README.md
@@ -121,6 +121,17 @@ terraform plan
 - Remote state is intentionally deferred to a later hardening step.
 - WSL is used here because the Lambda zip needs Linux-compatible dependencies.
 - Use a non-root AWS profile for Terraform work. Do not use the AWS account root profile for preflight or deployment tasks.
+
+## CI Terraform checks
+
+CI runs Terraform checks without AWS credentials.
+
+- `terraform fmt -check -recursive infra` checks formatting.
+- `infra/environments/dev` runs `terraform init -backend=false` and `terraform validate`.
+- Modules with `.tftest.hcl` coverage run `terraform init -backend=false` and `terraform test`.
+- Module tests use mocked providers and do not create AWS resources.
+- `modules/rds_postgres` is excluded until it has `.tftest.hcl` coverage.
+
 ## Dev cost expectation
 
 - Check AWS Billing before the first `terraform apply`.


### PR DESCRIPTION
## What changed and why

Extended CI beyond Terraform formatting so infrastructure drift is caught before deployment.

Changes include:
- added credential-free `terraform init -backend=false` and `terraform validate` for `infra/environments/dev`
- added a Terraform module test matrix for existing `.tftest.hcl` module coverage
- documented the CI Terraform validation model in `infra/README.md`

## Assumptions

The dev environment `.tftest.hcl` is intentionally out of scope for this PR. CI runs module tests plus dev validation only.

Terraform version remains managed by `hashicorp/setup-terraform@v4`; no explicit version pin was added.

## Security validation

No backend tenant-isolation logic changed. No `tenant_id` handling changed.

CI remains credential-free and does not run `terraform plan`, `terraform apply`, or any AWS-mutating command. Module tests use mocked providers.

## Cost validation

No new AWS services or resources were added. CI validation does not create AWS resources.

## Remaining risks or TODOs

`modules/rds_postgres` is not included in module tests yet because it currently has no `.tftest.hcl` coverage.

## Validation

- `git diff --check`
- `terraform fmt -check -recursive infra`
- `terraform init -backend=false`
- `terraform validate`
- `terraform test` for all six covered Terraform modules
