### PR TITLE
frontend: add property and lease update flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,14 +74,14 @@ Implemented now:
 - Terraform modules for network, RDS, Cognito, Lambda, and API Gateway
 - Local portfolio demo client for the deployed MVP flow
 - Real browser frontend slice with Hosted UI auth plus properties and leases
-  list/create flows
+  list/create/update flows
 - Terraform-managed S3 + CloudFront hosting path for the frontend SPA
 
 Planned next:
 
 - Complete hosted frontend smoke validation after the dev Terraform remote
   state source of truth is fixed.
-- Extend the browser frontend with reminders and notifications.
+- Extend the browser frontend with dashboard, reminders, and notifications.
 - Add delivery behavior on top of persisted notifications
 - Add more automated backend and tenant-isolation test coverage
 - Refine operational setup for scheduled workflows and monitoring

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -73,7 +73,7 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
 - Dev Terraform now provides allowlisted browser CORS on the HTTP API for
   approved frontend origins.
 - The browser frontend slice covers sign-in plus properties and leases
-  list/create flows.
+  list/create/update flows.
 - Terraform now defines a private S3 + CloudFront hosting path for the static
   SPA.
 - Hosted asset upload and browser smoke validation are operator-run release

--- a/docs/frontend-mvp-strategy.md
+++ b/docs/frontend-mvp-strategy.md
@@ -19,7 +19,7 @@ local portfolio/demo tool and not the production-like frontend path.
 - The dev Terraform stack now configures allowlisted browser CORS on the HTTP
   API for approved frontend origins.
 - The first local browser frontend slice now exists under `frontend/` with
-  sign-in plus properties and leases list/create flows.
+  sign-in plus properties and leases list/create/update flows.
 - The dev Terraform stack now includes an S3 + CloudFront hosting path for the
   static SPA. Asset upload remains a local operator command.
 - Hosted frontend smoke validation is still an operator-run release validation
@@ -77,10 +77,8 @@ Current implemented slice:
 
 - sign in / sign out
 - app shell and navigation
-- properties list and create flow
-- leases list and create flow
-- properties and leases structure remains update-ready for later PATCH route
-  support
+- properties list, create, and update flow
+- leases list, create, and update flow
 
 Later frontend follow-ups:
 
@@ -93,8 +91,7 @@ Later frontend follow-ups:
 
 - Complete hosted frontend smoke validation after the dev Terraform state
   source of truth is restored.
-- Add property and lease update flows, then dashboard, due reminders, and
-  notifications UI.
+- Add dashboard, due reminders, and notifications UI.
 
 ## Guardrails
 

--- a/docs/mvp-scope.md
+++ b/docs/mvp-scope.md
@@ -21,7 +21,8 @@
 - Infrastructure provisioning with Terraform modules.
 - Dev-focused deployment architecture on AWS Lambda + API Gateway.
 - Real browser frontend slice under `frontend/` with Cognito Hosted UI
-  sign-in/sign-out, protected routes, and properties/leases list/create flows.
+  sign-in/sign-out, protected routes, and properties/leases
+  list/create/update flows.
 - Terraform-managed static SPA hosting path with private S3 and CloudFront.
   Hosted asset upload and browser smoke validation remain operator-run release
   validation, not a CI deploy pipeline.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -11,8 +11,8 @@ tool.
 - Cognito Hosted UI sign in and sign out
 - OAuth authorization code flow with PKCE
 - protected browser routes
-- properties list and create
-- leases list and create
+- properties list, create, and update
+- leases list, create, and update
 
 This slice does not include dashboard, reminders, or notifications UI yet.
 

--- a/frontend/src/features/leases/useLeasesPage.ts
+++ b/frontend/src/features/leases/useLeasesPage.ts
@@ -8,6 +8,7 @@ import {
   type Lease,
   type Property,
   UnauthorizedApiError,
+  type UpdateLeaseInput,
 } from "../../lib/api";
 import { getRuntimeConfig } from "../../lib/config";
 
@@ -18,6 +19,7 @@ type LeasesPageState = {
   isSubmitting: boolean;
   leases: Lease[];
   properties: Property[];
+  updateLease: (leaseId: string, input: UpdateLeaseInput) => Promise<void>;
 };
 
 export function useLeasesPageState(): LeasesPageState {
@@ -109,6 +111,39 @@ export function useLeasesPageState(): LeasesPageState {
     }
   }
 
+  async function updateLease(leaseId: string, input: UpdateLeaseInput) {
+    if (!auth.session) {
+      navigate("/", { replace: true });
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const client = createApiClient({
+        config: getRuntimeConfig(),
+        onUnauthorized: auth.markSessionExpired,
+        session: auth.session,
+      });
+      const updated = await client.updateLease(leaseId, input);
+      setLeases((current) =>
+        current.map((lease) => (lease.lease_id === updated.lease_id ? updated : lease))
+      );
+    } catch (errorValue) {
+      if (errorValue instanceof UnauthorizedApiError) {
+        navigate("/", { replace: true });
+        return;
+      }
+      setError(
+        errorValue instanceof ApiError ? errorValue.message : "Could not update the lease."
+      );
+      throw errorValue;
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
   return {
     createLease,
     error,
@@ -116,5 +151,6 @@ export function useLeasesPageState(): LeasesPageState {
     isSubmitting,
     leases,
     properties,
+    updateLease,
   };
 }

--- a/frontend/src/features/properties/usePropertiesPage.ts
+++ b/frontend/src/features/properties/usePropertiesPage.ts
@@ -7,6 +7,7 @@ import {
   type CreatePropertyInput,
   type Property,
   UnauthorizedApiError,
+  type UpdatePropertyInput,
 } from "../../lib/api";
 import { getRuntimeConfig } from "../../lib/config";
 
@@ -16,6 +17,7 @@ type PropertiesPageState = {
   isLoading: boolean;
   isSubmitting: boolean;
   properties: Property[];
+  updateProperty: (propertyId: string, input: UpdatePropertyInput) => Promise<void>;
 };
 
 export function usePropertiesPageState(): PropertiesPageState {
@@ -106,11 +108,49 @@ export function usePropertiesPageState(): PropertiesPageState {
     }
   }
 
+  async function updateProperty(propertyId: string, input: UpdatePropertyInput) {
+    if (!auth.session) {
+      navigate("/", { replace: true });
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const client = createApiClient({
+        config: getRuntimeConfig(),
+        onUnauthorized: auth.markSessionExpired,
+        session: auth.session,
+      });
+      const updated = await client.updateProperty(propertyId, input);
+      setProperties((current) =>
+        current.map((property) =>
+          property.property_id === updated.property_id ? updated : property
+        )
+      );
+    } catch (errorValue) {
+      if (errorValue instanceof UnauthorizedApiError) {
+        navigate("/", { replace: true });
+        return;
+      }
+      setError(
+        errorValue instanceof ApiError
+          ? errorValue.message
+          : "Could not update the property."
+      );
+      throw errorValue;
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
   return {
     createProperty,
     error,
     isLoading,
     isSubmitting,
     properties,
+    updateProperty,
   };
 }

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createApiClient } from "./api";
+
+const fetchMock = vi.fn();
+
+const clientOptions = {
+  config: {
+    apiBaseUrl: "https://api.example.com/dev/",
+    cognitoClientId: "client-id",
+    cognitoHostedUiBaseUrl: "https://auth.example.com",
+  },
+  onUnauthorized: vi.fn(),
+  session: {
+    accessToken: "access-token",
+    expiresAt: Date.now() + 60_000,
+    idToken: "id-token",
+    tokenType: "Bearer",
+  },
+};
+
+describe("createApiClient", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("patches a property without tenant_id", async () => {
+    const client = createApiClient(clientOptions);
+
+    await client.updateProperty("property-1", {
+      address: "Updated Street 2",
+      name: "Updated HQ",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/dev/properties/property-1",
+      expect.objectContaining({
+        method: "PATCH",
+      })
+    );
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer id-token",
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(String(init.body))).toEqual({
+      address: "Updated Street 2",
+      name: "Updated HQ",
+    });
+    expect(JSON.parse(String(init.body))).not.toHaveProperty("tenant_id");
+  });
+
+  it("patches a lease without tenant_id or property_id", async () => {
+    const client = createApiClient(clientOptions);
+
+    await client.updateLease("lease-1", {
+      end_date: "2026-12-31",
+      rent_due_day_of_month: 9,
+      resident_name: "Updated Resident",
+      start_date: "2026-06-01",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/dev/leases/lease-1",
+      expect.objectContaining({
+        method: "PATCH",
+      })
+    );
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer id-token",
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(String(init.body))).toEqual({
+      end_date: "2026-12-31",
+      rent_due_day_of_month: 9,
+      resident_name: "Updated Resident",
+      start_date: "2026-06-01",
+    });
+    expect(JSON.parse(String(init.body))).not.toHaveProperty("tenant_id");
+    expect(JSON.parse(String(init.body))).not.toHaveProperty("property_id");
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -33,6 +33,15 @@ export type CreateLeaseInput = {
   start_date: string;
 };
 
+export type UpdatePropertyInput = CreatePropertyInput;
+
+export type UpdateLeaseInput = {
+  end_date: string;
+  rent_due_day_of_month: number;
+  resident_name: string;
+  start_date: string;
+};
+
 type ListResponse<T> = {
   items: T[];
 };
@@ -115,6 +124,18 @@ export function createApiClient({ config, onUnauthorized, session }: ApiClientOp
     },
     listProperties() {
       return request<ListResponse<Property>>("/properties");
+    },
+    updateLease(leaseId: string, input: UpdateLeaseInput) {
+      return request<Lease>(`/leases/${encodeURIComponent(leaseId)}`, {
+        body: JSON.stringify(input),
+        method: "PATCH",
+      });
+    },
+    updateProperty(propertyId: string, input: UpdatePropertyInput) {
+      return request<Property>(`/properties/${encodeURIComponent(propertyId)}`, {
+        body: JSON.stringify(input),
+        method: "PATCH",
+      });
     },
   };
 }

--- a/frontend/src/pages/LeasesPage.test.tsx
+++ b/frontend/src/pages/LeasesPage.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LeasesPage } from "./LeasesPage";
 
 const createLease = vi.fn();
+const updateLease = vi.fn();
 const mockedUseLeasesPageState = vi.fn();
 
 vi.mock("../features/leases/useLeasesPage", () => ({
@@ -13,6 +14,8 @@ describe("LeasesPage", () => {
   beforeEach(() => {
     createLease.mockReset();
     createLease.mockResolvedValue(undefined);
+    updateLease.mockReset();
+    updateLease.mockResolvedValue(undefined);
     mockedUseLeasesPageState.mockReset();
   });
 
@@ -24,6 +27,7 @@ describe("LeasesPage", () => {
       isSubmitting: false,
       leases: [],
       properties: [],
+      updateLease,
     });
 
     render(<LeasesPage />);
@@ -59,6 +63,7 @@ describe("LeasesPage", () => {
           tenant_id: "tenant-a",
         },
       ],
+      updateLease,
     });
 
     render(<LeasesPage />);
@@ -92,6 +97,7 @@ describe("LeasesPage", () => {
           tenant_id: "tenant-a",
         },
       ],
+      updateLease,
     });
 
     render(<LeasesPage />);
@@ -150,6 +156,7 @@ describe("LeasesPage", () => {
           tenant_id: "tenant-a",
         },
       ],
+      updateLease,
     });
 
     render(<LeasesPage />);
@@ -181,5 +188,217 @@ describe("LeasesPage", () => {
     expect(screen.getByLabelText("Rent due day")).toHaveValue(9);
     expect(screen.getByLabelText("Start date")).toHaveValue("2026-07-01");
     expect(screen.getByLabelText("End date")).toHaveValue("2026-07-31");
+  });
+
+  it("fills the form from a lease and submits an update without tenant_id or property_id", async () => {
+    mockedUseLeasesPageState.mockReturnValue({
+      createLease,
+      error: null,
+      isLoading: false,
+      isSubmitting: false,
+      leases: [
+        {
+          created_at: "2026-04-24T08:00:00Z",
+          end_date: "2026-05-30",
+          lease_id: "lease-1",
+          property_id: "property-1",
+          rent_due_day_of_month: 24,
+          resident_name: "Airbnb customer",
+          start_date: "2026-04-24",
+          tenant_id: "tenant-a",
+        },
+      ],
+      properties: [
+        {
+          address: "First street",
+          created_at: "2026-04-22T08:00:00Z",
+          name: "First property",
+          property_id: "property-1",
+          tenant_id: "tenant-a",
+        },
+      ],
+      updateLease,
+    });
+
+    render(<LeasesPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Airbnb customer" }));
+
+    expect(screen.getByText("Linked property: First property")).toBeInTheDocument();
+    expect(screen.getByLabelText("Resident name")).toHaveValue("Airbnb customer");
+    expect(screen.getByLabelText("Rent due day")).toHaveValue(24);
+    expect(screen.getByLabelText("Start date")).toHaveValue("2026-04-24");
+    expect(screen.getByLabelText("End date")).toHaveValue("2026-05-30");
+
+    fireEvent.change(screen.getByLabelText("Resident name"), {
+      target: { value: "Updated Resident" },
+    });
+    fireEvent.change(screen.getByLabelText("Rent due day"), {
+      target: { value: "9" },
+    });
+    fireEvent.change(screen.getByLabelText("Start date"), {
+      target: { value: "2026-06-01" },
+    });
+    fireEvent.change(screen.getByLabelText("End date"), {
+      target: { value: "2026-12-31" },
+    });
+    fireEvent.submit(screen.getByRole("button", { name: "Update lease" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(updateLease).toHaveBeenCalledWith("lease-1", {
+        end_date: "2026-12-31",
+        rent_due_day_of_month: 9,
+        resident_name: "Updated Resident",
+        start_date: "2026-06-01",
+      });
+    });
+
+    expect(updateLease.mock.calls[0][1]).not.toHaveProperty("tenant_id");
+    expect(updateLease.mock.calls[0][1]).not.toHaveProperty("property_id");
+    expect(createLease).not.toHaveBeenCalled();
+  });
+
+  it("resets lease edit mode after a successful update", async () => {
+    mockedUseLeasesPageState.mockReturnValue({
+      createLease,
+      error: null,
+      isLoading: false,
+      isSubmitting: false,
+      leases: [
+        {
+          created_at: "2026-04-24T08:00:00Z",
+          end_date: "2026-05-30",
+          lease_id: "lease-1",
+          property_id: "property-1",
+          rent_due_day_of_month: 24,
+          resident_name: "Airbnb customer",
+          start_date: "2026-04-24",
+          tenant_id: "tenant-a",
+        },
+      ],
+      properties: [
+        {
+          address: "First street",
+          created_at: "2026-04-22T08:00:00Z",
+          name: "First property",
+          property_id: "property-1",
+          tenant_id: "tenant-a",
+        },
+      ],
+      updateLease,
+    });
+
+    render(<LeasesPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Airbnb customer" }));
+    fireEvent.submit(screen.getByRole("button", { name: "Update lease" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(updateLease).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.getByRole("button", { name: "Create lease" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Cancel edit" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Linked property: First property")).not.toBeInTheDocument();
+  });
+
+  it("cancels lease edit mode without submitting", () => {
+    mockedUseLeasesPageState.mockReturnValue({
+      createLease,
+      error: null,
+      isLoading: false,
+      isSubmitting: false,
+      leases: [
+        {
+          created_at: "2026-04-24T08:00:00Z",
+          end_date: "2026-05-30",
+          lease_id: "lease-1",
+          property_id: "property-1",
+          rent_due_day_of_month: 24,
+          resident_name: "Airbnb customer",
+          start_date: "2026-04-24",
+          tenant_id: "tenant-a",
+        },
+      ],
+      properties: [
+        {
+          address: "First street",
+          created_at: "2026-04-22T08:00:00Z",
+          name: "First property",
+          property_id: "property-1",
+          tenant_id: "tenant-a",
+        },
+      ],
+      updateLease,
+    });
+
+    render(<LeasesPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Airbnb customer" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel edit" }));
+
+    expect(updateLease).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Create lease" })).toBeInTheDocument();
+    expect(screen.queryByText("Linked property: First property")).not.toBeInTheDocument();
+  });
+
+  it("keeps form values when lease update fails", async () => {
+    updateLease.mockRejectedValue(new Error("Update failed"));
+    mockedUseLeasesPageState.mockReturnValue({
+      createLease,
+      error: null,
+      isLoading: false,
+      isSubmitting: false,
+      leases: [
+        {
+          created_at: "2026-04-24T08:00:00Z",
+          end_date: "2026-05-30",
+          lease_id: "lease-1",
+          property_id: "property-1",
+          rent_due_day_of_month: 24,
+          resident_name: "Airbnb customer",
+          start_date: "2026-04-24",
+          tenant_id: "tenant-a",
+        },
+      ],
+      properties: [
+        {
+          address: "First street",
+          created_at: "2026-04-22T08:00:00Z",
+          name: "First property",
+          property_id: "property-1",
+          tenant_id: "tenant-a",
+        },
+      ],
+      updateLease,
+    });
+
+    render(<LeasesPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Airbnb customer" }));
+    fireEvent.change(screen.getByLabelText("Resident name"), {
+      target: { value: "Updated Resident" },
+    });
+    fireEvent.change(screen.getByLabelText("Rent due day"), {
+      target: { value: "9" },
+    });
+    fireEvent.change(screen.getByLabelText("Start date"), {
+      target: { value: "2026-06-01" },
+    });
+    fireEvent.change(screen.getByLabelText("End date"), {
+      target: { value: "2026-12-31" },
+    });
+
+    fireEvent.submit(screen.getByRole("button", { name: "Update lease" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(updateLease).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.getByRole("button", { name: "Update lease" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Resident name")).toHaveValue("Updated Resident");
+    expect(screen.getByLabelText("Rent due day")).toHaveValue(9);
+    expect(screen.getByLabelText("Start date")).toHaveValue("2026-06-01");
+    expect(screen.getByLabelText("End date")).toHaveValue("2026-12-31");
   });
 });

--- a/frontend/src/pages/LeasesPage.tsx
+++ b/frontend/src/pages/LeasesPage.tsx
@@ -1,5 +1,6 @@
 import { useState, type FormEvent } from "react";
 import { useLeasesPageState } from "../features/leases/useLeasesPage";
+import type { Lease } from "../lib/api";
 
 type LeaseForm = {
   endDate: string;
@@ -25,30 +26,60 @@ function createInitialLeaseForm(propertyId = ""): LeaseForm {
 }
 
 export function LeasesPage() {
-  const { createLease, error, isLoading, isSubmitting, leases, properties } =
+  const { createLease, error, isLoading, isSubmitting, leases, properties, updateLease } =
     useLeasesPageState();
   const [form, setForm] = useState<LeaseForm>(() => createInitialLeaseForm());
+  const [editingLeaseId, setEditingLeaseId] = useState<string | null>(null);
 
+  const isEditing = editingLeaseId !== null;
   const hasProperties = properties.length > 0;
   const selectedPropertyId =
     form.propertyId || (hasProperties ? properties[0].property_id : "");
+  const linkedPropertyName =
+    properties.find((property) => property.property_id === form.propertyId)?.name ||
+    (form.propertyId ? `property ${form.propertyId.slice(0, 8)}` : "Unknown property");
+  const canSubmit = hasProperties || isEditing;
+
+  function resetForm(propertyId = selectedPropertyId) {
+    setEditingLeaseId(null);
+    setForm(createInitialLeaseForm(propertyId));
+  }
+
+  function startEdit(lease: Lease) {
+    setEditingLeaseId(lease.lease_id);
+    setForm({
+      endDate: lease.end_date,
+      propertyId: lease.property_id,
+      rentDueDayOfMonth: String(lease.rent_due_day_of_month ?? ""),
+      residentName: lease.resident_name,
+      startDate: lease.start_date,
+    });
+  }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!hasProperties) {
+    if (!canSubmit) {
       return;
     }
 
     try {
-      await createLease({
+      const input = {
         end_date: form.endDate,
-        property_id: selectedPropertyId,
         rent_due_day_of_month: Number(form.rentDueDayOfMonth),
         resident_name: form.residentName.trim(),
         start_date: form.startDate,
-      });
+      };
 
-      setForm(createInitialLeaseForm(selectedPropertyId));
+      if (editingLeaseId) {
+        await updateLease(editingLeaseId, input);
+      } else {
+        await createLease({
+          ...input,
+          property_id: selectedPropertyId,
+        });
+      }
+
+      resetForm(selectedPropertyId);
     } catch {
       // The hook already exposes the user-facing error message.
     }
@@ -62,30 +93,36 @@ export function LeasesPage() {
           <h2 className="section-title">Attach live residents to real properties.</h2>
         </div>
         <form className="stack-form" onSubmit={handleSubmit}>
-          <label className="field-label" htmlFor="lease-property">
-            Property
-          </label>
-          <select
-            disabled={!hasProperties}
-            id="lease-property"
-            onChange={(event) =>
-              setForm((current) => ({ ...current, propertyId: event.target.value }))
-            }
-            value={selectedPropertyId}
-          >
-            {hasProperties ? null : <option value="">Create a property first</option>}
-            {properties.map((property) => (
-              <option key={property.property_id} value={property.property_id}>
-                {property.name}
-              </option>
-            ))}
-          </select>
+          {isEditing ? (
+            <p className="supporting-copy">Linked property: {linkedPropertyName}</p>
+          ) : (
+            <>
+              <label className="field-label" htmlFor="lease-property">
+                Property
+              </label>
+              <select
+                disabled={!hasProperties}
+                id="lease-property"
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, propertyId: event.target.value }))
+                }
+                value={selectedPropertyId}
+              >
+                {hasProperties ? null : <option value="">Create a property first</option>}
+                {properties.map((property) => (
+                  <option key={property.property_id} value={property.property_id}>
+                    {property.name}
+                  </option>
+                ))}
+              </select>
+            </>
+          )}
 
           <label className="field-label" htmlFor="lease-resident-name">
             Resident name
           </label>
           <input
-            disabled={!hasProperties}
+            disabled={!canSubmit}
             id="lease-resident-name"
             onChange={(event) =>
               setForm((current) => ({ ...current, residentName: event.target.value }))
@@ -101,7 +138,7 @@ export function LeasesPage() {
                 Rent due day
               </label>
               <input
-                disabled={!hasProperties}
+                disabled={!canSubmit}
                 id="lease-rent-day"
                 max="31"
                 min="1"
@@ -121,7 +158,7 @@ export function LeasesPage() {
                 Start date
               </label>
               <input
-                disabled={!hasProperties}
+                disabled={!canSubmit}
                 id="lease-start-date"
                 onChange={(event) =>
                   setForm((current) => ({ ...current, startDate: event.target.value }))
@@ -137,7 +174,7 @@ export function LeasesPage() {
             End date
           </label>
           <input
-            disabled={!hasProperties}
+            disabled={!canSubmit}
             id="lease-end-date"
             onChange={(event) =>
               setForm((current) => ({ ...current, endDate: event.target.value }))
@@ -147,11 +184,16 @@ export function LeasesPage() {
             value={form.endDate}
           />
 
-          <button className="primary-button" disabled={!hasProperties || isSubmitting} type="submit">
-            {isSubmitting ? "Saving..." : "Create lease"}
+          <button className="primary-button" disabled={!canSubmit || isSubmitting} type="submit">
+            {isSubmitting ? "Saving..." : isEditing ? "Update lease" : "Create lease"}
           </button>
+          {isEditing ? (
+            <button className="ghost-button" onClick={() => resetForm()} type="button">
+              Cancel edit
+            </button>
+          ) : null}
         </form>
-        {!hasProperties ? (
+        {!hasProperties && !isEditing ? (
           <p className="supporting-copy">
             Lease creation stays disabled until the tenant has at least one property.
           </p>
@@ -184,7 +226,17 @@ export function LeasesPage() {
                     Due day {lease.rent_due_day_of_month} | {lease.start_date} to {lease.end_date}
                   </p>
                 </div>
-                <code className="resource-meta">property {lease.property_id.slice(0, 8)}</code>
+                <div className="resource-actions">
+                  <code className="resource-meta">property {lease.property_id.slice(0, 8)}</code>
+                  <button
+                    aria-label={`Edit ${lease.resident_name}`}
+                    className="ghost-button resource-edit-button"
+                    onClick={() => startEdit(lease)}
+                    type="button"
+                  >
+                    Edit
+                  </button>
+                </div>
               </li>
             ))}
           </ul>

--- a/frontend/src/pages/PropertiesPage.test.tsx
+++ b/frontend/src/pages/PropertiesPage.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PropertiesPage } from "./PropertiesPage";
 
 const createProperty = vi.fn();
+const updateProperty = vi.fn();
 const mockedUsePropertiesPageState = vi.fn();
 
 vi.mock("../features/properties/usePropertiesPage", () => ({
@@ -13,6 +14,8 @@ describe("PropertiesPage", () => {
   beforeEach(() => {
     createProperty.mockReset();
     createProperty.mockResolvedValue(undefined);
+    updateProperty.mockReset();
+    updateProperty.mockResolvedValue(undefined);
     mockedUsePropertiesPageState.mockReset();
     mockedUsePropertiesPageState.mockReturnValue({
       createProperty,
@@ -20,6 +23,7 @@ describe("PropertiesPage", () => {
       isLoading: false,
       isSubmitting: false,
       properties: [],
+      updateProperty,
     });
   });
 
@@ -64,5 +68,150 @@ describe("PropertiesPage", () => {
 
     expect(screen.getByLabelText("Name")).toHaveValue("North Yard Block A");
     expect(screen.getByLabelText("Address")).toHaveValue("Fjordinkatu 12, Helsinki");
+  });
+
+  it("fills the form from a property and submits an update without tenant_id", async () => {
+    mockedUsePropertiesPageState.mockReturnValue({
+      createProperty,
+      error: null,
+      isLoading: false,
+      isSubmitting: false,
+      properties: [
+        {
+          address: "Main Street 1",
+          created_at: "2026-04-22T08:00:00Z",
+          name: "HQ",
+          property_id: "property-1",
+          tenant_id: "tenant-a",
+        },
+      ],
+      updateProperty,
+    });
+
+    render(<PropertiesPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit HQ" }));
+
+    expect(screen.getByLabelText("Name")).toHaveValue("HQ");
+    expect(screen.getByLabelText("Address")).toHaveValue("Main Street 1");
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Updated HQ" },
+    });
+    fireEvent.change(screen.getByLabelText("Address"), {
+      target: { value: "Updated Street 2" },
+    });
+    fireEvent.submit(screen.getByRole("button", { name: "Update property" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(updateProperty).toHaveBeenCalledWith("property-1", {
+        address: "Updated Street 2",
+        name: "Updated HQ",
+      });
+    });
+
+    expect(updateProperty.mock.calls[0][1]).not.toHaveProperty("tenant_id");
+    expect(createProperty).not.toHaveBeenCalled();
+  });
+
+  it("resets property edit mode after a successful update", async () => {
+    mockedUsePropertiesPageState.mockReturnValue({
+      createProperty,
+      error: null,
+      isLoading: false,
+      isSubmitting: false,
+      properties: [
+        {
+          address: "Main Street 1",
+          created_at: "2026-04-22T08:00:00Z",
+          name: "HQ",
+          property_id: "property-1",
+          tenant_id: "tenant-a",
+        },
+      ],
+      updateProperty,
+    });
+
+    render(<PropertiesPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit HQ" }));
+    fireEvent.submit(screen.getByRole("button", { name: "Update property" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(updateProperty).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.getByRole("button", { name: "Create property" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Cancel edit" })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Name")).toHaveValue("");
+    expect(screen.getByLabelText("Address")).toHaveValue("");
+  });
+
+  it("cancels property edit mode without submitting", () => {
+    mockedUsePropertiesPageState.mockReturnValue({
+      createProperty,
+      error: null,
+      isLoading: false,
+      isSubmitting: false,
+      properties: [
+        {
+          address: "Main Street 1",
+          created_at: "2026-04-22T08:00:00Z",
+          name: "HQ",
+          property_id: "property-1",
+          tenant_id: "tenant-a",
+        },
+      ],
+      updateProperty,
+    });
+
+    render(<PropertiesPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit HQ" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel edit" }));
+
+    expect(updateProperty).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Create property" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Name")).toHaveValue("");
+    expect(screen.getByLabelText("Address")).toHaveValue("");
+  });
+
+  it("keeps form values when property update fails", async () => {
+    updateProperty.mockRejectedValue(new Error("Update failed"));
+    mockedUsePropertiesPageState.mockReturnValue({
+      createProperty,
+      error: null,
+      isLoading: false,
+      isSubmitting: false,
+      properties: [
+        {
+          address: "Main Street 1",
+          created_at: "2026-04-22T08:00:00Z",
+          name: "HQ",
+          property_id: "property-1",
+          tenant_id: "tenant-a",
+        },
+      ],
+      updateProperty,
+    });
+
+    render(<PropertiesPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit HQ" }));
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Updated HQ" },
+    });
+    fireEvent.change(screen.getByLabelText("Address"), {
+      target: { value: "Updated Street 2" },
+    });
+    fireEvent.submit(screen.getByRole("button", { name: "Update property" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(updateProperty).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.getByRole("button", { name: "Update property" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Name")).toHaveValue("Updated HQ");
+    expect(screen.getByLabelText("Address")).toHaveValue("Updated Street 2");
   });
 });

--- a/frontend/src/pages/PropertiesPage.tsx
+++ b/frontend/src/pages/PropertiesPage.tsx
@@ -1,5 +1,6 @@
 import { useState, type FormEvent } from "react";
 import { usePropertiesPageState } from "../features/properties/usePropertiesPage";
+import type { Property } from "../lib/api";
 
 type PropertyForm = {
   address: string;
@@ -12,18 +13,40 @@ const INITIAL_FORM: PropertyForm = {
 };
 
 export function PropertiesPage() {
-  const { createProperty, error, isLoading, isSubmitting, properties } =
+  const { createProperty, error, isLoading, isSubmitting, properties, updateProperty } =
     usePropertiesPageState();
   const [form, setForm] = useState<PropertyForm>(INITIAL_FORM);
+  const [editingPropertyId, setEditingPropertyId] = useState<string | null>(null);
+
+  const isEditing = editingPropertyId !== null;
+
+  function resetForm() {
+    setEditingPropertyId(null);
+    setForm(INITIAL_FORM);
+  }
+
+  function startEdit(property: Property) {
+    setEditingPropertyId(property.property_id);
+    setForm({
+      address: property.address,
+      name: property.name,
+    });
+  }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    const input = {
+      address: form.address.trim(),
+      name: form.name.trim(),
+    };
+
     try {
-      await createProperty({
-        address: form.address.trim(),
-        name: form.name.trim(),
-      });
-      setForm(INITIAL_FORM);
+      if (editingPropertyId) {
+        await updateProperty(editingPropertyId, input);
+      } else {
+        await createProperty(input);
+      }
+      resetForm();
     } catch {
       // The hook already exposes the user-facing error message.
     }
@@ -60,8 +83,13 @@ export function PropertiesPage() {
             value={form.address}
           />
           <button className="primary-button" disabled={isSubmitting} type="submit">
-            {isSubmitting ? "Saving..." : "Create property"}
+            {isSubmitting ? "Saving..." : isEditing ? "Update property" : "Create property"}
           </button>
+          {isEditing ? (
+            <button className="ghost-button" onClick={resetForm} type="button">
+              Cancel edit
+            </button>
+          ) : null}
         </form>
         <p className="supporting-copy">
           The browser never sends `tenant_id`. Tenant context comes from the
@@ -93,9 +121,19 @@ export function PropertiesPage() {
                   <p className="resource-title">{property.name}</p>
                   <p className="resource-subtitle">{property.address}</p>
                 </div>
-                <time className="resource-meta" dateTime={property.created_at}>
-                  {new Date(property.created_at).toLocaleDateString("en-GB")}
-                </time>
+                <div className="resource-actions">
+                  <time className="resource-meta" dateTime={property.created_at}>
+                    {new Date(property.created_at).toLocaleDateString("en-GB")}
+                  </time>
+                  <button
+                    aria-label={`Edit ${property.name}`}
+                    className="ghost-button resource-edit-button"
+                    onClick={() => startEdit(property)}
+                    type="button"
+                  >
+                    Edit
+                  </button>
+                </div>
               </li>
             ))}
           </ul>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -219,6 +219,18 @@ button {
   align-items: start;
 }
 
+.resource-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  align-items: flex-end;
+}
+
+.resource-edit-button {
+  padding: 0.55rem 0.85rem;
+  font-size: 0.86rem;
+}
+
 .resource-title {
   margin: 0 0 0.35rem;
   font-weight: 700;


### PR DESCRIPTION
## What changed and why

This PR adds the first browser edit flows for the existing tenant-safe property and lease PATCH endpoints.

The frontend can now:

- edit property `name` and `address`
- edit lease `resident_name`, `rent_due_day_of_month`, `start_date`, and `end_date`
- keep lease `property_id` immutable in the browser update flow because the backend PATCH contract rejects property moves
- preserve form values when update calls fail
- update frontend docs from list/create to list/create/update state

## Assumptions

- The existing two-column page layout remains the right UI shape for this slice.
- Update submits the full editable field set from the form instead of a minimal changed-field diff.
- Lease property changes remain out of scope because the backend does not support `property_id` in `PATCH /leases/{lease_id}`.
- Dashboard, reminders UI, notifications UI, hosting automation, and production readiness remain out of scope.

## Security validation

Tenant isolation remains backend-enforced from validated Cognito JWT claims.

The browser update payloads do not include `tenant_id`. Lease update payloads also do not include `property_id`. The new tests assert those payload constraints for both the API client and page submit paths.

## Cost validation

No AWS resources, Terraform code, backend routes, or deployed infrastructure behavior are changed.

This is a frontend and documentation change only, with no expected AWS cost impact.

## Verification

Local checks run:

- `npm run test` in `frontend/`: 7 files, 22 tests passed
- `npm run lint` in `frontend/`: passed
- `npm run build` in `frontend/`: passed
- `git diff --check`: passed
- `git diff --cached --check`: passed before commit

## Remaining risks / TODOs

- Manual browser verification against the deployed dev API is still optional follow-up for this PR.
- #108 hosted frontend smoke validation remains separate.
