### PR TITLE
frontend: fix lease list separator and swallow submit failures

### DIFF
--- a/frontend/src/pages/LeasesPage.test.tsx
+++ b/frontend/src/pages/LeasesPage.test.tsx
@@ -13,6 +13,7 @@ describe("LeasesPage", () => {
   beforeEach(() => {
     createLease.mockReset();
     createLease.mockResolvedValue(undefined);
+    mockedUseLeasesPageState.mockReset();
   });
 
   it("disables lease creation until a property exists", () => {
@@ -29,6 +30,43 @@ describe("LeasesPage", () => {
 
     expect(screen.getByRole("button", { name: "Create lease" })).toBeDisabled();
     expect(screen.getByText(/Lease creation stays disabled/i)).toBeInTheDocument();
+  });
+
+  it("renders lease metadata with an ASCII separator", () => {
+    mockedUseLeasesPageState.mockReturnValue({
+      createLease,
+      error: null,
+      isLoading: false,
+      isSubmitting: false,
+      leases: [
+        {
+          created_at: "2026-04-24T08:00:00Z",
+          end_date: "2026-05-30",
+          lease_id: "lease-1",
+          property_id: "property-1",
+          rent_due_day_of_month: 24,
+          resident_name: "Airbnb customer",
+          start_date: "2026-04-24",
+          tenant_id: "tenant-a",
+        },
+      ],
+      properties: [
+        {
+          address: "First street",
+          created_at: "2026-04-22T08:00:00Z",
+          name: "First property",
+          property_id: "property-1",
+          tenant_id: "tenant-a",
+        },
+      ],
+    });
+
+    render(<LeasesPage />);
+
+    expect(
+      screen.getByText("Due day 24 | 2026-04-24 to 2026-05-30")
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Â·/)).not.toBeInTheDocument();
   });
 
   it("uses the selected property value when creating a lease", async () => {
@@ -86,5 +124,62 @@ describe("LeasesPage", () => {
     });
 
     expect(createLease.mock.calls[0][0]).not.toHaveProperty("tenant_id");
+  });
+
+  it("keeps form values when lease creation fails", async () => {
+    createLease.mockRejectedValue(new Error("Create failed"));
+    mockedUseLeasesPageState.mockReturnValue({
+      createLease,
+      error: null,
+      isLoading: false,
+      isSubmitting: false,
+      leases: [],
+      properties: [
+        {
+          address: "First street",
+          created_at: "2026-04-22T08:00:00Z",
+          name: "First property",
+          property_id: "property-1",
+          tenant_id: "tenant-a",
+        },
+        {
+          address: "Second street",
+          created_at: "2026-04-22T08:00:00Z",
+          name: "Second property",
+          property_id: "property-2",
+          tenant_id: "tenant-a",
+        },
+      ],
+    });
+
+    render(<LeasesPage />);
+
+    fireEvent.change(screen.getByLabelText("Property"), {
+      target: { value: "property-2" },
+    });
+    fireEvent.change(screen.getByLabelText("Resident name"), {
+      target: { value: "Kaisa Tenant" },
+    });
+    fireEvent.change(screen.getByLabelText("Rent due day"), {
+      target: { value: "9" },
+    });
+    fireEvent.change(screen.getByLabelText("Start date"), {
+      target: { value: "2026-07-01" },
+    });
+    fireEvent.change(screen.getByLabelText("End date"), {
+      target: { value: "2026-07-31" },
+    });
+
+    fireEvent.submit(screen.getByRole("button", { name: "Create lease" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(createLease).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.getByLabelText("Property")).toHaveValue("property-2");
+    expect(screen.getByLabelText("Resident name")).toHaveValue("Kaisa Tenant");
+    expect(screen.getByLabelText("Rent due day")).toHaveValue(9);
+    expect(screen.getByLabelText("Start date")).toHaveValue("2026-07-01");
+    expect(screen.getByLabelText("End date")).toHaveValue("2026-07-31");
   });
 });

--- a/frontend/src/pages/LeasesPage.tsx
+++ b/frontend/src/pages/LeasesPage.tsx
@@ -39,15 +39,19 @@ export function LeasesPage() {
       return;
     }
 
-    await createLease({
-      end_date: form.endDate,
-      property_id: selectedPropertyId,
-      rent_due_day_of_month: Number(form.rentDueDayOfMonth),
-      resident_name: form.residentName.trim(),
-      start_date: form.startDate,
-    });
+    try {
+      await createLease({
+        end_date: form.endDate,
+        property_id: selectedPropertyId,
+        rent_due_day_of_month: Number(form.rentDueDayOfMonth),
+        resident_name: form.residentName.trim(),
+        start_date: form.startDate,
+      });
 
-    setForm(createInitialLeaseForm(selectedPropertyId));
+      setForm(createInitialLeaseForm(selectedPropertyId));
+    } catch {
+      // The hook already exposes the user-facing error message.
+    }
   }
 
   return (
@@ -177,7 +181,7 @@ export function LeasesPage() {
                 <div>
                   <p className="resource-title">{lease.resident_name}</p>
                   <p className="resource-subtitle">
-                    Due day {lease.rent_due_day_of_month} · {lease.start_date} to {lease.end_date}
+                    Due day {lease.rent_due_day_of_month} | {lease.start_date} to {lease.end_date}
                   </p>
                 </div>
                 <code className="resource-meta">property {lease.property_id.slice(0, 8)}</code>

--- a/frontend/src/pages/PropertiesPage.test.tsx
+++ b/frontend/src/pages/PropertiesPage.test.tsx
@@ -3,21 +3,24 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PropertiesPage } from "./PropertiesPage";
 
 const createProperty = vi.fn();
+const mockedUsePropertiesPageState = vi.fn();
 
 vi.mock("../features/properties/usePropertiesPage", () => ({
-  usePropertiesPageState: () => ({
-    createProperty,
-    error: null,
-    isLoading: false,
-    isSubmitting: false,
-    properties: [],
-  }),
+  usePropertiesPageState: () => mockedUsePropertiesPageState(),
 }));
 
 describe("PropertiesPage", () => {
   beforeEach(() => {
     createProperty.mockReset();
     createProperty.mockResolvedValue(undefined);
+    mockedUsePropertiesPageState.mockReset();
+    mockedUsePropertiesPageState.mockReturnValue({
+      createProperty,
+      error: null,
+      isLoading: false,
+      isSubmitting: false,
+      properties: [],
+    });
   });
 
   it("submits a property payload without tenant_id", async () => {
@@ -39,5 +42,27 @@ describe("PropertiesPage", () => {
     });
 
     expect(createProperty.mock.calls[0][0]).not.toHaveProperty("tenant_id");
+  });
+
+  it("keeps form values when property creation fails", async () => {
+    createProperty.mockRejectedValue(new Error("Create failed"));
+
+    render(<PropertiesPage />);
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "North Yard Block A" },
+    });
+    fireEvent.change(screen.getByLabelText("Address"), {
+      target: { value: "Fjordinkatu 12, Helsinki" },
+    });
+
+    fireEvent.submit(screen.getByRole("button", { name: "Create property" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(createProperty).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.getByLabelText("Name")).toHaveValue("North Yard Block A");
+    expect(screen.getByLabelText("Address")).toHaveValue("Fjordinkatu 12, Helsinki");
   });
 });

--- a/frontend/src/pages/PropertiesPage.tsx
+++ b/frontend/src/pages/PropertiesPage.tsx
@@ -18,11 +18,15 @@ export function PropertiesPage() {
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    await createProperty({
-      address: form.address.trim(),
-      name: form.name.trim(),
-    });
-    setForm(INITIAL_FORM);
+    try {
+      await createProperty({
+        address: form.address.trim(),
+        name: form.name.trim(),
+      });
+      setForm(INITIAL_FORM);
+    } catch {
+      // The hook already exposes the user-facing error message.
+    }
   }
 
   return (


### PR DESCRIPTION
## What changed and why

This PR polishes the first LeaseFlow browser frontend slice by fixing two issues found during review:

- Lease list metadata now uses a stable ASCII separator (`|`) instead of a mojibake/encoding artifact.
- Property and lease create form submit handlers catch rejected create calls locally so failures do not bubble as unhandled promise rejections in the browser console.

The hook-level `error` state remains the user-facing error source. On failed submits, the form values are preserved.

## Security validation

- Tenant isolation behavior is unchanged.
- The frontend still does not send `tenant_id` in create payloads.
- No changes to auth, JWT handling, backend authorization, or Terraform.

## Cost validation

- No AWS resources or cost-impacting infrastructure changes.

## Verification

- `cd frontend && npm run lint`
- `cd frontend && npm run test`
- `cd frontend && npm run build`
- `git diff --check`

Note: `npm run test` and `npm run build` were run outside the local sandbox due to a Windows `spawn EPERM` restriction affecting Vite startup inside the sandbox. This does not apply to GitHub Actions (Ubuntu runner).

## Remaining risks / TODOs

- Verify CI passes on the PR run.
