### PR TITLE
build: add reproducible lambda artifact command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PYTHON ?= python
+LAMBDA_PYTHON ?= python3.12
 BACKEND_DIR := backend
 TF_DIR := infra
 LOCAL_ENV_FILE := .env.local
@@ -7,7 +8,7 @@ LOCAL_USER_ID ?= user-local
 PROPERTY_NAME ?= HQ
 PROPERTY_ADDRESS ?= Main Street 1
 
-.PHONY: format lint test migrate check-local-env migrate-local db-check-local test-local test-integration-local invoke-local-health invoke-local-list-properties invoke-local-list-due-lease-reminders invoke-local-scan-due-lease-reminders invoke-local-create-property tf-fmt
+.PHONY: format lint test migrate build-lambda-artifact check-local-env migrate-local db-check-local test-local test-integration-local invoke-local-health invoke-local-list-properties invoke-local-list-due-lease-reminders invoke-local-scan-due-lease-reminders invoke-local-create-property tf-fmt
 
 format:
 	cd $(BACKEND_DIR) && $(PYTHON) -m ruff format src tests migrations
@@ -20,6 +21,9 @@ test:
 
 migrate:
 	cd $(BACKEND_DIR) && $(PYTHON) -m alembic upgrade head
+
+build-lambda-artifact:
+	PYTHON_BIN="$(LAMBDA_PYTHON)" bash scripts/build_lambda_artifact.sh
 
 check-local-env:
 	cd $(BACKEND_DIR) && test -f $(LOCAL_ENV_FILE) || (echo "Missing $(BACKEND_DIR)/$(LOCAL_ENV_FILE). Copy $(BACKEND_DIR)/.env.local.example first." && exit 1)

--- a/infra/README.md
+++ b/infra/README.md
@@ -39,16 +39,15 @@ The goal is to:
 
 This preflight intentionally keeps:
 
-- local artifact packaging
+- local reproducible artifact packaging
 - local Terraform state
-- no automation script or Make target
 - no `terraform apply`
 
 ### Prerequisites
 
 - WSL is available on the Windows machine.
 - Python `3.12` is available in WSL to match the Lambda runtime.
-- `python3.12-full`, `python3.12-venv`, and `rsync` are installed in WSL.
+- `python3.12-full`, `python3.12-venv`, `make`, `rsync`, and `zip` are installed in WSL.
 - Terraform is installed in WSL.
 - AWS credentials already work in WSL via environment variables or a configured profile.
 
@@ -58,7 +57,7 @@ If the repository lives under `/mnt/c/...`, create a working copy inside the Lin
 
 ```bash
 sudo apt update
-sudo apt install -y python3.12-full python3.12-venv rsync
+sudo apt install -y python3.12-full python3.12-venv make rsync zip
 mkdir -p ~/leaseflow-preflight
 rsync -a --delete /mnt/c/Repos/LeaseFlow/ ~/leaseflow-preflight/ \
   --exclude '.git/' \
@@ -74,15 +73,7 @@ Run these commands from the Linux-side working copy:
 
 ```bash
 cd ~/leaseflow-preflight
-rm -rf dist/lambda-build dist/leaseflow-backend.zip .venv
-python3.12 -m venv .venv
-source .venv/bin/activate
-python -m pip install --upgrade pip
-python -m pip install ./backend -t dist/lambda-build
-cp backend/alembic.ini dist/lambda-build/alembic.ini
-rsync -a backend/migrations/ dist/lambda-build/migrations/
-find dist/lambda-build -type d -name "__pycache__" -prune -exec rm -rf {} +
-(cd dist/lambda-build && zip -r ../leaseflow-backend.zip .)
+make build-lambda-artifact
 ```
 
 Terraform expects the Lambda artifact at `dist/leaseflow-backend.zip`, which matches the current dev variable default.
@@ -200,6 +191,10 @@ terraform apply tfplan
 When the dev stack is already deployed but the private RDS schema is missing, use the backend Lambda's internal migration event.
 
 Build and deploy a fresh Lambda artifact first so the zip contains both `alembic.ini` and `migrations/`.
+
+```bash
+make build-lambda-artifact
+```
 
 Then invoke the migration path directly:
 

--- a/infra/modules/lambda_backend/main.tf
+++ b/infra/modules/lambda_backend/main.tf
@@ -88,7 +88,7 @@ resource "aws_lambda_function" "this" {
   timeout       = var.timeout
   memory_size   = var.memory_size
 
-  # TODO: replace local file packaging with CI build artifact publishing.
+  # Build this zip with `make build-lambda-artifact` before planning or applying.
   filename         = var.package_file
   source_code_hash = filebase64sha256(var.package_file)
 

--- a/scripts/build_lambda_artifact.sh
+++ b/scripts/build_lambda_artifact.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "Build must run in WSL/Linux so Lambda dependencies are Linux-compatible." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/dist/lambda-build"
+VENV_DIR="${REPO_ROOT}/dist/lambda-venv"
+ARTIFACT="${REPO_ROOT}/dist/leaseflow-backend.zip"
+PYTHON_BIN="${PYTHON_BIN:-python3.12}"
+NORMALIZED_TIMESTAMP="${NORMALIZED_TIMESTAMP:-202601010000.00}"
+
+for command_name in "${PYTHON_BIN}" rsync zip; do
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    echo "Missing required command: ${command_name}" >&2
+    exit 1
+  fi
+done
+
+cd "${REPO_ROOT}"
+
+rm -rf "${BUILD_DIR}" "${VENV_DIR}" "${ARTIFACT}"
+mkdir -p "${BUILD_DIR}"
+
+"${PYTHON_BIN}" -m venv "${VENV_DIR}"
+# shellcheck source=/dev/null
+source "${VENV_DIR}/bin/activate"
+python -m pip install --upgrade pip
+python -m pip install --no-cache-dir ./backend -t "${BUILD_DIR}"
+deactivate
+
+cp backend/alembic.ini "${BUILD_DIR}/alembic.ini"
+rsync -a --delete backend/migrations/ "${BUILD_DIR}/migrations/"
+
+find "${BUILD_DIR}" -type d \
+  \( -name "__pycache__" -o -name ".pytest_cache" -o -name ".ruff_cache" -o -name "tests" \) \
+  -prune -exec rm -rf {} +
+find "${BUILD_DIR}" -type f \
+  \( -name "*.pyc" -o -name "*.pyo" -o -name ".DS_Store" -o -name "direct_url.json" \) \
+  -delete
+
+# Normalize mtimes and zip entry ordering to keep review diffs stable enough for dev deploys.
+find "${BUILD_DIR}" -exec touch -h -t "${NORMALIZED_TIMESTAMP}" {} +
+(
+  cd "${BUILD_DIR}"
+  find . -type f -print | LC_ALL=C sort | zip -X -q "${ARTIFACT}" -@
+)
+
+rm -rf "${VENV_DIR}"
+
+echo "Built ${ARTIFACT}"


### PR DESCRIPTION
## What changed and why

Added a reproducible WSL/Linux command for building the backend Lambda deployment artifact.

Changes include:
- added `scripts/build_lambda_artifact.sh`
- added `make build-lambda-artifact`
- updated the infra preflight docs to use the new command
- updated the Lambda module comment to reference the reproducible build command
- kept Terraform consuming `lambda_package_file` unchanged

## Assumptions

This is a local/WSL/Linux build path, not a CI artifact publishing flow.

The artifact is reproducible enough for review and dev deployment, but this is not a cryptographic supply-chain build.

## Security validation

The artifact content was checked to avoid local secrets and development-only files.

Verified absent from the zip:
- `.env`
- `.venv`
- `__pycache__`
- `.pytest_cache`
- `.terraform`
- `terraform.tfstate`
- `tests/`
- `direct_url.json`

No tenant isolation logic changed.

## Cost validation

No AWS resources or services were added. No runtime cost impact.

## Remaining risks or TODOs

The build currently runs best from a Linux-side WSL working copy. Building from `/mnt/c` works, but is slow because dependency installation writes many files through the Windows mount.

A future ticket could add CI artifact publishing if we want the deployment zip produced by GitHub Actions.

## Validation

- `make build-lambda-artifact`
- artifact content inspection with `System.IO.Compression.ZipFile`
- `terraform validate` in `infra/environments/dev`
- `terraform fmt -check -recursive infra`
- `git diff --check`
