### PR TITLE
test: stabilize lease reminder integration date coverage

### DIFF
--- a/backend/tests/test_db_integration.py
+++ b/backend/tests/test_db_integration.py
@@ -975,9 +975,9 @@ def test_update_lease_changes_due_reminder_candidates(integration_settings: Sett
     db = Database(integration_settings)
     tenant_id = f"test-local-{uuid4().hex}"
     actor_user_id = f"user-{uuid4().hex[:12]}"
-    today = date.today()
-    next_year = today.replace(year=today.year + 1)
-    original_due_day = today.day + 10 if today.day <= 18 else 28
+    as_of_date = date(2026, 4, 3)
+    original_due_day = 20
+    updated_due_day = 5
 
     try:
         property_record = db.create_property(
@@ -992,13 +992,13 @@ def test_update_lease_changes_due_reminder_candidates(integration_settings: Sett
             property_id=property_record.property_id,
             resident_name="Reminder Candidate Resident",
             rent_due_day_of_month=original_due_day,
-            start_date=today,
-            end_date=next_year,
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
         )
 
         before = db.list_due_lease_reminders(
             tenant_id=tenant_id,
-            as_of_date=today,
+            as_of_date=as_of_date,
             days=7,
         )
 
@@ -1006,12 +1006,12 @@ def test_update_lease_changes_due_reminder_candidates(integration_settings: Sett
             tenant_id=tenant_id,
             actor_user_id=actor_user_id,
             lease_id=created.lease_id,
-            updates={"rent_due_day_of_month": today.day},
+            updates={"rent_due_day_of_month": updated_due_day},
         )
 
         after = db.list_due_lease_reminders(
             tenant_id=tenant_id,
-            as_of_date=today,
+            as_of_date=as_of_date,
             days=7,
         )
 


### PR DESCRIPTION
## What changed and why

This PR fixes a date-sensitive local PostgreSQL integration test in [backend/tests/test_db_integration.py](c:\Repos\LeaseFlow\backend\tests\test_db_integration.py).

The failing test `test_update_lease_changes_due_reminder_candidates` previously depended on:
- `date.today()`
- a month-end heuristic for the original due day

That made the test calendar-sensitive. On some days, the “before” lease due date still landed inside the 7-day reminder window, so the test failed even though the reminder logic was behaving correctly.

The test now uses:
- a fixed `as_of_date`
- a deterministic original due day outside the 7-day window
- a deterministic updated due day inside the 7-day window
- fixed lease start and end dates covering the entire test window

This keeps the original intent intact:
- `before` has no reminder candidates
- `after` contains the updated lease

No production code, reminder logic, database schema, Terraform, or AWS configuration was changed.

## Assumptions

- The bug was in test setup, not in `Database.list_due_lease_reminders` or `_next_due_date`.
- A fixed date is the correct approach here because the test is validating reminder inclusion/exclusion behavior, not real-time calendar behavior.
- The existing reminder logic is already covered correctly by the passing reminder integration tests in the same file.

## Security validation

- Tenant isolation behavior is unchanged.
- The test still creates tenant-scoped properties and leases and queries reminders by `tenant_id`.
- No JWT handling, auth context, or backend tenant filtering logic was changed.

## Cost validation

- No AWS services were added or changed.
- No infrastructure or runtime cost impact.

## Verification

Verified in the local WSL PostgreSQL workflow:

- `cd /mnt/c/Repos/LeaseFlow/backend && source .venv/bin/activate && set -a && . ./.env.local && set +a && LEASEFLOW_RUN_DB_INTEGRATION=1 python -m pytest -q tests/test_db_integration.py -k update_lease_changes_due_reminder_candidates`
- `cd /mnt/c/Repos/LeaseFlow/backend && source .venv/bin/activate && set -a && . ./.env.local && set +a && LEASEFLOW_RUN_DB_INTEGRATION=1 python -m pytest -q tests/test_db_integration.py`
- `cd /mnt/c/Repos/LeaseFlow && source backend/.venv/bin/activate && make test-integration-local`
- `git diff --check`

Results:
- targeted reminder update test passed
- full DB integration file passed
- repo-root `make test-integration-local` passed when run with `backend/.venv` activated

## Remaining risks / TODOs

- The repo-root `make test-integration-local` target still assumes a Python environment is already active in the shell. That is a local workflow/documentation concern, not part of this test fix.
