### PR TITLE
infra: enable hosted ui auth and browser cors for frontend origins

### DIFF
--- a/demo-client/README.md
+++ b/demo-client/README.md
@@ -2,7 +2,9 @@
 
 This is a local portfolio/demo client for the deployed LeaseFlow dev API.
 
-It is not a production frontend.
+It is not a production frontend. The real browser-frontend path now uses
+Cognito Hosted UI plus direct browser API access for approved origins, while
+this tool stays as a local demo/operator helper.
 
 ## Run
 
@@ -171,6 +173,13 @@ aws cognito-idp admin-delete-user \
 
 ## Why There Is A Local Server
 
-The deployed HTTP API is not configured as a browser product API with CORS.
-The local server lets the browser talk to `localhost` while the server proxies
-only the allowlisted demo API calls to the deployed API Gateway.
+The local server is still intentional even though the dev stack now has browser
+CORS for approved origins.
+
+The demo client keeps a local proxy because it combines:
+
+- token-paste operator workflow
+- allowlisted API proxy calls
+- internal reminder-scan helper invocation through the local AWS CLI context
+
+The future real frontend uses the direct browser path instead.

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -68,11 +68,12 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
   `docs/frontend-mvp-strategy.md`.
 - The chosen frontend direction is React + Vite + TypeScript in a future
   `frontend/` directory.
-- Browser auth is planned through Cognito Hosted UI with OAuth Authorization
-  Code + PKCE.
+- Dev Terraform now provides Cognito Hosted UI foundation through a managed
+  domain and OAuth Authorization Code + PKCE-capable app client settings.
+- Dev Terraform now provides allowlisted browser CORS on the HTTP API for
+  approved frontend origins.
 - Later hosting is planned as a static SPA behind S3 + CloudFront.
-- Hosted UI and browser CORS are not yet implemented in the current Terraform
-  stack.
+- The real browser frontend is still not implemented yet.
 
 ## Operational Runbooks
 

--- a/docs/frontend-mvp-strategy.md
+++ b/docs/frontend-mvp-strategy.md
@@ -13,11 +13,13 @@ local portfolio/demo tool and not the production-like frontend path.
   a backend/infra MVP.
 - The current `demo-client` is a localhost proxy-based demo helper, not a real
   browser product frontend.
-- The current Cognito app client is not yet configured for Hosted UI or OAuth
-  flows.
-- The current API Gateway HTTP API is not yet configured as a browser product
-  API with CORS.
-- These gaps are expected and require follow-up implementation tickets.
+- The dev Terraform stack now configures a Cognito Hosted UI foundation with a
+  managed domain, OAuth authorization code flow, and callback/logout URLs for
+  approved frontend origins.
+- The dev Terraform stack now configures allowlisted browser CORS on the HTTP
+  API for approved frontend origins.
+- A real browser frontend is still not implemented yet; only the auth/CORS
+  foundation exists.
 
 ## Chosen Frontend Direction
 
@@ -38,8 +40,9 @@ local portfolio/demo tool and not the production-like frontend path.
 - Protected API calls continue to use a Cognito ID token in the
   `Authorization` header because the backend reads tenant context from the
   Cognito claim `custom:tenant_id`.
-- Follow-up Cognito work must add the OAuth flows, callback URLs, and logout
-  URLs required for the browser frontend.
+- The current Terraform foundation already includes the OAuth flows,
+  callback URLs, logout URLs, and managed Hosted UI domain required for the
+  first browser frontend slice.
 
 ## CORS Contract
 
@@ -50,6 +53,7 @@ local portfolio/demo tool and not the production-like frontend path.
 - Planned browser headers: `Authorization`, `Content-Type`
 - Browser API calls use bearer tokens in the `Authorization` header, not
   cookie-based cross-site credentials.
+- Current Terraform uses `allow_credentials = false` for the browser path.
 - CORS is browser access control only. It is not authentication or
   authorization.
 
@@ -82,8 +86,6 @@ Later frontend follow-ups:
 
 ## Follow-Up Tickets
 
-- `#91` Enable Cognito Hosted UI, OAuth PKCE, and API Gateway CORS for
-  frontend origins.
 - `#92` Build the React + Vite + TypeScript frontend shell with auth,
   properties, and leases flows.
 - `#93` Add the later S3 + CloudFront hosting path for the frontend.

--- a/docs/portfolio-demo-flow.md
+++ b/docs/portfolio-demo-flow.md
@@ -23,7 +23,9 @@ python scripts/demo_client_server.py
 ```
 
 Then open `http://127.0.0.1:8765`. The client uses a localhost proxy because
-the deployed HTTP API is not configured as a browser product API with CORS.
+the demo tool still wraps the deployed API and internal reminder-scan helper in
+one local operator flow. The real frontend path is separate and now uses
+Hosted UI plus direct browser API access for approved origins.
 See `demo-client/README.md` for the browser-client setup checklist, including
 DB migrations, temporary Cognito user creation, token verification, and cleanup.
 For sanitized portfolio evidence capture, use

--- a/infra/README.md
+++ b/infra/README.md
@@ -7,7 +7,7 @@ Terraform code is split into reusable modules and environment composition.
 - `bootstrap/terraform_state`: S3 bucket used by Terraform remote state.
 - `modules/network`: VPC, private subnets, Lambda/RDS security groups.
 - `modules/rds_postgres`: private PostgreSQL instance and subnet group.
-- `modules/cognito`: user pool and app client.
+- `modules/cognito`: user pool, app client, and managed Hosted UI domain.
 - `modules/lambda_backend`: backend Lambda function, IAM role, log group.
 - `modules/reminder_scheduler`: EventBridge Scheduler + IAM role for daily reminder scans.
 - `modules/api_http`: HTTP API, JWT authorizer, route wiring.
@@ -21,6 +21,20 @@ Terraform code is split into reusable modules and environment composition.
 - Gives the dev environment a remote encrypted Terraform state path with locking.
 - The Terraform RDS environment is for deployed AWS verification, not for everyday backend development.
 - Normal backend development can use local PostgreSQL in WSL to avoid leaving billable AWS resources running.
+
+## Browser frontend foundation
+
+The dev stack now includes the browser-auth and browser-CORS foundation needed
+for a future real frontend.
+
+- Cognito app client is configured for Hosted UI OAuth authorization code flow.
+- Cognito uses a managed domain prefix that you must set explicitly in
+  `terraform.tfvars`.
+- API Gateway HTTP API allows browser calls only from approved origins.
+- Default local frontend origin is `http://localhost:5173`.
+- Optional hosted frontend origin must be HTTPS.
+- `allow_credentials = false`; browser calls use bearer tokens, not cookies.
+- The existing `demo-client` remains a separate local demo/operator tool.
 
 ## DB password handling
 
@@ -169,6 +183,7 @@ cd ~/leaseflow-preflight/infra/environments/dev
 cp terraform.tfvars.example terraform.tfvars
 test -f backend.hcl || cp backend.hcl.example backend.hcl
 grep -q "<aws-account-id>" backend.hcl && echo "Replace backend.hcl bucket with the real bootstrap output first." && exit 1
+grep -q "replace-with-a-unique-dev-prefix" terraform.tfvars && echo "Replace cognito_hosted_ui_domain_prefix with a globally unique value first." && exit 1
 export AWS_PROFILE=terraform
 aws sts get-caller-identity
 terraform init -backend-config=backend.hcl
@@ -181,6 +196,8 @@ terraform plan
 - Do not run dev stack `terraform apply` as part of this preflight.
 - Replace the placeholder bucket in `backend.hcl` with the real bootstrap output
   before using remote state.
+- Replace the placeholder `cognito_hosted_ui_domain_prefix` in `terraform.tfvars`
+  with a globally unique value before planning or applying the dev stack.
 - WSL is used here because the Lambda zip needs Linux-compatible dependencies.
 - Use a non-root AWS profile for Terraform work. Do not use the AWS account root profile for preflight or deployment tasks.
 

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -1,5 +1,19 @@
 locals {
-  name_prefix = "${var.project_name}-${var.environment}"
+  name_prefix            = "${var.project_name}-${var.environment}"
+  frontend_hosted_origin = trimsuffix(trimspace(var.frontend_hosted_origin), "/")
+  frontend_local_origin  = trimsuffix(trimspace(var.frontend_local_origin), "/")
+  frontend_allowed_origins = compact([
+    local.frontend_local_origin,
+    local.frontend_hosted_origin,
+  ])
+  frontend_callback_urls = concat(
+    ["${local.frontend_local_origin}/auth/callback"],
+    local.frontend_hosted_origin == "" ? [] : ["${local.frontend_hosted_origin}/auth/callback"]
+  )
+  frontend_logout_urls = concat(
+    ["${local.frontend_local_origin}/"],
+    local.frontend_hosted_origin == "" ? [] : ["${local.frontend_hosted_origin}/"]
+  )
   common_tags = merge(
     {
       Project     = var.project_name
@@ -51,8 +65,13 @@ module "rds_postgres" {
 module "cognito" {
   source = "../../modules/cognito"
 
-  name_prefix = local.name_prefix
-  tags        = local.common_tags
+  aws_region              = var.aws_region
+  callback_urls           = local.frontend_callback_urls
+  default_redirect_uri    = local.frontend_callback_urls[0]
+  hosted_ui_domain_prefix = var.cognito_hosted_ui_domain_prefix
+  logout_urls             = local.frontend_logout_urls
+  name_prefix             = local.name_prefix
+  tags                    = local.common_tags
 }
 
 module "lambda_backend" {
@@ -117,6 +136,10 @@ module "api_http" {
 
   name_prefix                 = local.name_prefix
   aws_region                  = var.aws_region
+  cors_allowed_origins        = local.frontend_allowed_origins
+  cors_allow_credentials      = false
+  cors_allow_headers          = ["Authorization", "Content-Type"]
+  cors_allow_methods          = ["GET", "OPTIONS", "PATCH", "POST"]
   stage_name                  = var.environment
   lambda_invoke_arn           = module.lambda_backend.invoke_arn
   lambda_function_name        = module.lambda_backend.function_name

--- a/infra/environments/dev/outputs.tf
+++ b/infra/environments/dev/outputs.tf
@@ -13,6 +13,11 @@ output "cognito_user_pool_client_id" {
   value       = module.cognito.user_pool_client_id
 }
 
+output "cognito_hosted_ui_base_url" {
+  description = "Managed Cognito Hosted UI base URL for the dev frontend auth flow."
+  value       = module.cognito.hosted_ui_base_url
+}
+
 output "rds_endpoint" {
   description = "RDS endpoint."
   value       = module.rds_postgres.endpoint

--- a/infra/environments/dev/terraform.tfvars.example
+++ b/infra/environments/dev/terraform.tfvars.example
@@ -13,5 +13,14 @@ db_engine_version = "15.17"
 lambda_package_file   = "../../../dist/leaseflow-backend.zip"
 db_password_ssm_param = "/leaseflow/dev/db/password"
 
+# Required. Must be globally unique within Cognito managed domains.
+cognito_hosted_ui_domain_prefix = "replace-with-a-unique-dev-prefix"
+
+# Local browser frontend origin used by Vite during development.
+frontend_local_origin = "http://localhost:5173"
+
+# Optional later hosted browser frontend origin. Leave empty until hosting exists.
+frontend_hosted_origin = ""
+
 # Optional. AWS sends a confirmation email before SNS starts delivery.
 baseline_alarm_notification_email = ""

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -64,6 +64,28 @@ variable "lambda_package_file" {
   default     = "../../../dist/leaseflow-backend.zip"
 }
 
+variable "frontend_local_origin" {
+  type        = string
+  description = "Local browser frontend origin allowed by Cognito and API Gateway CORS."
+  default     = "http://localhost:5173"
+}
+
+variable "frontend_hosted_origin" {
+  type        = string
+  description = "Optional hosted browser frontend origin allowed by Cognito and API Gateway CORS."
+  default     = ""
+
+  validation {
+    condition     = trimspace(var.frontend_hosted_origin) == "" || startswith(trimspace(var.frontend_hosted_origin), "https://")
+    error_message = "frontend_hosted_origin must be empty or start with https://."
+  }
+}
+
+variable "cognito_hosted_ui_domain_prefix" {
+  type        = string
+  description = "Globally unique Cognito managed Hosted UI domain prefix for the dev frontend auth flow."
+}
+
 variable "db_password_ssm_param" {
   type        = string
   description = "SSM parameter path for generated runtime DB password."

--- a/infra/modules/api_http/defaults.tftest.hcl
+++ b/infra/modules/api_http/defaults.tftest.hcl
@@ -3,6 +3,10 @@ mock_provider "aws" {}
 variables {
   name_prefix                 = "leaseflow-dev"
   aws_region                  = "eu-north-1"
+  cors_allow_credentials      = false
+  cors_allow_headers          = ["Authorization", "Content-Type"]
+  cors_allow_methods          = ["GET", "OPTIONS", "PATCH", "POST"]
+  cors_allowed_origins        = ["http://localhost:5173"]
   stage_name                  = "dev"
   lambda_invoke_arn           = "arn:aws:lambda:eu-north-1:123456789012:function:leaseflow-dev-backend:$LATEST"
   lambda_function_name        = "leaseflow-dev-backend"
@@ -74,5 +78,66 @@ run "exposes_backend_route_parity" {
   assert {
     condition     = aws_apigatewayv2_route.update_property.authorization_type == "JWT"
     error_message = "Property update route should require JWT auth."
+  }
+
+  assert {
+    condition     = try(contains(aws_apigatewayv2_api.this.cors_configuration[0].allow_origins, "http://localhost:5173"), false)
+    error_message = "HTTP API should allow the local frontend origin by default."
+  }
+
+  assert {
+    condition     = try(contains(aws_apigatewayv2_api.this.cors_configuration[0].allow_headers, "Authorization"), false)
+    error_message = "HTTP API should allow the Authorization header for browser calls."
+  }
+
+  assert {
+    condition     = try(contains(aws_apigatewayv2_api.this.cors_configuration[0].allow_headers, "Content-Type"), false)
+    error_message = "HTTP API should allow the Content-Type header for browser calls."
+  }
+
+  assert {
+    condition     = try(contains(aws_apigatewayv2_api.this.cors_configuration[0].allow_methods, "GET"), false)
+    error_message = "HTTP API should allow GET in browser CORS."
+  }
+
+  assert {
+    condition     = try(contains(aws_apigatewayv2_api.this.cors_configuration[0].allow_methods, "POST"), false)
+    error_message = "HTTP API should allow POST in browser CORS."
+  }
+
+  assert {
+    condition     = try(contains(aws_apigatewayv2_api.this.cors_configuration[0].allow_methods, "PATCH"), false)
+    error_message = "HTTP API should allow PATCH in browser CORS."
+  }
+
+  assert {
+    condition     = try(contains(aws_apigatewayv2_api.this.cors_configuration[0].allow_methods, "OPTIONS"), false)
+    error_message = "HTTP API should allow OPTIONS in browser CORS."
+  }
+
+  assert {
+    condition     = aws_apigatewayv2_api.this.cors_configuration[0].allow_credentials == false
+    error_message = "HTTP API should not allow browser credentials for this frontend phase."
+  }
+}
+
+run "supports_optional_hosted_frontend_origin" {
+  command = plan
+
+  variables {
+    cors_allowed_origins = [
+      "http://localhost:5173",
+      "https://demo.example.com",
+    ]
+  }
+
+  assert {
+    condition     = try(length(aws_apigatewayv2_api.this.cors_configuration[0].allow_origins), 0) == 2
+    error_message = "HTTP API should allow both the local and hosted frontend origins when configured."
+  }
+
+  assert {
+    condition     = try(contains(aws_apigatewayv2_api.this.cors_configuration[0].allow_origins, "https://demo.example.com"), false)
+    error_message = "HTTP API should include the configured hosted frontend origin."
   }
 }

--- a/infra/modules/api_http/main.tf
+++ b/infra/modules/api_http/main.tf
@@ -2,6 +2,13 @@ resource "aws_apigatewayv2_api" "this" {
   name          = "${var.name_prefix}-http-api"
   protocol_type = "HTTP"
   tags          = merge(var.tags, { Name = "${var.name_prefix}-http-api" })
+
+  cors_configuration {
+    allow_credentials = var.cors_allow_credentials
+    allow_headers     = var.cors_allow_headers
+    allow_methods     = var.cors_allow_methods
+    allow_origins     = var.cors_allowed_origins
+  }
 }
 
 resource "aws_apigatewayv2_integration" "backend" {

--- a/infra/modules/api_http/variables.tf
+++ b/infra/modules/api_http/variables.tf
@@ -33,6 +33,26 @@ variable "cognito_user_pool_client_id" {
   description = "Cognito app client ID."
 }
 
+variable "cors_allowed_origins" {
+  type        = list(string)
+  description = "Browser origins allowed to call the HTTP API."
+}
+
+variable "cors_allow_headers" {
+  type        = list(string)
+  description = "Headers allowed by the HTTP API CORS configuration."
+}
+
+variable "cors_allow_methods" {
+  type        = list(string)
+  description = "Methods allowed by the HTTP API CORS configuration."
+}
+
+variable "cors_allow_credentials" {
+  type        = bool
+  description = "Whether the HTTP API CORS configuration allows browser credentials."
+}
+
 variable "tags" {
   type        = map(string)
   description = "Common tags."

--- a/infra/modules/cognito/main.tf
+++ b/infra/modules/cognito/main.tf
@@ -5,10 +5,20 @@ locals {
     "ALLOW_REFRESH_TOKEN_AUTH",
     "ALLOW_USER_SRP_AUTH",
   ]
+  app_client_allowed_oauth_flows = [
+    "code",
+  ]
+  app_client_allowed_oauth_scopes = [
+    "email",
+    "openid",
+  ]
   app_client_read_attributes = [
     "custom:tenant_id",
     "email",
     "email_verified",
+  ]
+  app_client_supported_identity_providers = [
+    "COGNITO",
   ]
   app_client_write_attributes = [
     "email",
@@ -51,8 +61,19 @@ resource "aws_cognito_user_pool_client" "this" {
   generate_secret                      = false
   prevent_user_existence_errors        = "ENABLED"
   enable_token_revocation              = true
-  allowed_oauth_flows_user_pool_client = false
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_flows                  = local.app_client_allowed_oauth_flows
+  allowed_oauth_scopes                 = local.app_client_allowed_oauth_scopes
+  callback_urls                        = var.callback_urls
+  default_redirect_uri                 = var.default_redirect_uri
   explicit_auth_flows                  = local.app_client_explicit_auth_flows
+  logout_urls                          = var.logout_urls
   read_attributes                      = local.app_client_read_attributes
+  supported_identity_providers         = local.app_client_supported_identity_providers
   write_attributes                     = local.app_client_write_attributes
+}
+
+resource "aws_cognito_user_pool_domain" "this" {
+  domain       = var.hosted_ui_domain_prefix
+  user_pool_id = aws_cognito_user_pool.this.id
 }

--- a/infra/modules/cognito/outputs.tf
+++ b/infra/modules/cognito/outputs.tf
@@ -7,3 +7,8 @@ output "user_pool_client_id" {
   value       = aws_cognito_user_pool_client.this.id
   description = "Cognito app client ID."
 }
+
+output "hosted_ui_base_url" {
+  value       = "https://${aws_cognito_user_pool_domain.this.domain}.auth.${var.aws_region}.amazoncognito.com"
+  description = "Managed Cognito Hosted UI base URL."
+}

--- a/infra/modules/cognito/tests/defaults.tftest.hcl
+++ b/infra/modules/cognito/tests/defaults.tftest.hcl
@@ -1,7 +1,12 @@
 mock_provider "aws" {}
 
 variables {
-  name_prefix = "leaseflow-dev"
+  aws_region              = "eu-north-1"
+  callback_urls           = ["http://localhost:5173/auth/callback"]
+  default_redirect_uri    = "http://localhost:5173/auth/callback"
+  hosted_ui_domain_prefix = "leaseflow-dev-example"
+  logout_urls             = ["http://localhost:5173/"]
+  name_prefix             = "leaseflow-dev"
   tags = {
     Project = "leaseflow"
   }
@@ -29,6 +34,46 @@ run "exposes_tenant_id_claim_for_api_auth" {
   }
 
   assert {
+    condition     = aws_cognito_user_pool_client.this.allowed_oauth_flows_user_pool_client == true
+    error_message = "App client should enable OAuth flows for Hosted UI browser login."
+  }
+
+  assert {
+    condition     = try(contains(aws_cognito_user_pool_client.this.allowed_oauth_flows, "code"), false)
+    error_message = "App client should allow the OAuth authorization code flow."
+  }
+
+  assert {
+    condition     = try(contains(aws_cognito_user_pool_client.this.allowed_oauth_scopes, "openid"), false)
+    error_message = "App client should allow the openid OAuth scope."
+  }
+
+  assert {
+    condition     = try(contains(aws_cognito_user_pool_client.this.allowed_oauth_scopes, "email"), false)
+    error_message = "App client should allow the email OAuth scope."
+  }
+
+  assert {
+    condition     = try(contains(aws_cognito_user_pool_client.this.supported_identity_providers, "COGNITO"), false)
+    error_message = "App client should use Cognito as the supported identity provider."
+  }
+
+  assert {
+    condition     = try(contains(aws_cognito_user_pool_client.this.callback_urls, "http://localhost:5173/auth/callback"), false)
+    error_message = "App client should include the local frontend callback URL."
+  }
+
+  assert {
+    condition     = try(contains(aws_cognito_user_pool_client.this.logout_urls, "http://localhost:5173/"), false)
+    error_message = "App client should include the local frontend logout URL."
+  }
+
+  assert {
+    condition     = aws_cognito_user_pool_client.this.default_redirect_uri == "http://localhost:5173/auth/callback"
+    error_message = "App client should use the local callback URL as the default redirect URI."
+  }
+
+  assert {
     condition     = try(contains(aws_cognito_user_pool_client.this.read_attributes, "custom:tenant_id"), false)
     error_message = "App client should expose custom:tenant_id as a readable attribute."
   }
@@ -41,5 +86,10 @@ run "exposes_tenant_id_claim_for_api_auth" {
   assert {
     condition     = try(contains(aws_cognito_user_pool_client.this.write_attributes, "custom:tenant_id"), false) == false
     error_message = "App client should not allow writing custom:tenant_id."
+  }
+
+  assert {
+    condition     = aws_cognito_user_pool_domain.this.domain == "leaseflow-dev-example"
+    error_message = "Cognito should create the managed Hosted UI domain from the configured prefix."
   }
 }

--- a/infra/modules/cognito/variables.tf
+++ b/infra/modules/cognito/variables.tf
@@ -3,6 +3,31 @@ variable "name_prefix" {
   description = "Prefix for Cognito resources."
 }
 
+variable "aws_region" {
+  type        = string
+  description = "AWS region used to build the Cognito Hosted UI URL."
+}
+
+variable "hosted_ui_domain_prefix" {
+  type        = string
+  description = "Globally unique Cognito managed Hosted UI domain prefix."
+}
+
+variable "callback_urls" {
+  type        = list(string)
+  description = "Allowed OAuth callback URLs for the browser frontend."
+}
+
+variable "logout_urls" {
+  type        = list(string)
+  description = "Allowed OAuth logout return URLs for the browser frontend."
+}
+
+variable "default_redirect_uri" {
+  type        = string
+  description = "Default redirect URI for the Cognito app client."
+}
+
 variable "tags" {
   type        = map(string)
   description = "Common tags."


### PR DESCRIPTION
## What changed and why

This PR adds the browser-auth and browser-API foundation required for the future LeaseFlow frontend, without building the frontend UI yet.

Changes included:
- extend the Cognito module to support Hosted UI browser login
  - managed domain prefix
  - OAuth code flow
  - `openid` and `email` scopes
  - Cognito-only identity provider
  - callback/logout URL support
  - Hosted UI base URL output
- keep existing smoke-test auth support by preserving `ALLOW_ADMIN_USER_PASSWORD_AUTH`
- extend the HTTP API module with explicit browser CORS inputs and `cors_configuration`
- wire the dev environment to:
  - allow `http://localhost:5173`
  - optionally allow one future hosted HTTPS frontend origin
  - compute callback/logout URLs from configured origins
  - expose the Cognito Hosted UI base URL as a dev output
- update Terraform module tests and dev validation coverage
- update docs so they no longer claim Hosted UI and browser CORS are missing

## Assumptions

- This PR does not build the frontend app itself.
- This PR does not add CloudFront hosting yet.
- The browser frontend will continue using Cognito ID tokens because the backend depends on `custom:tenant_id` in validated JWT claims.
- The Hosted UI uses a Cognito-managed domain prefix in this phase, not a custom domain.
- Operators must provide a globally unique `cognito_hosted_ui_domain_prefix` before dev apply.

## Security validation

- Tenant isolation remains unchanged: backend tenant context still comes from validated Cognito JWT claims, not request body input.
- Browser auth is configured for Hosted UI / OAuth code flow, while admin auth stays outside the browser for smoke/demo tooling only.
- API CORS is allowlist-based, not wildcard-based.
- `allow_credentials = false`; browser calls use bearer tokens, not cookie-based cross-site credentials.
- Docs explicitly state that CORS is not authentication or authorization.
- No change makes RDS public.

## Cost validation

- No new AWS service category was added.
- This reuses the existing Cognito and API Gateway resources by extending their configuration.
- Cost impact should remain negligible for the dev stack.

## Remaining risks / TODOs

- A real browser frontend still does not exist yet.
- The dev stack will fail at apply time if `cognito_hosted_ui_domain_prefix` is not set to a globally unique value.
- Hosted frontend deployment is still later work.
- Next ticket: `#92 Build React + Vite + TypeScript frontend shell with auth, properties, and leases flows`.
