### PR TITLE
docs: sync frontend mvp state

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,14 @@ Implemented now:
 - Alembic migrations for property, lease, and notification tables
 - Terraform modules for network, RDS, Cognito, Lambda, and API Gateway
 - Local portfolio demo client for the deployed MVP flow
-- Local browser frontend slice with Hosted UI auth plus properties and leases
+- Real browser frontend slice with Hosted UI auth plus properties and leases
   list/create flows
 - Terraform-managed S3 + CloudFront hosting path for the frontend SPA
 
 Planned next:
 
+- Complete hosted frontend smoke validation after the dev Terraform remote
+  state source of truth is fixed.
 - Extend the browser frontend with reminders and notifications.
 - Add delivery behavior on top of persisted notifications
 - Add more automated backend and tenant-isolation test coverage

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -62,12 +62,12 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
 
 ## Frontend Direction
 
-- The current browser-facing helper is `demo-client`, which is local demo
-  tooling and not the future production-like frontend.
+- `demo-client` remains local demo/operator tooling and is separate from the
+  real browser frontend.
 - The real frontend direction is documented in
   `docs/frontend-mvp-strategy.md`.
 - The chosen frontend direction is React + Vite + TypeScript, and the first
-  local browser slice now exists under `frontend/`.
+  browser slice now exists under `frontend/`.
 - Dev Terraform now provides Cognito Hosted UI foundation through a managed
   domain and OAuth Authorization Code + PKCE-capable app client settings.
 - Dev Terraform now provides allowlisted browser CORS on the HTTP API for
@@ -76,7 +76,9 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
   list/create flows.
 - Terraform now defines a private S3 + CloudFront hosting path for the static
   SPA.
-- Asset upload, reminders, and notifications UI are still follow-up work.
+- Hosted asset upload and browser smoke validation are operator-run release
+  validation steps, not CI deployment automation.
+- Dashboard, reminders, and notifications UI are still follow-up work.
 
 ## Operational Runbooks
 

--- a/docs/frontend-mvp-strategy.md
+++ b/docs/frontend-mvp-strategy.md
@@ -22,12 +22,14 @@ local portfolio/demo tool and not the production-like frontend path.
   sign-in plus properties and leases list/create flows.
 - The dev Terraform stack now includes an S3 + CloudFront hosting path for the
   static SPA. Asset upload remains a local operator command.
+- Hosted frontend smoke validation is still an operator-run release validation
+  item, not an implemented CI deployment path.
 - Dashboard, reminders, and notifications UI are still follow-up work.
 
 ## Chosen Frontend Direction
 
 - Real frontend target: `React + Vite + TypeScript`
-- Real frontend location: future `frontend/` directory
+- Real frontend location: `frontend/` directory
 - Local development mode: Vite dev server on `http://localhost:5173`
 - Hosting target: static SPA assets in private S3 behind CloudFront
 - This phase does not add SSR, Next.js, or a separate backend-for-frontend
@@ -50,10 +52,10 @@ local portfolio/demo tool and not the production-like frontend path.
 ## CORS Contract
 
 - API Gateway CORS is allowlist-based, not wildcard-based.
-- Planned local origin: `http://localhost:5173`
+- Local origin: `http://localhost:5173`
 - Hosted origin: HTTPS CloudFront-backed SPA origin from Terraform output
-- Planned browser methods: `GET`, `POST`, `PATCH`, `OPTIONS`
-- Planned browser headers: `Authorization`, `Content-Type`
+- Browser methods: `GET`, `POST`, `PATCH`, `OPTIONS`
+- Browser headers: `Authorization`, `Content-Type`
 - Browser API calls use bearer tokens in the `Authorization` header, not
   cookie-based cross-site credentials.
 - Current Terraform uses `allow_credentials = false` for the browser path.
@@ -85,12 +87,14 @@ Later frontend follow-ups:
 - dashboard summary UI
 - due reminders UI
 - notifications list and mark-read UI
-- hosted asset upload and validation workflow
+- hosted asset upload and browser smoke validation before release
 
 ## Follow-Up Tickets
 
-- Add dashboard, due reminders, and notifications UI after the hosted browser
-  path is validated.
+- Complete hosted frontend smoke validation after the dev Terraform state
+  source of truth is restored.
+- Add property and lease update flows, then dashboard, due reminders, and
+  notifications UI.
 
 ## Guardrails
 

--- a/docs/mvp-scope.md
+++ b/docs/mvp-scope.md
@@ -20,6 +20,11 @@
 - EventBridge Scheduler for daily invocation of the internal reminder scan.
 - Infrastructure provisioning with Terraform modules.
 - Dev-focused deployment architecture on AWS Lambda + API Gateway.
+- Real browser frontend slice under `frontend/` with Cognito Hosted UI
+  sign-in/sign-out, protected routes, and properties/leases list/create flows.
+- Terraform-managed static SPA hosting path with private S3 and CloudFront.
+  Hosted asset upload and browser smoke validation remain operator-run release
+  validation, not a CI deploy pipeline.
 
 ## Data Scope (Current MVP)
 
@@ -45,4 +50,6 @@
 - Email delivery and external notification integrations.
 - PostgreSQL Row-Level Security (future hardening).
 - NAT Gateway and non-essential managed services.
-- Frontend implementation.
+- Dashboard summary UI.
+- Due reminders and notifications UI.
+- Custom domain, CI-based frontend deployment, and production readiness.


### PR DESCRIPTION
## What changed and why

This PR syncs the MVP docs with the current frontend-era state of LeaseFlow before the planned v0.3.0 release checkpoint.

The docs now reflect that:

- the real browser frontend exists under `frontend/`
- the current browser slice supports Hosted UI sign-in/sign-out plus properties and leases list/create flows
- Terraform defines the S3 + CloudFront static SPA hosting path
- hosted asset upload and browser smoke validation are still operator-run release validation, not CI deployment automation
- dashboard, due reminders UI, notifications UI, custom domain, CI frontend deploy, and production readiness remain follow-ups

This also removes the stale claim that frontend implementation is still out of scope.

## Assumptions

- #109 remains docs-only.
- #108 and #114 remain the right places to complete hosted smoke validation and fix the dev Terraform remote state source of truth.
- The docs should mention hosted validation state carefully without becoming an incident log.

## Security validation

Tenant isolation behavior is unchanged.

The docs continue to state that tenant context comes from validated Cognito JWT claims and is not trusted from browser request bodies. No backend auth, JWT validation, request payloads, Cognito settings, API Gateway settings, Terraform resources, or database behavior were changed.

## Cost validation

No AWS resources were added or changed.

This PR is documentation-only and does not run deployments, frontend uploads, CloudFront invalidations, Terraform apply, or CI deploy automation.

## Verification

- `git diff --check`
- `git diff --cached --check`
- Manual docs review for stale frontend/out-of-scope claims
- Manual review that docs do not claim hosted browser smoke has passed while #108/#114 remain unresolved
- Manual review for no secrets, JWTs, Cognito emails, tenant IDs, SSM values, DB endpoints, or raw evidence

## Remaining risks / TODOs

- Hosted frontend smoke validation still needs to be completed under #108 after the dev Terraform state source of truth is fixed in #114.