### PR TITLE
Add v0.3.0 frontend MVP release draft

### DIFF
--- a/docs/releases/v0.3.0-draft.md
+++ b/docs/releases/v0.3.0-draft.md
@@ -1,0 +1,47 @@
+# v0.3.0 - Frontend MVP Slice
+
+Draft status: release preparation only. Do not create the `v0.3.0` tag or GitHub Release until the final checklist is complete.
+
+## Summary
+
+`v0.3.0` is planned as the first frontend-era LeaseFlow release checkpoint. It builds on the validated `v0.2.0` backend and infrastructure MVP by adding a real browser frontend slice, browser-safe Cognito auth, CORS support, frontend CI checks, and a Terraform-managed S3 + CloudFront hosting path.
+
+This is still a dev/portfolio MVP release. It must not be described as production-ready.
+
+## Included Scope Since v0.2.0
+
+- Frontend MVP strategy documented, including the separation between `demo-client` operator tooling and the real browser frontend.
+- Cognito Hosted UI, OAuth authorization code + PKCE, and API Gateway browser CORS support added for approved frontend origins.
+- React + Vite + TypeScript browser frontend added under `frontend/`.
+- Browser sign-in/sign-out, protected navigation, properties list/create, and leases list/create implemented.
+- Hosted UI scope corrected so Cognito ID tokens can include readable custom attributes such as `custom:tenant_id`.
+- S3 + CloudFront frontend hosting infrastructure path added with private S3 and CloudFront Origin Access Control.
+- Frontend build, test, and lint checks added to CI.
+- Frontend form failure behavior and lease list text rendering polished.
+- MVP documentation synced with the implemented frontend and hosting state.
+
+## Important Boundaries
+
+- Hosted frontend browser smoke validation has not passed yet. It remains blocked by #114, which must restore the dev Terraform remote state source of truth before #108 can be completed end to end.
+- The S3 + CloudFront path exists in Terraform, but hosted asset upload and browser validation are still operator-run, not a CI deploy pipeline.
+- There is no custom domain, Route 53 setup, ACM certificate, WAF, SSR layer, Lambda@Edge customization, or production deployment strategy in this release.
+- Dashboard, due reminders UI, notifications UI, and browser update flows for properties and leases remain follow-up work.
+- Tenant isolation remains backend-enforced: tenant context comes from validated Cognito JWT claims, not from browser request body input.
+- The browser frontend must not use Cognito admin auth APIs or token-paste flows.
+
+## Draft Release Notes
+
+This release marks LeaseFlow's transition from a backend-only cloud MVP to a small but real browser MVP.
+
+The frontend now uses Cognito Hosted UI with OAuth authorization code + PKCE and calls the tenant-protected API directly from the browser. The first browser slice focuses on core flows only: sign-in, sign-out, properties, and leases. Broader product areas such as dashboard summaries, reminder views, notifications, update flows, and production hosting polish are intentionally deferred.
+
+The infrastructure now includes the foundation for static SPA hosting on private S3 behind CloudFront, and API Gateway CORS is configured for approved frontend origins. However, the hosted browser path is not yet release-validated because the dev Terraform remote state source of truth needs to be fixed before assets can be uploaded and tested safely.
+
+## Final Release Checklist
+
+- #114 is resolved and `terraform output` returns the expected dev frontend hosting outputs from the configured remote backend.
+- #108 hosted frontend smoke validation is rerun and passes from the CloudFront origin.
+- `main` is clean and all required CI checks pass.
+- Release notes are reviewed for no secrets, JWTs, authorization headers, session storage values, Cognito user emails, tenant IDs, SSM values, DB endpoints, connection strings, property data, resident data, notification text, raw response bodies, or screenshots with sensitive values.
+- The final GitHub Release keeps the dev/portfolio MVP framing and does not claim production readiness.
+- Only after the above items pass, create tag `v0.3.0` and publish the GitHub Release.


### PR DESCRIPTION
## Summary
- Add a tracked `v0.3.0` draft release note for the frontend-era LeaseFlow milestone.
- Document the included frontend, auth, CORS, hosting, CI, and docs work since `v0.2.0`.
- Call out the current release boundaries clearly: hosted smoke validation still depends on #114, and this is not production-ready.
- Include a final release checklist so the real tag and GitHub Release only happen after hosted validation passes.

## Testing
- `git diff --check` passed.
- Manual review confirmed the draft does not claim hosted smoke validation has passed, does not claim production readiness, and preserves tenant-isolation wording.
- Not run (not requested): application tests or deployment checks.