### PR TITLE
frontend: add reminders and notifications page

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,26 +62,30 @@ Implemented now:
 - `GET /properties`
 - `POST /leases`
 - `GET /leases`
+- `PATCH /properties/{property_id}`
+- `PATCH /leases/{lease_id}`
+- `GET /lease-reminders/due-soon`
 - `GET /notifications`
+- `PATCH /notifications/{notification_id}/read`
 - Internal due reminder scan flow that writes notification records idempotently
 - Daily EventBridge Scheduler invocation for the internal reminder scan
 - JWT claim extraction with tenant-aware request context
 - Tenant-scoped PostgreSQL access
 - Explicit `rent_due_day_of_month` on leases to prepare future reminder flows
 - Notification persistence for due-soon rent reminders
-- Audit logging for property and lease creation
+- Audit logging for property and lease writes
 - Alembic migrations for property, lease, and notification tables
 - Terraform modules for network, RDS, Cognito, Lambda, and API Gateway
 - Local portfolio demo client for the deployed MVP flow
-- Real browser frontend slice with Hosted UI auth plus properties and leases
-  list/create/update flows
+- Real browser frontend slice with Hosted UI auth, properties and leases
+  list/create/update flows, due-soon reminders, and notifications mark-read UI
 - Terraform-managed S3 + CloudFront hosting path for the frontend SPA
 
 Planned next:
 
 - Complete hosted frontend smoke validation after the dev Terraform remote
   state source of truth is fixed.
-- Extend the browser frontend with dashboard, reminders, and notifications.
+- Extend the browser frontend with a dashboard summary UI.
 - Add delivery behavior on top of persisted notifications
 - Add more automated backend and tenant-isolation test coverage
 - Refine operational setup for scheduled workflows and monitoring

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -72,13 +72,14 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
   domain and OAuth Authorization Code + PKCE-capable app client settings.
 - Dev Terraform now provides allowlisted browser CORS on the HTTP API for
   approved frontend origins.
-- The browser frontend slice covers sign-in plus properties and leases
-  list/create/update flows.
+- The browser frontend slice covers sign-in, properties and leases
+  list/create/update flows, due-soon reminder display, and notifications
+  list/mark-read UI.
 - Terraform now defines a private S3 + CloudFront hosting path for the static
   SPA.
 - Hosted asset upload and browser smoke validation are operator-run release
   validation steps, not CI deployment automation.
-- Dashboard, reminders, and notifications UI are still follow-up work.
+- Dashboard UI is still follow-up work.
 
 ## Operational Runbooks
 

--- a/docs/frontend-mvp-strategy.md
+++ b/docs/frontend-mvp-strategy.md
@@ -18,13 +18,14 @@ local portfolio/demo tool and not the production-like frontend path.
   approved frontend origins.
 - The dev Terraform stack now configures allowlisted browser CORS on the HTTP
   API for approved frontend origins.
-- The first local browser frontend slice now exists under `frontend/` with
-  sign-in plus properties and leases list/create/update flows.
+- The local browser frontend now exists under `frontend/` with sign-in,
+  properties and leases list/create/update flows, due-soon reminder display,
+  and notifications list/mark-read UI.
 - The dev Terraform stack now includes an S3 + CloudFront hosting path for the
   static SPA. Asset upload remains a local operator command.
 - Hosted frontend smoke validation is still an operator-run release validation
   item, not an implemented CI deployment path.
-- Dashboard, reminders, and notifications UI are still follow-up work.
+- Dashboard UI is still follow-up work.
 
 ## Chosen Frontend Direction
 
@@ -79,19 +80,19 @@ Current implemented slice:
 - app shell and navigation
 - properties list, create, and update flow
 - leases list, create, and update flow
+- due-soon reminder candidate list using the backend default 7-day window
+- notifications list and mark-read flow
 
 Later frontend follow-ups:
 
 - dashboard summary UI
-- due reminders UI
-- notifications list and mark-read UI
 - hosted asset upload and browser smoke validation before release
 
 ## Follow-Up Tickets
 
 - Complete hosted frontend smoke validation after the dev Terraform state
   source of truth is restored.
-- Add dashboard, due reminders, and notifications UI.
+- Add dashboard summary UI.
 
 ## Guardrails
 

--- a/docs/mvp-readiness-review.md
+++ b/docs/mvp-readiness-review.md
@@ -137,8 +137,9 @@ Other valid next phases:
 
 - Production-readiness hardening: remote Terraform state, stronger operational alerting, production-like DR design, and stricter runtime controls.
 - AWS SAA-C03 study extraction: turn the project decisions into exam-focused notes about serverless, private networking, RDS, IAM, monitoring, and operational tradeoffs.
-- Frontend MVP: continue the browser frontend in slices, adding reminders and
-  notifications after auth, properties, and leases.
+- Frontend MVP: continue the browser frontend in slices, adding dashboard
+  summary UI and hosted validation after auth, properties, leases, reminders,
+  and notifications.
 
 Production-readiness hardening is scoped in
 `docs/production-readiness-hardening.md`.

--- a/docs/mvp-scope.md
+++ b/docs/mvp-scope.md
@@ -21,8 +21,8 @@
 - Infrastructure provisioning with Terraform modules.
 - Dev-focused deployment architecture on AWS Lambda + API Gateway.
 - Real browser frontend slice under `frontend/` with Cognito Hosted UI
-  sign-in/sign-out, protected routes, and properties/leases
-  list/create/update flows.
+  sign-in/sign-out, protected routes, properties/leases list/create/update
+  flows, due-soon reminder display, and notifications list/mark-read UI.
 - Terraform-managed static SPA hosting path with private S3 and CloudFront.
   Hosted asset upload and browser smoke validation remain operator-run release
   validation, not a CI deploy pipeline.
@@ -52,5 +52,5 @@
 - PostgreSQL Row-Level Security (future hardening).
 - NAT Gateway and non-essential managed services.
 - Dashboard summary UI.
-- Due reminders and notifications UI.
+- Notification creation from the browser.
 - Custom domain, CI-based frontend deployment, and production readiness.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,8 +13,11 @@ tool.
 - protected browser routes
 - properties list, create, and update
 - leases list, create, and update
+- due-soon reminder candidate list
+- persisted notifications list and mark-read action
 
-This slice does not include dashboard, reminders, or notifications UI yet.
+This slice does not include a dashboard, notification creation, email delivery,
+or hosted CI deploy automation.
 
 ## Prerequisites
 

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -4,6 +4,7 @@ import { ProtectedRoute } from "./ProtectedRoute";
 import { AuthCallbackPage } from "../pages/AuthCallbackPage";
 import { LandingPage } from "../pages/LandingPage";
 import { LeasesPage } from "../pages/LeasesPage";
+import { NotificationsPage } from "../pages/NotificationsPage";
 import { PropertiesPage } from "../pages/PropertiesPage";
 
 export function App() {
@@ -27,6 +28,16 @@ export function App() {
           <ProtectedRoute>
             <AppShell>
               <LeasesPage />
+            </AppShell>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/notifications"
+        element={
+          <ProtectedRoute>
+            <AppShell>
+              <NotificationsPage />
             </AppShell>
           </ProtectedRoute>
         }

--- a/frontend/src/app/AppShell.test.tsx
+++ b/frontend/src/app/AppShell.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { AuthContext, type AuthContextValue } from "./AuthContext";
+import { AppShell } from "./AppShell";
+
+function createAuthValue(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
+  return {
+    completeSignIn: vi.fn(),
+    isAuthenticated: true,
+    markSessionExpired: vi.fn(),
+    session: {
+      accessToken: "access-token",
+      expiresAt: Date.now() + 60_000,
+      idToken: "id-token",
+      tokenType: "Bearer",
+    },
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("AppShell", () => {
+  it("shows notifications in authenticated navigation", () => {
+    render(
+      <AuthContext.Provider value={createAuthValue()}>
+        <MemoryRouter>
+          <AppShell>
+            <div>Secure content</div>
+          </AppShell>
+        </MemoryRouter>
+      </AuthContext.Provider>
+    );
+
+    expect(screen.getByRole("link", { name: "Notifications" })).toHaveAttribute(
+      "href",
+      "/notifications"
+    );
+  });
+});

--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -33,6 +33,14 @@ export function AppShell({ children }: PropsWithChildren) {
         >
           Leases
         </NavLink>
+        <NavLink
+          className={({ isActive }) =>
+            isActive ? "nav-link nav-link-active" : "nav-link"
+          }
+          to="/notifications"
+        >
+          Notifications
+        </NavLink>
       </nav>
       <main>{children}</main>
     </div>

--- a/frontend/src/features/notifications/useNotificationsPage.test.tsx
+++ b/frontend/src/features/notifications/useNotificationsPage.test.tsx
@@ -1,0 +1,187 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthContext, type AuthContextValue } from "../../app/AuthContext";
+import { useNotificationsPageState } from "./useNotificationsPage";
+
+const fetchMock = vi.fn();
+const navigateMock = vi.fn();
+const markSessionExpired = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom"
+  );
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+function createAuthValue(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
+  return {
+    completeSignIn: vi.fn(),
+    isAuthenticated: true,
+    markSessionExpired,
+    session: {
+      accessToken: "access-token",
+      expiresAt: Date.now() + 60_000,
+      idToken: "id-token",
+      tokenType: "Bearer",
+    },
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderHookConsumer() {
+  function HookConsumer() {
+    const {
+      dueReminders,
+      error,
+      isLoading,
+      markNotificationRead,
+      notifications,
+      readingNotificationId,
+    } = useNotificationsPageState();
+
+    async function handleMarkRead(notificationId: string) {
+      try {
+        await markNotificationRead(notificationId);
+      } catch {
+        // Page submit/click handlers consume hook rethrows after error state is set.
+      }
+    }
+
+    if (isLoading) {
+      return <p>Loading notifications...</p>;
+    }
+
+    return (
+      <div>
+        {error ? <p>{error}</p> : null}
+        <p>Reminders: {dueReminders.length}</p>
+        {notifications.map((notification) => (
+          <article key={notification.notification_id}>
+            <h2>{notification.title}</h2>
+            <p>{notification.read_at ?? "Unread"}</p>
+            <button
+              disabled={readingNotificationId === notification.notification_id}
+              onClick={() => void handleMarkRead(notification.notification_id)}
+              type="button"
+            >
+              Mark read
+            </button>
+          </article>
+        ))}
+      </div>
+    );
+  }
+
+  return render(
+    <AuthContext.Provider value={createAuthValue()}>
+      <MemoryRouter>
+        <HookConsumer />
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    status,
+  });
+}
+
+describe("useNotificationsPageState", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    markSessionExpired.mockReset();
+    navigateMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("VITE_API_BASE_URL", "https://api.example.com/dev");
+    vi.stubEnv("VITE_COGNITO_HOSTED_UI_BASE_URL", "https://auth.example.com");
+    vi.stubEnv("VITE_COGNITO_CLIENT_ID", "client-id");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("updates local notification state after mark-read succeeds", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ items: [] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              created_at: "2026-04-28T10:00:00Z",
+              due_date: "2026-04-30",
+              lease_id: "lease-1",
+              message: "Rent is due soon.",
+              notification_id: "notification-1",
+              read_at: null,
+              title: "Rent due soon",
+              type: "rent_due",
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          created_at: "2026-04-28T10:00:00Z",
+          due_date: "2026-04-30",
+          lease_id: "lease-1",
+          message: "Rent is due soon.",
+          notification_id: "notification-1",
+          read_at: "2026-04-28T11:00:00Z",
+          title: "Rent due soon",
+          type: "rent_due",
+        })
+      );
+
+    renderHookConsumer();
+
+    await screen.findByText("Rent due soon");
+    fireEvent.click(screen.getByRole("button", { name: "Mark read" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("2026-04-28T11:00:00Z")).toBeInTheDocument();
+    });
+  });
+
+  it("preserves visible state and exposes an error when mark-read fails", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ items: [] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              created_at: "2026-04-28T10:00:00Z",
+              due_date: "2026-04-30",
+              lease_id: "lease-1",
+              message: "Rent is due soon.",
+              notification_id: "notification-1",
+              read_at: null,
+              title: "Rent due soon",
+              type: "rent_due",
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ error: "Could not mark read." }, 500));
+
+    renderHookConsumer();
+
+    await screen.findByText("Rent due soon");
+    fireEvent.click(screen.getByRole("button", { name: "Mark read" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Could not mark read.")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Unread")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/notifications/useNotificationsPage.ts
+++ b/frontend/src/features/notifications/useNotificationsPage.ts
@@ -1,0 +1,129 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../../app/AuthContext";
+import {
+  ApiError,
+  createApiClient,
+  type LeaseReminderCandidate,
+  type NotificationItem,
+  UnauthorizedApiError,
+} from "../../lib/api";
+import { getRuntimeConfig } from "../../lib/config";
+
+type NotificationsPageState = {
+  dueReminders: LeaseReminderCandidate[];
+  error: string | null;
+  isLoading: boolean;
+  markNotificationRead: (notificationId: string) => Promise<void>;
+  notifications: NotificationItem[];
+  readingNotificationId: string | null;
+};
+
+export function useNotificationsPageState(): NotificationsPageState {
+  const auth = useAuth();
+  const navigate = useNavigate();
+  const [dueReminders, setDueReminders] = useState<LeaseReminderCandidate[]>([]);
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [readingNotificationId, setReadingNotificationId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadPageData() {
+      if (!auth.session) {
+        return;
+      }
+
+      try {
+        setIsLoading(true);
+        setError(null);
+        const client = createApiClient({
+          config: getRuntimeConfig(),
+          onUnauthorized: auth.markSessionExpired,
+          session: auth.session,
+        });
+        const [remindersResponse, notificationsResponse] = await Promise.all([
+          client.listDueLeaseReminders(),
+          client.listNotifications(),
+        ]);
+        if (!cancelled) {
+          setDueReminders(remindersResponse.items);
+          setNotifications(notificationsResponse.items);
+        }
+      } catch (errorValue) {
+        if (cancelled) {
+          return;
+        }
+        if (errorValue instanceof UnauthorizedApiError) {
+          navigate("/", { replace: true });
+          return;
+        }
+        setError(
+          errorValue instanceof ApiError
+            ? errorValue.message
+            : "Could not load notifications."
+        );
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void loadPageData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [auth.markSessionExpired, auth.session, navigate]);
+
+  async function markNotificationRead(notificationId: string) {
+    if (!auth.session) {
+      navigate("/", { replace: true });
+      return;
+    }
+
+    setReadingNotificationId(notificationId);
+    setError(null);
+
+    try {
+      const client = createApiClient({
+        config: getRuntimeConfig(),
+        onUnauthorized: auth.markSessionExpired,
+        session: auth.session,
+      });
+      const updated = await client.markNotificationRead(notificationId);
+      setNotifications((current) =>
+        current.map((notification) =>
+          notification.notification_id === updated.notification_id
+            ? updated
+            : notification
+        )
+      );
+    } catch (errorValue) {
+      if (errorValue instanceof UnauthorizedApiError) {
+        navigate("/", { replace: true });
+        return;
+      }
+      setError(
+        errorValue instanceof ApiError
+          ? errorValue.message
+          : "Could not mark notification as read."
+      );
+      throw errorValue;
+    } finally {
+      setReadingNotificationId(null);
+    }
+  }
+
+  return {
+    dueReminders,
+    error,
+    isLoading,
+    markNotificationRead,
+    notifications,
+    readingNotificationId,
+  };
+}

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -92,4 +92,50 @@ describe("createApiClient", () => {
     expect(JSON.parse(String(init.body))).not.toHaveProperty("tenant_id");
     expect(JSON.parse(String(init.body))).not.toHaveProperty("property_id");
   });
+
+  it("lists due lease reminders without tenant query params", async () => {
+    const client = createApiClient(clientOptions);
+
+    await client.listDueLeaseReminders();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/dev/lease-reminders/due-soon",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer id-token",
+        }),
+      })
+    );
+  });
+
+  it("lists notifications", async () => {
+    const client = createApiClient(clientOptions);
+
+    await client.listNotifications();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/dev/notifications",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer id-token",
+        }),
+      })
+    );
+  });
+
+  it("marks a notification read without tenant_id or request body", async () => {
+    const client = createApiClient(clientOptions);
+
+    await client.markNotificationRead("notification-1");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/dev/notifications/notification-1/read",
+      expect.objectContaining({
+        method: "PATCH",
+      })
+    );
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.body).toBeUndefined();
+  });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -20,6 +20,26 @@ export type Lease = {
   tenant_id: string;
 };
 
+export type LeaseReminderCandidate = {
+  days_until_due: number;
+  due_date: string;
+  lease_id: string;
+  property_id: string;
+  rent_due_day_of_month: number;
+  resident_name: string;
+};
+
+export type NotificationItem = {
+  created_at: string;
+  due_date: string;
+  lease_id: string;
+  message: string;
+  notification_id: string;
+  read_at: string | null;
+  title: string;
+  type: string;
+};
+
 export type CreatePropertyInput = {
   address: string;
   name: string;
@@ -119,11 +139,25 @@ export function createApiClient({ config, onUnauthorized, session }: ApiClientOp
         method: "POST",
       });
     },
+    listDueLeaseReminders() {
+      return request<ListResponse<LeaseReminderCandidate>>("/lease-reminders/due-soon");
+    },
     listLeases() {
       return request<ListResponse<Lease>>("/leases");
     },
+    listNotifications() {
+      return request<ListResponse<NotificationItem>>("/notifications");
+    },
     listProperties() {
       return request<ListResponse<Property>>("/properties");
+    },
+    markNotificationRead(notificationId: string) {
+      return request<NotificationItem>(
+        `/notifications/${encodeURIComponent(notificationId)}/read`,
+        {
+          method: "PATCH",
+        }
+      );
     },
     updateLease(leaseId: string, input: UpdateLeaseInput) {
       return request<Lease>(`/leases/${encodeURIComponent(leaseId)}`, {

--- a/frontend/src/pages/NotificationsPage.test.tsx
+++ b/frontend/src/pages/NotificationsPage.test.tsx
@@ -1,0 +1,158 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NotificationsPage } from "./NotificationsPage";
+
+const markNotificationRead = vi.fn();
+const mockedUseNotificationsPageState = vi.fn();
+
+vi.mock("../features/notifications/useNotificationsPage", () => ({
+  useNotificationsPageState: () => mockedUseNotificationsPageState(),
+}));
+
+describe("NotificationsPage", () => {
+  beforeEach(() => {
+    markNotificationRead.mockReset();
+    markNotificationRead.mockResolvedValue(undefined);
+    mockedUseNotificationsPageState.mockReset();
+    mockedUseNotificationsPageState.mockReturnValue({
+      dueReminders: [],
+      error: null,
+      isLoading: false,
+      markNotificationRead,
+      notifications: [],
+      readingNotificationId: null,
+    });
+  });
+
+  it("renders the due reminder empty state", () => {
+    render(<NotificationsPage />);
+
+    expect(screen.getByText("No rent due soon")).toBeInTheDocument();
+  });
+
+  it("renders due reminder candidates", () => {
+    mockedUseNotificationsPageState.mockReturnValue({
+      dueReminders: [
+        {
+          days_until_due: 2,
+          due_date: "2026-04-30",
+          lease_id: "lease-1",
+          property_id: "property-1",
+          rent_due_day_of_month: 30,
+          resident_name: "Kaisa Tenant",
+        },
+      ],
+      error: null,
+      isLoading: false,
+      markNotificationRead,
+      notifications: [],
+      readingNotificationId: null,
+    });
+
+    render(<NotificationsPage />);
+
+    expect(screen.getByText("Kaisa Tenant")).toBeInTheDocument();
+    expect(screen.getByText("Due 2026-04-30 | 2 days from now")).toBeInTheDocument();
+    expect(screen.getByText("rent due day 30")).toBeInTheDocument();
+  });
+
+  it("renders the notification empty state", () => {
+    render(<NotificationsPage />);
+
+    expect(screen.getByText("No persisted notifications yet")).toBeInTheDocument();
+  });
+
+  it("renders unread notifications with a mark-read action", async () => {
+    mockedUseNotificationsPageState.mockReturnValue({
+      dueReminders: [],
+      error: null,
+      isLoading: false,
+      markNotificationRead,
+      notifications: [
+        {
+          created_at: "2026-04-28T10:00:00Z",
+          due_date: "2026-04-30",
+          lease_id: "lease-1",
+          message: "Rent is due soon.",
+          notification_id: "notification-1",
+          read_at: null,
+          title: "Rent due soon",
+          type: "rent_due",
+        },
+      ],
+      readingNotificationId: null,
+    });
+
+    render(<NotificationsPage />);
+
+    expect(screen.getByText("Rent due soon")).toBeInTheDocument();
+    expect(screen.getByText("Unread")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark Rent due soon read" }));
+
+    await waitFor(() => {
+      expect(markNotificationRead).toHaveBeenCalledWith("notification-1");
+    });
+  });
+
+  it("renders read notifications without a mark-read action", () => {
+    mockedUseNotificationsPageState.mockReturnValue({
+      dueReminders: [],
+      error: null,
+      isLoading: false,
+      markNotificationRead,
+      notifications: [
+        {
+          created_at: "2026-04-28T10:00:00Z",
+          due_date: "2026-04-30",
+          lease_id: "lease-1",
+          message: "Rent is due soon.",
+          notification_id: "notification-1",
+          read_at: "2026-04-28T11:00:00Z",
+          title: "Rent due soon",
+          type: "rent_due",
+        },
+      ],
+      readingNotificationId: null,
+    });
+
+    render(<NotificationsPage />);
+
+    expect(screen.getByText("Read")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Mark Rent due soon read/i })).not.toBeInTheDocument();
+  });
+
+  it("preserves visible notification state when mark-read fails", async () => {
+    markNotificationRead.mockRejectedValue(new Error("Mark read failed"));
+    mockedUseNotificationsPageState.mockReturnValue({
+      dueReminders: [],
+      error: "Could not mark notification as read.",
+      isLoading: false,
+      markNotificationRead,
+      notifications: [
+        {
+          created_at: "2026-04-28T10:00:00Z",
+          due_date: "2026-04-30",
+          lease_id: "lease-1",
+          message: "Rent is due soon.",
+          notification_id: "notification-1",
+          read_at: null,
+          title: "Rent due soon",
+          type: "rent_due",
+        },
+      ],
+      readingNotificationId: null,
+    });
+
+    render(<NotificationsPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Mark Rent due soon read" }));
+
+    await waitFor(() => {
+      expect(markNotificationRead).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.getByText("Rent due soon")).toBeInTheDocument();
+    expect(screen.getByText("Unread")).toBeInTheDocument();
+    expect(screen.getByText("Could not mark notification as read.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -1,0 +1,128 @@
+import { useNotificationsPageState } from "../features/notifications/useNotificationsPage";
+import type { NotificationItem } from "../lib/api";
+
+function formatDaysUntilDue(days: number) {
+  if (days === 0) {
+    return "today";
+  }
+  if (days === 1) {
+    return "1 day from now";
+  }
+  return `${days} days from now`;
+}
+
+export function NotificationsPage() {
+  const {
+    dueReminders,
+    error,
+    isLoading,
+    markNotificationRead,
+    notifications,
+    readingNotificationId,
+  } = useNotificationsPageState();
+
+  async function handleMarkRead(notification: NotificationItem) {
+    try {
+      await markNotificationRead(notification.notification_id);
+    } catch {
+      // The hook already exposes the user-facing error message.
+    }
+  }
+
+  return (
+    <section className="page-grid notifications-grid">
+      <article className="panel-card">
+        <div className="section-heading">
+          <p className="eyebrow">Due reminders</p>
+          <h2 className="section-title">Rent coming due soon.</h2>
+        </div>
+        {isLoading ? (
+          <p className="supporting-copy">Loading reminders...</p>
+        ) : dueReminders.length === 0 ? (
+          <div className="empty-state">
+            <h3>No rent due soon</h3>
+            <p>The backend default 7-day reminder window has no matching leases.</p>
+          </div>
+        ) : (
+          <ul className="resource-list">
+            {dueReminders.map((reminder) => (
+              <li className="resource-card" key={reminder.lease_id}>
+                <div>
+                  <p className="resource-title">{reminder.resident_name}</p>
+                  <p className="resource-subtitle">
+                    Due {reminder.due_date} | {formatDaysUntilDue(reminder.days_until_due)}
+                  </p>
+                </div>
+                <div className="resource-actions">
+                  <code className="resource-meta">
+                    rent due day {reminder.rent_due_day_of_month}
+                  </code>
+                  <code className="resource-meta">
+                    property {reminder.property_id.slice(0, 8)}
+                  </code>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </article>
+
+      <article className="panel-card">
+        <div className="section-heading">
+          <p className="eyebrow">Notifications</p>
+          <h2 className="section-title">Persisted tenant notifications.</h2>
+        </div>
+        {isLoading ? (
+          <p className="supporting-copy">Loading notifications...</p>
+        ) : notifications.length === 0 ? (
+          <div className="empty-state">
+            <h3>No persisted notifications yet</h3>
+            <p>Notification rows appear here after backend reminder processing creates them.</p>
+          </div>
+        ) : (
+          <ul className="resource-list">
+            {notifications.map((notification) => {
+              const isRead = notification.read_at !== null;
+
+              return (
+                <li className="resource-card notification-card" key={notification.notification_id}>
+                  <div>
+                    <div className="notification-title-row">
+                      <p className="resource-title">{notification.title}</p>
+                      <span className={isRead ? "status-pill" : "status-pill status-pill-unread"}>
+                        {isRead ? "Read" : "Unread"}
+                      </span>
+                    </div>
+                    <p className="resource-subtitle">{notification.message}</p>
+                    <p className="resource-meta">
+                      Due {notification.due_date} | Created{" "}
+                      {new Date(notification.created_at).toLocaleDateString("en-GB")}
+                    </p>
+                  </div>
+                  <div className="resource-actions">
+                    {isRead ? (
+                      <time className="resource-meta" dateTime={notification.read_at ?? undefined}>
+                        Read {new Date(notification.read_at ?? "").toLocaleDateString("en-GB")}
+                      </time>
+                    ) : (
+                      <button
+                        aria-label={`Mark ${notification.title} read`}
+                        className="ghost-button resource-edit-button"
+                        disabled={readingNotificationId === notification.notification_id}
+                        onClick={() => void handleMarkRead(notification)}
+                        type="button"
+                      >
+                        Mark read
+                      </button>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        {error ? <p className="error-text">{error}</p> : null}
+      </article>
+    </section>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -237,9 +237,38 @@ button {
   color: var(--ink-strong);
 }
 
+.notification-title-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+  margin-bottom: 0.35rem;
+}
+
+.notification-title-row .resource-title {
+  margin: 0;
+}
+
 .resource-meta {
   font-size: 0.82rem;
   white-space: nowrap;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 0.65rem;
+  border-radius: 999px;
+  background: rgba(19, 38, 31, 0.08);
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.status-pill-unread {
+  background: rgba(232, 152, 83, 0.22);
+  color: #7a3f17;
 }
 
 .panel-card {


### PR DESCRIPTION
## What changed and why

- Added a protected `/notifications` browser page with due-soon reminders and persisted notifications.
- Added typed API client methods for `GET /lease-reminders/due-soon`, `GET /notifications`, and `PATCH /notifications/{notification_id}/read`.
- Added a feature-local notifications hook that loads reminders and notifications together, handles unauthorized responses consistently, and updates local notification state after mark-read succeeds.
- Added authenticated navigation for `Notifications` after the route exists.
- Updated docs so reminders and notifications UI are no longer described as future work.

## Assumptions

- The backend default 7-day reminder window is used; the frontend does not send a `days` query parameter in this slice.
- The browser only reads existing reminder/notification data and acknowledges notifications; it does not create notification records.
- The internal reminder scan remains operator/internal only and is not exposed in the browser UI.

## Security validation

- Browser requests do not send `tenant_id` in request bodies or query parameters.
- `markNotificationRead` sends `PATCH /notifications/{notification_id}/read` with no request body.
- Tenant isolation remains backend-enforced from validated Cognito JWT claims.
- Added tests covering no tenant query/body behavior for the new API client methods.

## Cost validation

- No backend, Terraform, AWS, Cognito, CORS, database, or hosting changes.
- No new AWS services or runtime cost impact.

## Validation

- `cd frontend && npm run test` -> 10 files, 34 tests passed.
- `cd frontend && npm run lint` -> passed.
- `cd frontend && npm run build` -> passed.
- `git diff --check` and `git diff --cached --check` -> passed.

## Remaining risks / TODOs

- Manual dev API verification is still optional and depends on having reminder/notification test data.
- Dashboard, custom domain, CI deploy, production readiness, and hosted smoke evidence remain separate work.
