### PR TITLE
docs: define production-like RDS protection baseline

### DIFF
--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -53,6 +53,8 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
 
 - Single backend Lambda for MVP simplicity.
 - One RDS instance in dev with small sizing.
+- Dev RDS remains cost-controlled; the production-like protection baseline is
+  documented separately in `docs/rds-production-protection-baseline.md`.
 - No NAT Gateway in dev environment.
 - Private AWS API dependencies are reached through targeted interface endpoints where required.
 - No extra services unless they deliver clear MVP value.
@@ -65,6 +67,8 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
   `docs/runbooks/demo-client-safe-demo.md`.
 - Deployed dev smoke validation is documented in `docs/runbooks/deployed-dev-smoke-test.md`.
 - Dev RDS restore validation is documented in `docs/runbooks/dev-rds-restore-validation.md`.
+- Production-like RDS protection expectations are documented in
+  `docs/rds-production-protection-baseline.md`.
 - Production-readiness hardening is scoped in `docs/production-readiness-hardening.md`.
 - The restore validation runbook defines the quarterly MVP cadence, event-driven
   rerun triggers, evidence retention, and backup retention review triggers.

--- a/docs/production-readiness-hardening.md
+++ b/docs/production-readiness-hardening.md
@@ -80,6 +80,8 @@ Target posture:
 - Deletion protection and final snapshot behavior reviewed for production-like use.
 - Multi-AZ tradeoff reviewed against availability needs and cost.
 - Restore objectives and evidence cadence defined before real tenant data exists.
+- Production-like defaults are defined in
+  `docs/rds-production-protection-baseline.md`.
 
 Cost impact: medium to high.
 
@@ -303,9 +305,10 @@ demo readiness.
 
 Highest-value follow-ups:
 
-1. Define production-like RDS protection baseline.
-2. Add stricter Terraform state access boundaries if the project becomes
+1. Add stricter Terraform state access boundaries if the project becomes
    team-managed.
+2. Implement the RDS production-like protection baseline only if the project
+   moves beyond portfolio/demo mode.
 
 Defer for now:
 
@@ -336,6 +339,6 @@ Current recommendation:
 
 - Keep LeaseFlow in portfolio/demo mode unless the project goal explicitly
   changes.
-- Treat RDS protection and stricter Terraform state access boundaries as the
-  first hardening work if the project moves toward team-managed or
-  production-like operation.
+- Treat stricter Terraform state access boundaries and RDS protection
+  implementation as the first hardening work if the project moves toward
+  team-managed or production-like operation.

--- a/docs/rds-production-protection-baseline.md
+++ b/docs/rds-production-protection-baseline.md
@@ -1,0 +1,128 @@
+# RDS Production-Like Protection Baseline
+
+## Purpose
+
+Define the RDS protection posture LeaseFlow would need before storing real
+tenant data or running a production-like environment.
+
+This is a design baseline, not an implementation ticket. The current dev
+Terraform behavior remains cost-controlled.
+
+Not included in this baseline:
+
+- AWS Backup plans.
+- Cross-region replication.
+- Public RDS access.
+- Bastion hosts.
+- Application or schema changes.
+
+## Current Dev Posture
+
+Current Terraform-managed dev RDS settings:
+
+| Control | Current dev value | Reason |
+| --- | --- | --- |
+| Public access | `publicly_accessible = false` | RDS must stay private. |
+| Storage encryption | `storage_encrypted = true` | Encrypt data at rest. |
+| Backup retention | `backup_retention_period = 1` | Minimal dev restore window for cost control. |
+| Multi-AZ | `multi_az = false` | Lower dev cost. |
+| Deletion protection | `deletion_protection = false` | Allows easy dev stack destroy. |
+| Final snapshot | `skip_final_snapshot = true` | Faster and cheaper dev cleanup. |
+
+This posture is acceptable for short-lived portfolio/dev validation. It is not
+production-ready database protection.
+
+## Production-Like Baseline
+
+| Control | Production-like baseline | Cost impact | Why |
+| --- | --- | --- | --- |
+| Public access | Keep disabled. | None | Public RDS access is not an acceptable shortcut. |
+| Backup retention | Minimum `7` days before real tenant or demo-critical data. | Low to medium | Gives a wider point-in-time restore window than dev. |
+| Deletion protection | Enable by default. | None | Prevents accidental destructive deletes. |
+| Final snapshot | Require before destructive deletion. | Medium | Preserves a last recovery point before removal. |
+| Multi-AZ | Enable only when availability justifies the added cost. | Medium to high | Improves availability and failover posture. |
+| Restore validation | Run before go-live and after meaningful DB changes. | Medium | Proves restore behavior, not just backup configuration. |
+| Data-level validation | Use only a private execution path. | Low to medium | Confirms schema/data posture without exposing RDS. |
+
+## Recovery Assumptions
+
+These are project assumptions, not AWS service guarantees:
+
+- Dev RTO: best effort, operator-driven, suitable only for learning and demo
+  recovery.
+- Dev RPO: bounded by the current one-day backup retention and latest
+  restorable time.
+- Production-like RTO and RPO must be defined before go-live.
+- Backup retention must be increased when recovery expectations exceed the dev
+  one-day window.
+- Restore validation evidence must be kept for production-like readiness claims.
+
+## Decision Rules
+
+Keep the current dev posture when:
+
+- the environment is short-lived
+- data can be recreated
+- AWS cost control is more important than recovery realism
+- the stack is destroyed after validation
+
+Move to the production-like baseline when:
+
+- real tenant data exists
+- demo data is difficult or expensive to recreate
+- multiple operators depend on the environment
+- recovery expectations are explicit
+- destructive changes require reviewable safeguards
+
+## Restore Validation
+
+Dev restore validation remains covered by:
+
+- `docs/runbooks/dev-rds-restore-validation.md`
+- `docs/runbooks/dev-rds-private-data-validation.md`
+
+For production-like use, restore validation must include:
+
+- source DB identifier
+- latest restorable time
+- restore start and completion time
+- restored DB privacy and encryption posture
+- migration/schema validation through a private path
+- cleanup confirmation or documented reason for retention
+- follow-up actions for any gap
+
+Safe evidence must not include tenant data, tenant IDs, passwords, SSM values,
+JWTs, full connection strings, or row contents.
+
+## Well-Architected Notes
+
+Reliability:
+
+- Backup retention, final snapshots, and restore validation support recovery.
+- Multi-AZ supports availability and failover, not backup retention.
+
+Security:
+
+- RDS remains private.
+- Data-level restore checks must stay inside an approved private execution path.
+- Evidence must exclude secrets and tenant data.
+
+Cost Optimization:
+
+- Longer retention, final snapshots, and Multi-AZ can increase cost.
+- Production-like controls should be enabled only when their recovery or
+  availability value is accepted.
+
+Operational Excellence:
+
+- Restore validation cadence and evidence make recoverability reviewable.
+- Destructive database operations need explicit operator workflow.
+
+## SAA-C03 Pitfalls
+
+- Automated backups are not the same as restore validation.
+- Backup retention defines the point-in-time restore window.
+- Multi-AZ is not a backup feature.
+- Deletion protection does not replace backups.
+- A final snapshot is not the same as continuous point-in-time recovery.
+- A private restored DB still needs a private validation path.


### PR DESCRIPTION
## What changed and why

Adds a docs-only production-like RDS protection baseline for LeaseFlow.

The new baseline documents:
- current cost-controlled dev RDS posture
- production-like target posture
- backup retention expectations
- deletion protection and final snapshot behavior
- Multi-AZ tradeoff and cost impact
- restore validation and RTO/RPO assumptions
- safe evidence rules
- AWS Well-Architected and SAA-C03 pitfalls

This keeps #84 as a design artifact only. No Terraform, backend code, AWS resources, or architecture changes are added.

## Assumptions

- LeaseFlow remains portfolio/demo-first.
- Current dev RDS settings stay unchanged:
  - `backup_retention_period = 1`
  - `multi_az = false`
  - `deletion_protection = false`
  - `skip_final_snapshot = true`
- Production-like RDS controls are documented but not applied.
- RDS must remain private.

## Security validation

- No secrets, tenant IDs, passwords, SSM values, full DB connection strings, or tenant row contents were added.
- The baseline explicitly rejects public RDS access.
- Restore data-level validation must remain private.

## Cost validation

- No AWS resources are added.
- The baseline calls out cost impact for longer backup retention, final snapshots, and Multi-AZ.
- Dev remains cost-controlled.

## Validation

- `git diff --check`
- Manual docs review for secrets, tenant data, public RDS claims, production-readiness overclaiming, and Multi-AZ/backup confusion.

## Remaining risks / TODOs

- This does not implement production-like RDS settings.
- Actual RTO/RPO values still need to be selected before any production-like environment.
- Future implementation should be separate and cost-approved.
