### PR TITLE
feat: add local portfolio demo client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LOCAL_USER_ID ?= user-local
 PROPERTY_NAME ?= HQ
 PROPERTY_ADDRESS ?= Main Street 1
 
-.PHONY: format lint test migrate build-lambda-artifact check-local-env migrate-local db-check-local test-local test-integration-local invoke-local-health invoke-local-list-properties invoke-local-list-due-lease-reminders invoke-local-scan-due-lease-reminders invoke-local-create-property tf-fmt
+.PHONY: format lint test migrate build-lambda-artifact demo-client check-local-env migrate-local db-check-local test-local test-integration-local invoke-local-health invoke-local-list-properties invoke-local-list-due-lease-reminders invoke-local-scan-due-lease-reminders invoke-local-create-property tf-fmt
 
 format:
 	cd $(BACKEND_DIR) && $(PYTHON) -m ruff format src tests migrations
@@ -24,6 +24,9 @@ migrate:
 
 build-lambda-artifact:
 	PYTHON_BIN="$(LAMBDA_PYTHON)" bash scripts/build_lambda_artifact.sh
+
+demo-client:
+	$(PYTHON) scripts/demo_client_server.py
 
 check-local-env:
 	cd $(BACKEND_DIR) && test -f $(LOCAL_ENV_FILE) || (echo "Missing $(BACKEND_DIR)/$(LOCAL_ENV_FILE). Copy $(BACKEND_DIR)/.env.local.example first." && exit 1)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ LeaseFlow is a cloud-native, multi-tenant rental management system MVP built as 
 Use `docs/portfolio-demo-flow.md` for a short deployed MVP walkthrough suitable
 for portfolio reviews or interviews.
 
+For a local browser-based demo helper, run:
+
+```bash
+make demo-client
+```
+
+Then open `http://127.0.0.1:8765`. The demo client is local portfolio tooling,
+not a hosted production frontend.
+
 ## Current MVP Status
 
 Implemented now:
@@ -51,6 +60,7 @@ Implemented now:
 - Audit logging for property and lease creation
 - Alembic migrations for property, lease, and notification tables
 - Terraform modules for network, RDS, Cognito, Lambda, and API Gateway
+- Local portfolio demo client for the deployed MVP flow
 
 Planned next:
 

--- a/demo-client/README.md
+++ b/demo-client/README.md
@@ -1,0 +1,42 @@
+# LeaseFlow Demo Client
+
+This is a local portfolio/demo client for the deployed LeaseFlow dev API.
+
+It is not a production frontend.
+
+## Run
+
+```bash
+make demo-client
+```
+
+Then open:
+
+```text
+http://127.0.0.1:8765
+```
+
+## Inputs
+
+The UI asks for:
+
+- deployed API base URL
+- temporary Cognito ID token
+- AWS region, default `eu-north-1`
+- backend Lambda function name, default `leaseflow-dev-backend`
+
+The ID token is kept in browser memory and sent only to the local demo server.
+Do not paste production tokens.
+
+## Safety
+
+- Use synthetic demo data only.
+- Do not screenshot JWTs, passwords, emails, tenant IDs, SSM values, or real tenant data.
+- Keep RDS private.
+- Destroy the dev stack after demo use when it is not needed.
+
+## Why There Is A Local Server
+
+The deployed HTTP API is not configured as a browser product API with CORS.
+The local server lets the browser talk to `localhost` while the server proxies
+only the allowlisted demo API calls to the deployed API Gateway.

--- a/demo-client/app.js
+++ b/demo-client/app.js
@@ -1,0 +1,226 @@
+const state = {
+  propertyId: "",
+  leaseId: "",
+  notificationId: "",
+};
+
+const cards = document.querySelector("#statusCards");
+
+function value(id) {
+  return document.querySelector(`#${id}`).value.trim();
+}
+
+function setDefaults() {
+  const now = new Date();
+  const today = now.toISOString().slice(0, 10);
+  const end = new Date(now);
+  end.setUTCDate(end.getUTCDate() + 30);
+
+  document.querySelector("#rentDueDay").value = String(now.getUTCDate());
+  document.querySelector("#startDate").value = today;
+  document.querySelector("#endDate").value = end.toISOString().slice(0, 10);
+}
+
+function addCard(title, message, ok = true) {
+  const card = document.createElement("article");
+  card.className = `card ${ok ? "ok" : "error"}`;
+  card.innerHTML = `<h3>${escapeHtml(title)}</h3><p>${escapeHtml(message)}</p>`;
+  cards.prepend(card);
+}
+
+function escapeHtml(input) {
+  return String(input)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function decodeTenantClaim(token) {
+  const payload = token.split(".")[1];
+  if (!payload) {
+    throw new Error("Token is not a JWT.");
+  }
+  const normalized = payload.replaceAll("-", "+").replaceAll("_", "/");
+  const decoded = JSON.parse(atob(normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=")));
+  if (!decoded["custom:tenant_id"]) {
+    throw new Error("Token does not include custom:tenant_id.");
+  }
+  return decoded["custom:tenant_id"];
+}
+
+async function postLocal(path, payload) {
+  const response = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data.error || "Local demo server request failed.");
+  }
+  return data;
+}
+
+async function apiRequest(method, path, body) {
+  return postLocal("/local/proxy", {
+    apiBaseUrl: value("apiBaseUrl"),
+    token: value("idToken"),
+    method,
+    path,
+    body,
+  });
+}
+
+async function runHealth() {
+  const result = await apiRequest("GET", "/health");
+  addCard("Health", `GET /health => ${result.statusCode}`, result.statusCode === 200);
+}
+
+async function createProperty() {
+  const body = {
+    tenant_id: "client-supplied-tenant-must-be-ignored",
+    name: value("propertyName"),
+    address: value("propertyAddress"),
+  };
+  const result = await apiRequest("POST", "/properties", body);
+  const expectedTenant = decodeTenantClaim(value("idToken"));
+  const tenantCheck = result.body.tenant_id === expectedTenant;
+  state.propertyId = result.body.property_id || "";
+  addCard(
+    "Create property",
+    `POST /properties => ${result.statusCode}; tenant override check: ${
+      tenantCheck ? "passed" : "failed"
+    }`,
+    result.statusCode === 201 && tenantCheck,
+  );
+}
+
+async function listProperties() {
+  const result = await apiRequest("GET", "/properties");
+  const items = result.body.items || [];
+  const containsCreated = items.some((item) => item.property_id === state.propertyId);
+  addCard(
+    "List properties",
+    `GET /properties => ${result.statusCode}; items: ${items.length}; created item present: ${
+      containsCreated ? "yes" : "not checked"
+    }`,
+    result.statusCode === 200,
+  );
+}
+
+async function createLease() {
+  if (!state.propertyId) {
+    throw new Error("Create a property before creating a lease.");
+  }
+  const body = {
+    property_id: state.propertyId,
+    resident_name: value("residentName"),
+    rent_due_day_of_month: Number(value("rentDueDay")),
+    start_date: value("startDate"),
+    end_date: value("endDate"),
+  };
+  const result = await apiRequest("POST", "/leases", body);
+  state.leaseId = result.body.lease_id || "";
+  addCard("Create lease", `POST /leases => ${result.statusCode}`, result.statusCode === 201);
+}
+
+async function listLeases() {
+  const result = await apiRequest("GET", "/leases");
+  const items = result.body.items || [];
+  const containsCreated = items.some((item) => item.lease_id === state.leaseId);
+  addCard(
+    "List leases",
+    `GET /leases => ${result.statusCode}; items: ${items.length}; created item present: ${
+      containsCreated ? "yes" : "not checked"
+    }`,
+    result.statusCode === 200,
+  );
+}
+
+async function dueSoon() {
+  const result = await apiRequest("GET", "/lease-reminders/due-soon?days=7");
+  const items = result.body.items || [];
+  const containsLease = items.some((item) => item.lease_id === state.leaseId);
+  addCard(
+    "Due soon",
+    `GET /lease-reminders/due-soon?days=7 => ${result.statusCode}; candidates: ${
+      items.length
+    }; created lease present: ${containsLease ? "yes" : "not checked"}`,
+    result.statusCode === 200,
+  );
+}
+
+async function scan() {
+  const result = await postLocal("/local/reminder-scan", {
+    token: value("idToken"),
+    region: value("awsRegion"),
+    functionName: value("backendFunction"),
+    days: 7,
+    asOfDate: value("startDate"),
+  });
+  const body = result.body || {};
+  addCard(
+    "Reminder scan",
+    `scan => ${result.statusCode}; candidates: ${body.candidate_count ?? "?"}; created: ${
+      body.created_count ?? "?"
+    }; duplicates: ${body.duplicate_count ?? "?"}`,
+    result.statusCode === 200,
+  );
+}
+
+async function notifications() {
+  const result = await apiRequest("GET", "/notifications");
+  const items = result.body.items || [];
+  const match = items.find((item) => item.lease_id === state.leaseId && item.type === "rent_due_soon");
+  state.notificationId = match?.notification_id || "";
+  addCard(
+    "Notifications",
+    `GET /notifications => ${result.statusCode}; items: ${items.length}; due reminder present: ${
+      state.notificationId ? "yes" : "no"
+    }`,
+    result.statusCode === 200 && Boolean(state.notificationId),
+  );
+}
+
+async function markRead() {
+  if (!state.notificationId) {
+    throw new Error("Load notifications before marking one read.");
+  }
+  const result = await apiRequest("PATCH", `/notifications/${state.notificationId}/read`);
+  addCard(
+    "Mark notification read",
+    `PATCH /notifications/{notification_id}/read => ${result.statusCode}; read_at set: ${
+      result.body.read_at ? "yes" : "no"
+    }`,
+    result.statusCode === 200 && Boolean(result.body.read_at),
+  );
+}
+
+const actions = {
+  health: runHealth,
+  createProperty,
+  listProperties,
+  createLease,
+  listLeases,
+  dueSoon,
+  scan,
+  notifications,
+  markRead,
+};
+
+document.querySelectorAll("[data-action]").forEach((button) => {
+  button.addEventListener("click", async () => {
+    button.disabled = true;
+    try {
+      await actions[button.dataset.action]();
+    } catch (error) {
+      addCard(button.textContent, error.message, false);
+    } finally {
+      button.disabled = false;
+    }
+  });
+});
+
+setDefaults();

--- a/demo-client/index.html
+++ b/demo-client/index.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>LeaseFlow Demo Client</title>
+    <link rel="stylesheet" href="/styles.css">
+  </head>
+  <body>
+    <main class="shell">
+      <section class="hero">
+        <p class="eyebrow">LeaseFlow MVP</p>
+        <h1>Portfolio demo client</h1>
+        <p>
+          Run the deployed AWS demo flow from localhost without exposing RDS, storing tokens,
+          or changing the backend API.
+        </p>
+      </section>
+
+      <section class="panel">
+        <h2>Connection</h2>
+        <div class="grid">
+          <label>
+            API base URL
+            <input id="apiBaseUrl" placeholder="https://api.example.invalid/dev">
+          </label>
+          <label>
+            ID token
+            <textarea id="idToken" rows="4" placeholder="Paste a temporary Cognito ID token"></textarea>
+          </label>
+          <label>
+            AWS region
+            <input id="awsRegion" value="eu-north-1">
+          </label>
+          <label>
+            Backend function
+            <input id="backendFunction" value="leaseflow-dev-backend">
+          </label>
+        </div>
+        <p class="note">
+          Token stays in browser memory and is sent only to this localhost demo server.
+          Do not paste production tokens.
+        </p>
+      </section>
+
+      <section class="panel">
+        <h2>Synthetic demo data</h2>
+        <div class="grid">
+          <label>
+            Property name
+            <input id="propertyName" value="Demo Property">
+          </label>
+          <label>
+            Property address
+            <input id="propertyAddress" value="Demo Address">
+          </label>
+          <label>
+            Resident name
+            <input id="residentName" value="Demo Resident">
+          </label>
+          <label>
+            Rent due day
+            <input id="rentDueDay" type="number" min="1" max="31">
+          </label>
+          <label>
+            Lease start
+            <input id="startDate" type="date">
+          </label>
+          <label>
+            Lease end
+            <input id="endDate" type="date">
+          </label>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>Run flow</h2>
+        <div class="actions">
+          <button data-action="health">1. Health</button>
+          <button data-action="createProperty">2. Create property</button>
+          <button data-action="listProperties">3. List properties</button>
+          <button data-action="createLease">4. Create lease</button>
+          <button data-action="listLeases">5. List leases</button>
+          <button data-action="dueSoon">6. Due soon</button>
+          <button data-action="scan">7. Reminder scan</button>
+          <button data-action="notifications">8. Notifications</button>
+          <button data-action="markRead">9. Mark read</button>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>Status</h2>
+        <div id="statusCards" class="cards"></div>
+      </section>
+
+      <section class="panel warning">
+        <h2>Safety notes</h2>
+        <ul>
+          <li>Use only synthetic demo data.</li>
+          <li>Do not screenshot JWTs, tenant IDs, emails, passwords, or real tenant data.</li>
+          <li>Destroy the dev stack after demo use if it is not needed.</li>
+        </ul>
+      </section>
+    </main>
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/demo-client/styles.css
+++ b/demo-client/styles.css
@@ -1,0 +1,192 @@
+:root {
+  --ink: #172018;
+  --muted: #5d665f;
+  --paper: #f7f2e8;
+  --panel: rgba(255, 252, 244, 0.92);
+  --line: #d5c9af;
+  --accent: #2e6f57;
+  --accent-strong: #164834;
+  --warn: #8d4f16;
+  --ok: #207348;
+  --bad: #a43f32;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  color: var(--ink);
+  font-family: "Aptos", "Trebuchet MS", sans-serif;
+  background:
+    radial-gradient(circle at 15% 10%, rgba(46, 111, 87, 0.22), transparent 26rem),
+    linear-gradient(135deg, #fbf6eb 0%, #eee2c7 46%, #dce8dd 100%);
+}
+
+.shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 40px 0;
+}
+
+.hero {
+  padding: 36px;
+  border: 1px solid var(--line);
+  border-radius: 28px;
+  background: rgba(255, 252, 244, 0.72);
+  box-shadow: 0 18px 60px rgba(36, 45, 32, 0.14);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1,
+h2 {
+  margin: 0;
+  letter-spacing: -0.04em;
+}
+
+h1 {
+  max-width: 780px;
+  font-size: clamp(2.6rem, 7vw, 5.5rem);
+  line-height: 0.9;
+}
+
+h2 {
+  margin-bottom: 18px;
+  font-size: 1.5rem;
+}
+
+.hero p:not(.eyebrow) {
+  max-width: 760px;
+  color: var(--muted);
+  font-size: 1.15rem;
+  line-height: 1.6;
+}
+
+.panel {
+  margin-top: 22px;
+  padding: 26px;
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  background: var(--panel);
+}
+
+.warning {
+  border-color: rgba(141, 79, 22, 0.35);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+label {
+  display: grid;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+input,
+textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 12px 14px;
+  color: var(--ink);
+  font: inherit;
+  background: #fffdf7;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.note {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+button {
+  border: 0;
+  border-radius: 999px;
+  padding: 13px 16px;
+  color: #fffdf7;
+  font: inherit;
+  font-weight: 800;
+  background: var(--accent);
+  cursor: pointer;
+}
+
+button:hover {
+  background: var(--accent-strong);
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.card {
+  border: 1px solid var(--line);
+  border-left: 6px solid var(--accent);
+  border-radius: 18px;
+  padding: 16px;
+  background: #fffdf7;
+}
+
+.card.ok {
+  border-left-color: var(--ok);
+}
+
+.card.error {
+  border-left-color: var(--bad);
+}
+
+.card h3 {
+  margin: 0 0 8px;
+  font-size: 1rem;
+}
+
+.card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+ul {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+@media (max-width: 760px) {
+  .grid,
+  .actions,
+  .cards {
+    grid-template-columns: 1fr;
+  }
+
+  .hero,
+  .panel {
+    padding: 22px;
+  }
+}

--- a/docs/portfolio-demo-flow.md
+++ b/docs/portfolio-demo-flow.md
@@ -9,6 +9,16 @@ This is a presentation-friendly walkthrough, not a full operator validation
 runbook. For full deployed verification and evidence capture, use
 `docs/runbooks/deployed-dev-smoke-test.md`.
 
+If you want a local browser helper instead of manually running each `curl`
+command, start the local demo client:
+
+```bash
+make demo-client
+```
+
+Then open `http://127.0.0.1:8765`. The client uses a localhost proxy because
+the deployed HTTP API is not configured as a browser product API with CORS.
+
 ## Audience and Demo Goal
 
 Audience:

--- a/scripts/demo_client_server.py
+++ b/scripts/demo_client_server.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import json
+import re
+import subprocess
+import tempfile
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
+from urllib.request import Request, urlopen
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+STATIC_DIR = ROOT_DIR / "demo-client"
+NOTIFICATION_READ_PATH = re.compile(
+    r"^/notifications/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/read$"
+)
+ALLOWED_ROUTES = {
+    ("GET", "/health"),
+    ("GET", "/properties"),
+    ("POST", "/properties"),
+    ("GET", "/leases"),
+    ("POST", "/leases"),
+    ("GET", "/lease-reminders/due-soon"),
+    ("GET", "/notifications"),
+}
+
+
+def normalize_api_base_url(value: str) -> str:
+    parsed = urlsplit(value.strip().rstrip("/"))
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise ValueError("API base URL must be an https URL.")
+    return f"{parsed.scheme}://{parsed.netloc}{parsed.path.rstrip('/')}"
+
+
+def is_allowed_proxy_request(method: str, path: str) -> bool:
+    parsed = urlsplit(path)
+    if parsed.scheme or parsed.netloc or not parsed.path.startswith("/"):
+        return False
+
+    normalized_method = method.upper()
+    if (normalized_method, parsed.path) in ALLOWED_ROUTES:
+        return True
+    return normalized_method == "PATCH" and NOTIFICATION_READ_PATH.fullmatch(parsed.path) is not None
+
+
+def requires_id_token(method: str, path: str) -> bool:
+    parsed = urlsplit(path)
+    return not (method.upper() == "GET" and parsed.path == "/health")
+
+
+def extract_tenant_id_from_jwt(token: str) -> str:
+    try:
+        _header, payload, _signature = token.split(".", 2)
+        payload += "=" * (-len(payload) % 4)
+        decoded = base64.urlsafe_b64decode(payload.encode())
+        claims = json.loads(decoded)
+    except (ValueError, json.JSONDecodeError, binascii.Error) as exc:
+        raise ValueError("ID token is not a valid JWT.") from exc
+
+    tenant_id = str(claims.get("custom:tenant_id", "")).strip()
+    if not tenant_id:
+        raise ValueError("ID token does not include custom:tenant_id.")
+    return tenant_id
+
+
+class DemoClientHandler(BaseHTTPRequestHandler):
+    server_version = "LeaseFlowDemoClient/1.0"
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/":
+            self._send_static("index.html")
+            return
+
+        requested = self.path.lstrip("/")
+        if requested in {"index.html", "styles.css", "app.js"}:
+            self._send_static(requested)
+            return
+
+        self._send_json(HTTPStatus.NOT_FOUND, {"error": "Not found"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        try:
+            if self.path == "/local/proxy":
+                self._send_json(HTTPStatus.OK, self._proxy_api_request())
+                return
+            if self.path == "/local/reminder-scan":
+                self._send_json(HTTPStatus.OK, self._invoke_reminder_scan())
+                return
+            self._send_json(HTTPStatus.NOT_FOUND, {"error": "Not found"})
+        except ValueError as exc:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+    def _send_static(self, filename: str) -> None:
+        path = STATIC_DIR / filename
+        if not path.is_file():
+            self._send_json(HTTPStatus.NOT_FOUND, {"error": "Static file not found"})
+            return
+
+        content_type = {
+            ".html": "text/html; charset=utf-8",
+            ".css": "text/css; charset=utf-8",
+            ".js": "text/javascript; charset=utf-8",
+        }.get(path.suffix, "application/octet-stream")
+        body = path.read_bytes()
+        self.send_response(int(HTTPStatus.OK))
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _proxy_api_request(self) -> dict[str, Any]:
+        payload = self._read_json()
+        method = str(payload.get("method", "")).upper()
+        path = str(payload.get("path", ""))
+        token = str(payload.get("token", "")).strip()
+        body = payload.get("body")
+
+        if not is_allowed_proxy_request(method, path):
+            raise ValueError("Requested API route is not allowed by the demo proxy.")
+        if requires_id_token(method, path) and not token:
+            raise ValueError("ID token is required for protected demo routes.")
+
+        api_base_url = normalize_api_base_url(str(payload.get("apiBaseUrl", "")))
+        url = f"{api_base_url}{path}"
+        request_body = None
+        headers = {"Accept": "application/json"}
+        if body is not None:
+            request_body = json.dumps(body).encode()
+            headers["Content-Type"] = "application/json"
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        request = Request(url, data=request_body, headers=headers, method=method)
+        try:
+            with urlopen(request, timeout=30) as response:
+                response_body = response.read().decode()
+                status_code = response.status
+        except HTTPError as exc:
+            response_body = exc.read().decode()
+            status_code = exc.code
+        except URLError as exc:
+            return {"statusCode": 502, "body": {"error": f"API request failed: {exc.reason}"}}
+
+        return {"statusCode": status_code, "body": _parse_json_or_text(response_body)}
+
+    def _invoke_reminder_scan(self) -> dict[str, Any]:
+        payload = self._read_json()
+        token = str(payload.get("token", "")).strip()
+        region = str(payload.get("region", "eu-north-1")).strip() or "eu-north-1"
+        function_name = str(payload.get("functionName", "leaseflow-dev-backend")).strip()
+        days = int(payload.get("days", 7))
+        as_of_date = str(payload.get("asOfDate", "")).strip()
+        tenant_id = extract_tenant_id_from_jwt(token)
+
+        detail: dict[str, Any] = {"tenant_id": tenant_id, "days": days}
+        if as_of_date:
+            detail["as_of_date"] = as_of_date
+        lambda_payload = {
+            "source": "leaseflow.internal",
+            "detail-type": "scan_due_lease_reminders",
+            "detail": detail,
+        }
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as response_file:
+            response_path = Path(response_file.name)
+
+        try:
+            result = subprocess.run(
+                [
+                    "aws",
+                    "lambda",
+                    "invoke",
+                    "--region",
+                    region,
+                    "--function-name",
+                    function_name,
+                    "--cli-binary-format",
+                    "raw-in-base64-out",
+                    "--payload",
+                    json.dumps(lambda_payload),
+                    str(response_path),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if result.returncode != 0:
+                return {"statusCode": 502, "body": {"error": "Reminder scan invoke failed."}}
+
+            raw_response = response_path.read_text(encoding="utf-8")
+        finally:
+            response_path.unlink(missing_ok=True)
+
+        outer = _parse_json_or_text(raw_response)
+        if not isinstance(outer, dict):
+            return {"statusCode": 502, "body": {"error": "Unexpected Lambda response."}}
+
+        body = _parse_json_or_text(str(outer.get("body", "{}")))
+        if isinstance(body, dict):
+            body.pop("tenant_id", None)
+        return {"statusCode": outer.get("statusCode", 502), "body": body}
+
+    def _read_json(self) -> dict[str, Any]:
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length).decode()
+        try:
+            payload = json.loads(raw or "{}")
+        except json.JSONDecodeError as exc:
+            raise ValueError("Request body must be JSON.") from exc
+        if not isinstance(payload, dict):
+            raise ValueError("Request body must be a JSON object.")
+        return payload
+
+    def _send_json(self, status: HTTPStatus, body: dict[str, Any]) -> None:
+        encoded = json.dumps(body).encode()
+        self.send_response(int(status))
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+def _parse_json_or_text(value: str) -> Any:
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the LeaseFlow local demo client.")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    args = parser.parse_args()
+
+    server = ThreadingHTTPServer((args.host, args.port), DemoClientHandler)
+    print(f"LeaseFlow demo client: http://{args.host}:{args.port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopping LeaseFlow demo client.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_demo_client_server.py
+++ b/tests/test_demo_client_server.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import base64
+import json
+import unittest
+
+from scripts.demo_client_server import (
+    extract_tenant_id_from_jwt,
+    is_allowed_proxy_request,
+    normalize_api_base_url,
+    requires_id_token,
+)
+
+
+def _fake_jwt(payload: dict[str, str]) -> str:
+    header = {"alg": "none", "typ": "JWT"}
+    parts = []
+    for item in (header, payload):
+        encoded = base64.urlsafe_b64encode(json.dumps(item).encode()).decode().rstrip("=")
+        parts.append(encoded)
+    return f"{parts[0]}.{parts[1]}.signature"
+
+
+class DemoClientServerTests(unittest.TestCase):
+    def test_extracts_tenant_claim_from_jwt_payload(self) -> None:
+        token = _fake_jwt({"sub": "synthetic-user", "custom:tenant_id": "synthetic-tenant"})
+
+        self.assertEqual(extract_tenant_id_from_jwt(token), "synthetic-tenant")
+
+    def test_rejects_missing_tenant_claim(self) -> None:
+        token = _fake_jwt({"sub": "synthetic-user"})
+
+        with self.assertRaises(ValueError):
+            extract_tenant_id_from_jwt(token)
+
+    def test_allows_only_demo_api_routes(self) -> None:
+        allowed = [
+            ("GET", "/health"),
+            ("POST", "/properties"),
+            ("GET", "/properties"),
+            ("POST", "/leases"),
+            ("GET", "/leases"),
+            ("GET", "/lease-reminders/due-soon"),
+            ("GET", "/notifications"),
+            ("PATCH", "/notifications/123e4567-e89b-12d3-a456-426614174000/read"),
+        ]
+
+        for method, path in allowed:
+            with self.subTest(method=method, path=path):
+                self.assertTrue(is_allowed_proxy_request(method, path))
+
+    def test_rejects_non_demo_api_routes(self) -> None:
+        rejected = [
+            ("DELETE", "/properties/123e4567-e89b-12d3-a456-426614174000"),
+            ("PATCH", "/leases/123e4567-e89b-12d3-a456-426614174000"),
+            ("GET", "/admin"),
+            ("POST", "/notifications"),
+            ("GET", "https://example.com/health"),
+        ]
+
+        for method, path in rejected:
+            with self.subTest(method=method, path=path):
+                self.assertFalse(is_allowed_proxy_request(method, path))
+
+    def test_normalizes_api_base_url(self) -> None:
+        self.assertEqual(
+            normalize_api_base_url(" https://api.example.invalid/dev/ "),
+            "https://api.example.invalid/dev",
+        )
+
+    def test_requires_token_for_protected_routes_only(self) -> None:
+        self.assertFalse(requires_id_token("GET", "/health"))
+        self.assertTrue(requires_id_token("GET", "/properties"))
+        self.assertTrue(requires_id_token("POST", "/properties"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed and why

Adds a local portfolio demo client for the deployed LeaseFlow MVP.

The client provides a browser-based localhost UI for:
- health check
- property create/list
- lease create/list
- due-soon reminder query
- internal reminder scan helper
- notification list/read flow
- tenant override validation

It uses a Python stdlib localhost server as a small proxy because the deployed HTTP API is not configured as a browser product API with CORS.

## Assumptions

- This is portfolio/demo tooling, not a production frontend.
- The deployed dev stack already exists when the client is used.
- The user obtains a temporary Cognito ID token through the existing runbook flow.
- No backend API, Terraform, AWS resources, or CI workflow changes are included.

## Tenant isolation validation

The demo property create flow intentionally sends a wrong request-body `tenant_id`.

The UI checks that the backend response tenant context matches the Cognito JWT `custom:tenant_id` claim, without displaying or storing the tenant value.

The local proxy only allowlists the implemented demo routes and requires an ID token for protected routes.

## Cost validation

No AWS resources are added.

The docs keep the existing guidance: destroy the dev stack after demo use when it is not needed.

## Validation

- `python -m unittest tests.test_demo_client_server`
- `python -m py_compile scripts/demo_client_server.py`
- WSL `make demo-client` smoke: localhost returned `200`
- `git diff --check`
- manual secret/tenant-data search

## Remaining risks / TODOs

- Full Cognito login UI is out of scope; token paste is intentional for MVP demo simplicity.
- The reminder scan helper depends on local AWS CLI credentials/profile.
- This is not hosted frontend delivery.
- Follow-up #78 should document the safe runbook and sanitized evidence flow.
