### PR TITLE
docs: clarify daily WSL backend workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ make lint
 make test
 ```
 
+For everyday backend and database development in WSL, use the local PostgreSQL
+workflow in `backend/README.md` instead of keeping the AWS dev RDS instance
+running.
+
 Migration command:
 
 ```bash

--- a/backend/README.md
+++ b/backend/README.md
@@ -24,10 +24,20 @@ Python Lambda backend for LeaseFlow MVP.
 
 ## Local setup
 
+For WSL/Linux:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -e ".[dev]"
+```
+
+For Windows PowerShell:
+
 ```bash
 python -m venv .venv
-. .venv/Scripts/activate
-pip install -e ".[dev]"
+.venv\Scripts\Activate.ps1
+python -m pip install -e ".[dev]"
 ```
 
 ## Local PostgreSQL in WSL
@@ -54,12 +64,68 @@ Then create a local env file from the example and load it before running backend
 
 ```bash
 cp .env.local.example .env.local
+sed -i 's/\r$//' .env.local
 set -a
 source .env.local
 set +a
 ```
 
-If you are working from the repo root in WSL with the backend virtual environment activated, you can then use:
+## Daily WSL workflow
+
+Run these commands from the repo root unless the command explicitly says
+`backend/`.
+
+What it does: activates the backend virtual environment from WSL.
+Target filename/service: `backend/.venv`.
+
+```bash
+cd /mnt/c/Repos/LeaseFlow/backend
+source .venv/bin/activate
+```
+
+What it does: loads the local backend DB configuration.
+Target filename/service: `backend/.env.local`.
+
+```bash
+set -a
+source .env.local
+set +a
+export DATABASE_URL="postgresql+psycopg://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
+```
+
+What it does: applies Alembic migrations to the local WSL PostgreSQL database.
+Target filename/service: local `leaseflow` PostgreSQL schema.
+
+```bash
+python -m alembic upgrade head
+```
+
+What it does: runs the root Makefile local backend targets.
+Target filename/service: repo root `Makefile`.
+
+```bash
+cd /mnt/c/Repos/LeaseFlow
+make test-local
+make test-integration-local
+make invoke-local-health
+make invoke-local-create-property
+make invoke-local-list-properties
+```
+
+Important:
+
+- Root-level `make` targets such as `make test-local` must be run from the repo
+  root, not from `backend/`.
+- WSL activation uses `source .venv/bin/activate`, not
+  `.venv/Scripts/activate`.
+- If `.env.local` was created from Windows tools, normalize line endings with
+  `sed -i 's/\r$//' .env.local` before sourcing it.
+- This local PostgreSQL path is for backend and DB development only. It does
+  not replace Cognito Hosted UI, API Gateway, or browser CORS validation in
+  AWS.
+
+If you are working from the repo root in WSL with the backend virtual
+environment already activated, you can also use:
 
 ```bash
 make migrate-local


### PR DESCRIPTION
## What changed and why

This PR clarifies the daily local backend workflow for LeaseFlow when using WSL PostgreSQL.

The existing repo already supported local backend and DB development, but the guidance was easy to misuse in practice:
- WSL activation was easy to mix up with Windows virtualenv activation
- local backend `make` targets live in the repo root `Makefile`, not under `backend/`
- `.env.local` sourced from Windows-created files may require LF normalization
- it was not explicit enough that local PostgreSQL is only for backend/DB development, not a full replacement for the AWS browser auth path

The updated docs now provide one clear WSL happy-path workflow for:
- activating the backend venv
- loading `.env.local`
- running Alembic locally
- running local backend checks from repo root
- invoking local handler paths

## Assumptions

- WSL PostgreSQL remains the preferred low-cost path for everyday backend development.
- The existing root `Makefile` local targets remain the source of truth.
- This PR is docs-only and does not change backend, Terraform, CI, or AWS resources.

## Security validation

- Tenant isolation behavior is unchanged.
- The docs explicitly keep the local WSL path limited to backend and DB development.
- The docs do not claim that local PostgreSQL replaces Cognito Hosted UI, API Gateway, or browser CORS validation in AWS.
- No secrets, JWTs, tenant IDs, SSM values, or DB connection strings were added beyond the existing local example pattern.

## Cost validation

- No AWS services or infrastructure were added.
- The documented workflow reinforces a lower-cost local backend development path by avoiding unnecessary dev RDS runtime for everyday work.

## Verification

- `git diff --check`

## Remaining risks / TODOs

- The date-sensitive integration test tracked in `#105` still needs a separate fix.
