### PR TITLE
docs: record dev terraform state recovery

### DIFF
--- a/docs/runbooks/evidence/dev-terraform-state-recovery-2026-04-28.md
+++ b/docs/runbooks/evidence/dev-terraform-state-recovery-2026-04-28.md
@@ -1,0 +1,90 @@
+# Dev Terraform State Recovery Evidence - 2026-04-28
+
+## Summary
+
+Issue `#114` restored the dev Terraform remote state source of truth enough to
+continue hosted frontend validation in `#108`.
+
+Result:
+
+- Terraform planned a clean dev stack creation from the configured remote
+  backend.
+- The plan showed `51 to add, 0 to change, 0 to destroy`.
+- The dev stack was applied by the operator.
+- The configured remote state now contains managed resources.
+- Required frontend hosting outputs are available from Terraform.
+- A final `terraform plan` reported no changes.
+
+## Context
+
+- Date: 2026-04-28
+- Branch: `114-fix-dev-terraform-remote-state-source-of-truth-for-hosted-frontend-validation`
+- Related issue: `#114 Fix dev Terraform remote state source of truth for hosted frontend validation`
+- Follow-up issue unblocked: `#108 Execute hosted frontend deployment and browser smoke validation`
+- Region: `eu-north-1`
+
+## Commands And Results
+
+Terraform formatting:
+
+```text
+make tf-fmt: attempted by operator, unavailable in the first shell
+```
+
+Terraform initialization and plan were rerun from the correct LeaseFlow dev
+environment path with the intended backend configuration.
+
+Pre-apply plan:
+
+```text
+terraform plan: 51 to add, 0 to change, 0 to destroy
+```
+
+Post-apply state check:
+
+```text
+terraform state list | wc -l: 60
+```
+
+Frontend hosting output checks:
+
+```text
+terraform output -raw frontend_bucket_name: succeeded
+terraform output -raw frontend_cloudfront_distribution_id: succeeded
+terraform output -raw frontend_cloudfront_url: succeeded
+```
+
+State locking:
+
+```text
+post-apply terraform plan: initially blocked by a stale apply state lock
+```
+
+Final drift check:
+
+```text
+terraform plan: No changes. Your infrastructure matches the configuration.
+```
+
+## Follow-Up
+
+`#108` can be resumed after this recovery because the configured dev remote
+state now exposes the frontend hosting outputs required for the hosted frontend
+asset upload, CloudFront invalidation, and browser smoke validation.
+
+## Evidence Hygiene
+
+This evidence intentionally does not include:
+
+- JWTs or Cognito tokens
+- authorization headers or session storage values
+- Cognito user emails
+- tenant IDs
+- property names or addresses
+- resident names or lease IDs
+- notification titles or messages
+- SSM values or DB connection strings
+- RDS endpoints
+- Terraform state contents
+- raw Terraform output values
+- raw browser response payloads


### PR DESCRIPTION
## What changed and why

This PR records sanitized evidence for #114 after the dev Terraform remote state source of truth was restored by standing up the dev stack from the configured remote backend.

The tracked repo change is limited to one evidence document:

- `docs/runbooks/evidence/dev-terraform-state-recovery-2026-04-28.md`

## Validation captured

- `terraform plan` before apply showed `51 to add, 0 to change, 0 to destroy`.
- `terraform state list | wc -l` returned `60` after apply.
- Required frontend hosting outputs were available from Terraform.
- A stale apply lock was encountered during post-apply validation and then resolved.
- Final `terraform plan` reported: `No changes. Your infrastructure matches the configuration.`

## Security validation

Tenant isolation behavior is unchanged.

This PR does not modify backend auth, JWT validation, frontend request payloads, API Gateway, Cognito, database behavior, or Terraform code. The evidence intentionally excludes JWTs, authorization headers, session storage values, Cognito user emails, tenant IDs, SSM values, DB endpoints, Terraform state contents, raw Terraform output values, property data, resident data, notification content, and raw response payloads.

## Cost validation

No Terraform code was changed in this PR, but the #114 operator action did create or restore the real dev AWS stack from Terraform.

This PR itself does not run `terraform apply`, upload frontend assets, create CloudFront invalidations, or add new AWS services beyond the stack already represented by the current Terraform configuration.

## Remaining risks / TODOs

- #108 still needs to be rerun to upload the frontend bundle, invalidate CloudFront if needed, and validate the hosted browser flow.
- The hosted browser smoke test has not passed as part of this PR.
