### PR TITLE
infra: add S3 remote state bootstrap path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ backend/pytest-cache-files-*
 *.tfstate
 *.tfstate.*
 *.tfplan
+backend.hcl
+*.backend.hcl
 tfdestroy
 crash.log
 *.tfvars

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ make migrate
 
 ## Infrastructure Layout
 
+- `infra/bootstrap/terraform_state`: S3 bucket for Terraform remote state.
 - `infra/modules/`: reusable Terraform modules (`network`, `rds_postgres`, `cognito`, `lambda_backend`, `api_http`)
 - `infra/environments/dev`: dev environment composition using the modules
 
@@ -91,5 +92,10 @@ Terraform commands:
 
 ```bash
 make tf-fmt
-cd infra/environments/dev && terraform init && terraform plan
+cd infra/environments/dev
+terraform init -backend-config=backend.hcl
+terraform plan
 ```
+
+Create `infra/environments/dev/backend.hcl` from the remote state bootstrap
+output before running dev environment Terraform commands.

--- a/docs/mvp-readiness-review.md
+++ b/docs/mvp-readiness-review.md
@@ -41,6 +41,7 @@ Tenant isolation:
 Infrastructure capabilities:
 
 - Terraform-managed AWS dev environment
+- S3 remote state bootstrap path with native Terraform S3 lockfile locking
 - API Gateway HTTP API with JWT authorization
 - Python Lambda backend
 - Cognito user pool and app client
@@ -86,7 +87,8 @@ The current state is a validated dev MVP, not a production workload.
 
 Known limitations:
 
-- Terraform state is local for the dev workflow, not remote encrypted state with locking.
+- Terraform state now has a dev S3 remote-state path, but this is still not a
+  complete production environment strategy.
 - Dev RDS is single-instance and cost-controlled, not a highly available production database design.
 - RDS deletion behavior is dev-oriented; destroy removes dev data.
 - No frontend UI exists.
@@ -107,7 +109,10 @@ Assumptions:
 
 Risks:
 
-- Local Terraform state is acceptable for this learning MVP but would be a collaboration and recovery weakness for team or production use.
+- Terraform state access remains sensitive because state can contain generated
+  password material and other infrastructure details.
+- Remote state improves collaboration and recovery, but it still requires
+  disciplined IAM access and operator workflow.
 - Sparse CloudWatch metrics and missing-data treatment can make alarm timing non-obvious.
 - Optional email alarm delivery can fail operationally if the SNS subscription is not confirmed.
 - The backend has no delete/archive flows, so API-created synthetic domain data is normally cleaned up through dev stack destroy.
@@ -145,6 +150,6 @@ The strongest current story is:
 
 ```text
 LeaseFlow demonstrates a tenant-aware AWS backend MVP with Terraform-managed dev infrastructure,
-local and CI validation, deployed smoke evidence, operational runbooks, baseline alarms,
+remote-state bootstrap support, local and CI validation, deployed smoke evidence, operational runbooks, baseline alarms,
 and explicit documentation of the remaining production-readiness gaps.
 ```

--- a/docs/production-readiness-hardening.md
+++ b/docs/production-readiness-hardening.md
@@ -32,15 +32,20 @@ Classification: production-blocking
 
 Current state:
 
-- Dev workflow uses local Terraform state.
+- Dev now has an S3 remote-state bootstrap path with native Terraform S3
+  lockfile locking.
+- Existing local dev state can be migrated manually with
+  `terraform init -backend-config=backend.hcl -migrate-state`.
 - CI validates Terraform without AWS credentials.
 - Dev stack creation and destroy are operator-driven.
 
 Target posture:
 
-- Remote encrypted Terraform state with locking.
+- Remote encrypted Terraform state is consistently used for team-managed
+  environments.
 - Clear environment separation, at minimum dev and a production-like stage.
-- Documented state bootstrap and recovery process.
+- Documented IAM access boundaries for state and lockfile operations.
+- Documented state recovery process.
 
 Cost impact: low to medium.
 
@@ -52,8 +57,9 @@ Well-Architected relevance:
 
 SAA-C03 pitfall:
 
-- Terraform files are not the same as Terraform state. Without protected remote
-  state, collaboration and recovery remain weak.
+- Terraform files are not the same as Terraform state. Remote state reduces one
+  operational risk, but production readiness still needs controlled access,
+  recovery procedures, and environment separation.
 
 ## RDS Production Posture
 
@@ -297,8 +303,9 @@ demo readiness.
 
 Highest-value follow-ups:
 
-1. Add remote encrypted Terraform state with locking.
-2. Define production-like RDS protection baseline.
+1. Define production-like RDS protection baseline.
+2. Add stricter Terraform state access boundaries if the project becomes
+   team-managed.
 
 Defer for now:
 
@@ -329,5 +336,6 @@ Current recommendation:
 
 - Keep LeaseFlow in portfolio/demo mode unless the project goal explicitly
   changes.
-- Treat remote Terraform state and RDS protection as the first hardening work if
-  the project moves toward team-managed or production-like operation.
+- Treat RDS protection and stricter Terraform state access boundaries as the
+  first hardening work if the project moves toward team-managed or
+  production-like operation.

--- a/infra/README.md
+++ b/infra/README.md
@@ -4,6 +4,7 @@ Terraform code is split into reusable modules and environment composition.
 
 ## Layout
 
+- `bootstrap/terraform_state`: S3 bucket used by Terraform remote state.
 - `modules/network`: VPC, private subnets, Lambda/RDS security groups.
 - `modules/rds_postgres`: private PostgreSQL instance and subnet group.
 - `modules/cognito`: user pool and app client.
@@ -17,6 +18,7 @@ Terraform code is split into reusable modules and environment composition.
 - Keeps module interfaces clear.
 - Makes dev/prod split straightforward later.
 - Preserves low-cost defaults and avoids NAT Gateway.
+- Gives the dev environment a remote encrypted Terraform state path with locking.
 - The Terraform RDS environment is for deployed AWS verification, not for everyday backend development.
 - Normal backend development can use local PostgreSQL in WSL to avoid leaving billable AWS resources running.
 
@@ -26,6 +28,72 @@ Terraform code is split into reusable modules and environment composition.
 - Terraform stores the generated password in AWS Systems Manager Parameter Store as a `SecureString`.
 - Lambda reads the password from `DB_PASSWORD_SSM_PARAM` at runtime instead of receiving a plaintext password environment variable.
 - The password still exists in Terraform state because both `aws_db_instance.password` and `aws_ssm_parameter.value` are stored there by the current Terraform/provider model.
+- Treat Terraform state bucket access as sensitive access.
+
+## Remote Terraform state bootstrap
+
+The dev environment supports an S3 backend with native S3 lockfile locking.
+
+Bootstrap creates only the Terraform state bucket. It does not create the
+LeaseFlow dev application stack.
+
+What it does: creates the S3 bucket used for encrypted Terraform remote state.
+Target service: Amazon S3.
+
+```bash
+cd infra/bootstrap/terraform_state
+export AWS_PROFILE=terraform
+export AWS_REGION=eu-north-1
+terraform init
+terraform apply
+terraform output -raw dev_backend_config > ../../environments/dev/backend.hcl
+```
+
+`backend.hcl` is ignored by Git and must not be committed. It contains
+account-specific backend configuration.
+
+The generated dev backend config uses:
+
+- `bucket`: the bootstrap state bucket.
+- `key`: `leaseflow/dev/terraform.tfstate`.
+- `region`: `eu-north-1`.
+- `encrypt = true`.
+- `use_lockfile = true`.
+
+Terraform's S3 lockfile support is used instead of DynamoDB locking. DynamoDB
+locking is intentionally not added because current Terraform documentation marks
+it as deprecated.
+
+### Migrate an existing local dev state
+
+If `infra/environments/dev/terraform.tfstate` already contains the current dev
+stack, migrate it manually after `backend.hcl` exists.
+
+What it does: migrates existing dev Terraform state into the configured S3 backend.
+Target service: Terraform S3 backend.
+
+```bash
+cd infra/environments/dev
+terraform init -backend-config=backend.hcl -migrate-state
+terraform validate
+```
+
+Do not delete the local state file until migration is confirmed. After migration,
+use the same `backend.hcl` for future `plan`, `apply`, and `destroy` commands.
+
+If the dev stack was already destroyed and local state is intentionally empty,
+the same backend init path creates a fresh remote state backend for the next
+apply.
+
+### Remote state safety rules
+
+- Do not commit `backend.hcl`.
+- Do not commit `.tfstate` files or Terraform plans.
+- Do not delete the remote state bucket casually.
+- Keep bucket versioning enabled so accidental state overwrites are recoverable.
+- Restrict state bucket access because state may include sensitive values.
+- Remote state improves collaboration and recovery, but it does not make the
+  workload production-ready by itself.
 
 ## First Dev Preflight
 
@@ -35,13 +103,13 @@ The goal is to:
 
 - build a Linux-compatible Lambda zip in WSL
 - verify AWS credentials work inside WSL
-- run a real `terraform init` / `validate` / `plan` without creating resources yet
+- run a real `terraform init` / `validate` / `plan` before creating dev resources
 
 This preflight intentionally keeps:
 
 - local reproducible artifact packaging
-- local Terraform state
-- no `terraform apply`
+- remote Terraform state configuration through `backend.hcl`
+- no dev stack `terraform apply`
 
 ### Prerequisites
 
@@ -99,17 +167,20 @@ Run the Terraform checks from the dev environment directory:
 ```bash
 cd ~/leaseflow-preflight/infra/environments/dev
 cp terraform.tfvars.example terraform.tfvars
+test -f backend.hcl || cp backend.hcl.example backend.hcl
+grep -q "<aws-account-id>" backend.hcl && echo "Replace backend.hcl bucket with the real bootstrap output first." && exit 1
 export AWS_PROFILE=terraform
 aws sts get-caller-identity
-terraform init
+terraform init -backend-config=backend.hcl
 terraform validate
 terraform plan
 ```
 
 ### Notes
 
-- Do not run `terraform apply` as part of this preflight.
-- Remote state is intentionally deferred to a later hardening step.
+- Do not run dev stack `terraform apply` as part of this preflight.
+- Replace the placeholder bucket in `backend.hcl` with the real bootstrap output
+  before using remote state.
 - WSL is used here because the Lambda zip needs Linux-compatible dependencies.
 - Use a non-root AWS profile for Terraform work. Do not use the AWS account root profile for preflight or deployment tasks.
 
@@ -141,13 +212,14 @@ CI runs Terraform checks without AWS credentials.
 
 ## Safe destroy workflow
 
-- Use the same working copy and the same Terraform state that created the resources.
+- Use the same working copy and Terraform backend config that created the resources.
 - Use the same AWS profile and region that were used during `apply`.
-- Do not delete the local Terraform state before destroying the environment.
+- Do not delete Terraform state before destroying the environment.
 - The current dev RDS config uses `skip_final_snapshot = true`, so destroying the stack will permanently delete the dev database contents.
 
 ```bash
 cd infra/environments/dev
+terraform init -backend-config=backend.hcl
 terraform plan -destroy -out=tfdestroy
 terraform apply tfdestroy
 ```
@@ -175,7 +247,7 @@ aws rds describe-db-engine-versions --engine postgres --region eu-north-1 \
 cd infra
 terraform fmt -recursive
 cd environments/dev
-terraform init
+terraform init -backend-config=backend.hcl
 terraform plan
 ```
 

--- a/infra/bootstrap/terraform_state/.terraform.lock.hcl
+++ b/infra/bootstrap/terraform_state/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.41.0"
+  constraints = "~> 6.37"
+  hashes = [
+    "h1:1FXO2hJl4cpcT7FAfI5ArdtU1fJL8PWEHPF7x/o6BkY=",
+    "h1:iFwjmQtc0tIkSpB1KL+LcqLfuR6KYIGs49ea+LdVXXQ=",
+    "zh:01835476adda6d93095e37fdf782f14e6709f6922dc62e88994f9684627deb69",
+    "zh:0b9bc5eda9def53df19e1a37562dcb67c1fba8452803e1b5601e75653c986255",
+    "zh:196f81d97ea2951d2c6667709445d7c36b5fd8603890c774495806b4da0743aa",
+    "zh:1ba36118b0146e5c3603020509b34d09e693db50ec29f9be5badc9f2a4fd95b8",
+    "zh:4253c2f6066ce279e5ce48849c78fc193f222dc42a929e6876b9563ed5c23fcf",
+    "zh:457ed8609680338dbcb9809e263638a530c06ba43208af9e660803133dc5e1e6",
+    "zh:4e8de5f3fcc3e3f41b6703ad4c0fa62175d0c29afcf56ac82eb16c604bb6dafa",
+    "zh:583ae622cfe4633fabca071ded738e9ef3398d9e9916cb26350aad28068462c5",
+    "zh:5b8bf11070c13e21a0fef05713a25be0392c7d064bd2199c2f99939cc345e8c5",
+    "zh:6aa7ae41d4fff4e95cedcbeaa143b2af9ad3e3a4b40208801b701d77a738b2c7",
+    "zh:8143670bca48af3b873b0db83443dbdcb868442f1e789ffba356d6adf4dbd7b9",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c22951cf0a4b169607ea066717dd499f46221af035903497b97f24590fb79d2c",
+    "zh:dbd9cd975206a41a9c12006d3a30c77b95c0e660fcba2cc3bb0ee5779431c107",
+    "zh:e6ea2e0f142001b7f2229e8d39eb7f8037084723861be9d53478005196cd7f9e",
+  ]
+}

--- a/infra/bootstrap/terraform_state/main.tf
+++ b/infra/bootstrap/terraform_state/main.tf
@@ -1,0 +1,80 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  state_bucket_name = var.state_bucket_name != "" ? var.state_bucket_name : lower(
+    "${var.project_name}-terraform-state-${data.aws_caller_identity.current.account_id}-${var.aws_region}"
+  )
+  dev_state_key = "${var.project_name}/${var.environment}/terraform.tfstate"
+  common_tags = merge(
+    {
+      Project     = var.project_name
+      Environment = "bootstrap"
+      ManagedBy   = "terraform"
+      Purpose     = "terraform-state"
+    },
+    var.tags
+  )
+}
+
+resource "aws_s3_bucket" "terraform_state" {
+  bucket        = local.state_bucket_name
+  force_destroy = false
+
+  tags = merge(local.common_tags, { Name = local.state_bucket_name })
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "terraform_state" {
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.terraform_state.arn,
+      "${aws_s3_bucket.terraform_state.arn}/*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+  policy = data.aws_iam_policy_document.terraform_state.json
+}

--- a/infra/bootstrap/terraform_state/outputs.tf
+++ b/infra/bootstrap/terraform_state/outputs.tf
@@ -1,0 +1,25 @@
+output "state_bucket_name" {
+  description = "S3 bucket name for Terraform remote state."
+  value       = aws_s3_bucket.terraform_state.bucket
+}
+
+output "state_bucket_arn" {
+  description = "S3 bucket ARN for Terraform remote state."
+  value       = aws_s3_bucket.terraform_state.arn
+}
+
+output "dev_state_key" {
+  description = "S3 object key for the dev Terraform state."
+  value       = local.dev_state_key
+}
+
+output "dev_backend_config" {
+  description = "Copyable backend config for infra/environments/dev/backend.hcl."
+  value       = <<-EOT
+bucket       = "${aws_s3_bucket.terraform_state.bucket}"
+key          = "${local.dev_state_key}"
+region       = "${var.aws_region}"
+encrypt      = true
+use_lockfile = true
+EOT
+}

--- a/infra/bootstrap/terraform_state/variables.tf
+++ b/infra/bootstrap/terraform_state/variables.tf
@@ -1,0 +1,29 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS region for the Terraform state bucket."
+  default     = "eu-north-1"
+}
+
+variable "project_name" {
+  type        = string
+  description = "Project name used in state bucket and key naming."
+  default     = "leaseflow"
+}
+
+variable "environment" {
+  type        = string
+  description = "Environment name used for the dev state key."
+  default     = "dev"
+}
+
+variable "state_bucket_name" {
+  type        = string
+  description = "Optional explicit Terraform state bucket name. Leave empty to derive one from project, account, and region."
+  default     = ""
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Extra tags."
+  default     = {}
+}

--- a/infra/bootstrap/terraform_state/versions.tf
+++ b/infra/bootstrap/terraform_state/versions.tf
@@ -1,16 +1,10 @@
 terraform {
   required_version = ">= 1.6.0"
 
-  backend "s3" {}
-
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 6.37"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.6"
     }
   }
 }

--- a/infra/environments/dev/backend.hcl.example
+++ b/infra/environments/dev/backend.hcl.example
@@ -1,0 +1,5 @@
+bucket       = "leaseflow-terraform-state-<aws-account-id>-eu-north-1"
+key          = "leaseflow/dev/terraform.tfstate"
+region       = "eu-north-1"
+encrypt      = true
+use_lockfile = true


### PR DESCRIPTION
## What changed and why

Adds a remote Terraform state path for the dev environment using an S3 backend with native Terraform S3 lockfile locking.

This includes:
- a new bootstrap Terraform stack for the state bucket
- S3 bucket versioning, SSE-S3 encryption, public access blocking, and TLS-only bucket policy
- partial S3 backend configuration for `infra/environments/dev`
- an ignored `backend.hcl` workflow with a committed example file
- documentation for bootstrap, manual state migration, safe destroy, and state access risks

DynamoDB locking is intentionally not added because current Terraform documentation marks DynamoDB state locking as deprecated in favor of S3 lockfile locking.

## Assumptions

- Terraform CLI is recent enough for `use_lockfile = true`.
- The bootstrap stack intentionally uses local state because the remote state bucket must exist first.
- Existing dev state migration is manual with `terraform init -backend-config=backend.hcl -migrate-state`.
- SSE-S3 is sufficient for this ticket; SSE-KMS can be a later hardening step.

## Security validation

- No secrets, JWTs, passwords, tenant IDs, or account-specific backend config were committed.
- `backend.hcl` is ignored and documented as account-specific sensitive configuration.
- Docs explicitly state that Terraform state may contain sensitive values and state bucket access must be restricted.
- RDS remains private; no application or database networking changes were made.

## Cost validation

- Adds only a low-cost S3 state bucket when the bootstrap stack is applied.
- No DynamoDB table, KMS key, production environment, or new runtime service is added.
- No AWS resources were created during this implementation.

## Validation

- `git diff --check`
- `terraform fmt -check -recursive infra`
- `terraform init -backend=false` in `infra/bootstrap/terraform_state`
- `terraform validate` in `infra/bootstrap/terraform_state`
- `terraform init -backend=false` in `infra/environments/dev`
- `terraform validate` in `infra/environments/dev`

## Remaining risks / TODOs

- The remote state bucket still needs to be bootstrapped with `terraform apply`.
- Existing local dev state still needs manual migration if the current dev stack state should be preserved.
- Production/team readiness still needs tighter IAM access boundaries and environment separation.

Additional live validation:
- Bootstrapped S3 state bucket `ilkandemo5000`.
- Migrated existing dev local state to S3 backend.
- Verified remote state object exists at `leaseflow/dev/terraform.tfstate`.
- Ran `terraform validate`.
- Ran `terraform plan`, result: no changes.
