### PR TITLE
fix: include profile scope for hosted ui tenant claim

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -90,5 +90,7 @@ npm run build
 - Browser auth uses Cognito Hosted UI, not admin auth APIs.
 - Protected API calls use the Cognito `id_token` because the backend depends on
   `custom:tenant_id`.
+- Hosted UI requests `openid email profile` so readable custom attributes can
+  be included in the ID token.
 - Session state is stored in `sessionStorage`.
 - Do not commit `.env.local`, tokens, tenant IDs, or any real user data.

--- a/frontend/src/lib/auth.test.ts
+++ b/frontend/src/lib/auth.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { buildHostedUiAuthorizeUrl } from "./auth";
+
+describe("Hosted UI auth", () => {
+  it("requests profile scope so ID tokens include readable custom attributes", () => {
+    const redirectUrl = new URL(
+      buildHostedUiAuthorizeUrl(
+        {
+          apiBaseUrl: "https://api.example.com/dev",
+          cognitoClientId: "client-id",
+          cognitoHostedUiBaseUrl: "https://leaseflow.auth.eu-north-1.amazoncognito.com",
+        },
+        "code-challenge",
+        "oauth-state"
+      )
+    );
+
+    expect(redirectUrl.pathname).toBe("/oauth2/authorize");
+    expect(redirectUrl.searchParams.get("scope")).toBe("openid email profile");
+  });
+});

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -140,6 +140,14 @@ export async function redirectToHostedUiSignIn(
 
   storePendingSignIn(verifier, oauthState, returnPath);
 
+  window.location.assign(buildHostedUiAuthorizeUrl(config, challenge, oauthState));
+}
+
+export function buildHostedUiAuthorizeUrl(
+  config: RuntimeConfig,
+  challenge: string,
+  oauthState: string
+) {
   const authorizeUrl = new URL(
     `${normalizeBaseUrl(config.cognitoHostedUiBaseUrl)}/oauth2/authorize`
   );
@@ -147,12 +155,12 @@ export async function redirectToHostedUiSignIn(
   authorizeUrl.searchParams.set("client_id", config.cognitoClientId);
   authorizeUrl.searchParams.set("redirect_uri", getRedirectUri());
   authorizeUrl.searchParams.set("response_type", "code");
-  authorizeUrl.searchParams.set("scope", "openid email");
+  authorizeUrl.searchParams.set("scope", "openid email profile");
   authorizeUrl.searchParams.set("code_challenge_method", "S256");
   authorizeUrl.searchParams.set("code_challenge", challenge);
   authorizeUrl.searchParams.set("state", oauthState);
 
-  window.location.assign(authorizeUrl.toString());
+  return authorizeUrl.toString();
 }
 
 export function redirectToHostedUiSignOut(config: RuntimeConfig) {

--- a/infra/modules/cognito/main.tf
+++ b/infra/modules/cognito/main.tf
@@ -11,6 +11,7 @@ locals {
   app_client_allowed_oauth_scopes = [
     "email",
     "openid",
+    "profile",
   ]
   app_client_read_attributes = [
     "custom:tenant_id",

--- a/infra/modules/cognito/tests/defaults.tftest.hcl
+++ b/infra/modules/cognito/tests/defaults.tftest.hcl
@@ -54,6 +54,11 @@ run "exposes_tenant_id_claim_for_api_auth" {
   }
 
   assert {
+    condition     = try(contains(aws_cognito_user_pool_client.this.allowed_oauth_scopes, "profile"), false)
+    error_message = "App client should allow the profile OAuth scope for readable custom attributes."
+  }
+
+  assert {
     condition     = try(contains(aws_cognito_user_pool_client.this.supported_identity_providers, "COGNITO"), false)
     error_message = "App client should use Cognito as the supported identity provider."
   }

--- a/migration-payload.json
+++ b/migration-payload.json
@@ -1,0 +1,1 @@
+{"source":"leaseflow.internal","detail-type":"run_db_migrations","detail":{}}

--- a/migration-response.json
+++ b/migration-response.json
@@ -1,0 +1,1 @@
+{"statusCode": 200, "headers": {"Content-Type": "application/json"}, "body": "{\"target_revision\": \"head\", \"previous_revision\": null, \"current_revision\": \"20260409_0006\"}"}


### PR DESCRIPTION
## What changed and why

This PR fixes the Hosted UI browser auth scope so Cognito ID tokens include the readable `custom:tenant_id` claim required by the backend.

Manual browser smoke testing showed that:
- the Cognito user had `custom:tenant_id`
- the frontend stored an ID token
- the ID token did not include `custom:tenant_id`
- protected API calls reached Lambda but failed with the missing tenant claim error

The fix adds the `profile` OAuth scope to the Cognito app client and requests `openid email profile` from the frontend Hosted UI authorize URL.

## Security validation

Tenant isolation remains unchanged. The backend still derives tenant context from validated JWT claims only.

The frontend still does not send `tenant_id` in request bodies, and admin auth flows remain outside browser use.

## Cost validation

No new AWS resources were added. This only changes Cognito app client configuration and frontend auth request parameters.

## Verification

- `npm run test`
- `npm run lint`
- `npm run build`
- `terraform test` in `infra/modules/cognito`
- `terraform init -backend=false && terraform validate` in `infra/environments/dev`
- `git diff --check`

## Remaining risks / TODOs

After deploy, the dev stack must be re-applied and the browser session must be refreshed:
- sign out
- clear `sessionStorage`
- sign in again through Hosted UI
- verify the decoded ID token includes `custom:tenant_id`
- retry `GET /properties`
