### PR TITLE
docs: record Context7 API usage review

### DIFF
--- a/docs/runbooks/evidence/context7-api-usage-review-2026-04-15.md
+++ b/docs/runbooks/evidence/context7-api-usage-review-2026-04-15.md
@@ -1,0 +1,115 @@
+# Context7-Backed API Usage Review Evidence
+
+Date: 2026-04-15
+
+Related issue: `#69 Run Context7-backed API usage review`
+
+## Purpose
+
+Review selected Terraform AWS provider and backend runtime library usage against
+documentation-backed sources instead of relying on model memory.
+
+This review did not use live AWS calls and did not send secrets, JWTs,
+passwords, tenant data, or customer data to MCP tools.
+
+## Sources Consulted
+
+Context7:
+
+- `/hashicorp/terraform-provider-aws`
+- `/psycopg/psycopg`
+- `/boto/boto3`
+
+Official AWS and provider documentation:
+
+- Terraform AWS provider `aws_lambda_permission`
+- Terraform AWS provider `aws_scheduler_schedule`
+- Terraform AWS provider `aws_cloudwatch_metric_alarm`
+- AWS API Gateway HTTP API CloudWatch metrics
+- AWS EventBridge Scheduler CloudWatch metrics
+- AWS EventBridge Scheduler confused deputy prevention
+- AWS Lambda CloudWatch metrics
+- AWS Systems Manager `get_parameter`
+
+## Terraform Review
+
+Reviewed files:
+
+- `infra/modules/api_http/main.tf`
+- `infra/modules/cloudwatch_alarms/main.tf`
+- `infra/modules/reminder_scheduler/main.tf`
+- `infra/modules/network/main.tf`
+- `infra/modules/lambda_backend/main.tf`
+
+Findings:
+
+- API Gateway HTTP API JWT authorizer uses `authorizer_type = "JWT"`,
+  `identity_sources = ["$request.header.Authorization"]`, Cognito app client
+  audience, and Cognito user pool issuer format expected for HTTP APIs.
+- Lambda permission uses `principal = "apigateway.amazonaws.com"` and scopes
+  invocation to the HTTP API execution ARN. The wildcard stage/method scope is
+  broad but appropriate for the MVP API module.
+- CloudWatch alarms use supported static-threshold arguments,
+  `alarm_actions`, `datapoints_to_alarm`, and `treat_missing_data`.
+- HTTP API 5xx alarm uses the `AWS/ApiGateway` namespace, `5xx` metric, and
+  `ApiId` plus `Stage` dimensions documented for HTTP APIs.
+- Lambda alarms use the `AWS/Lambda` namespace and `FunctionName` dimension.
+- Scheduler alarm uses the `AWS/Scheduler` namespace, `TargetErrorCount`
+  metric, and `ScheduleGroup` dimension.
+- Scheduler target configuration uses required `arn`, `role_arn`, and JSON
+  `input` values.
+- Scheduler execution role trust policy includes `scheduler.amazonaws.com`,
+  `aws:SourceAccount`, and schedule-group scoped `aws:SourceArn`, matching the
+  confused-deputy prevention pattern.
+- SSM and KMS VPC endpoints use `vpc_endpoint_type = "Interface"`,
+  `private_dns_enabled = true`, private subnet IDs, and endpoint security group
+  IDs.
+
+Result: no Terraform changes required.
+
+## Backend Library Review
+
+Reviewed files:
+
+- `backend/src/app/config.py`
+- `backend/src/app/db.py`
+- `backend/tests/test_config.py`
+
+Findings:
+
+- `boto3.client("ssm", region_name=...)` is used with the configured AWS
+  region.
+- SSM `get_parameter` is called with `Name` and `WithDecryption=True`, matching
+  the SecureString password retrieval path.
+- Existing unit tests cover direct password fallback, SSM client region,
+  `WithDecryption=True`, and missing password-source behavior.
+- `psycopg.connect(..., row_factory=dict_row)` matches documented row factory
+  usage.
+- `with psycopg.connect(...) as conn:` matches documented connection context
+  manager behavior: close on exit, commit when no exception, rollback on
+  exception.
+- Write paths wrap multi-statement operations in `with conn.transaction():`.
+- Dynamic SQL for update assignments uses `psycopg.sql.SQL` and `Identifier`
+  for identifiers, while values remain parameterized with `%s`.
+- Static SQL that appends tenant filters uses parameterized values and does not
+  interpolate user-controlled data into SQL text.
+
+Result: no backend code changes required.
+
+## Security Notes
+
+- No tenant isolation behavior was changed.
+- No AWS resources were created, updated, or destroyed.
+- No secrets or tenant data were sent to Context7 or captured in this evidence.
+- Repository code and project docs remain the higher-priority source of truth;
+  Context7 was used only to verify external API and library usage.
+
+## Follow-Up
+
+No immediate follow-up is required from this review.
+
+Potential future hardening, not required for #69:
+
+- Consider wrapping SSM `ClientError` exceptions in a project-level
+  configuration error if deployed troubleshooting needs cleaner operator-facing
+  messages.


### PR DESCRIPTION
## What changed and why

Adds an evidence note for #69 documenting a focused Context7-backed review of selected Terraform AWS provider usage and backend runtime library usage.

The goal was to verify implementation details against documentation-backed sources instead of relying on model memory.

## Assumptions

- This PR is documentation/evidence-only.
- No live AWS calls were needed.
- Repository code and docs remain the highest-priority source of truth.
- Context7 was used only for external API/library verification.

## Security validation

- No secrets, JWTs, passwords, tenant data, or customer data were sent to MCP tools or captured in evidence.
- Tenant isolation behavior was not changed.
- The review confirmed current tenant-sensitive backend SQL still uses parameterized values and tenant-scoped filters.

## Cost validation

- No AWS resources were created, updated, or destroyed.
- No new AWS services were added.
- No runtime cost impact.

## Results

- Terraform API Gateway, CloudWatch alarms, EventBridge Scheduler, VPC endpoints, and Lambda/SSM-related usage were reviewed.
- Backend `psycopg` connection/transaction/dynamic SQL usage was reviewed.
- Backend `boto3` SSM password resolution usage was reviewed.
- No code or Terraform changes were required.

## Remaining risks / TODOs

- Optional future hardening: wrap SSM `ClientError` exceptions into a project-level configuration error if deployed troubleshooting needs cleaner operator-facing messages.
