### PR TITLE
frontend: add authenticated dashboard summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,15 +77,15 @@ Implemented now:
 - Alembic migrations for property, lease, and notification tables
 - Terraform modules for network, RDS, Cognito, Lambda, and API Gateway
 - Local portfolio demo client for the deployed MVP flow
-- Real browser frontend slice with Hosted UI auth, properties and leases
-  list/create/update flows, due-soon reminders, and notifications mark-read UI
+- Real browser frontend slice with Hosted UI auth, dashboard summaries,
+  properties and leases list/create/update flows, due-soon reminders, and
+  notifications mark-read UI
 - Terraform-managed S3 + CloudFront hosting path for the frontend SPA
 
 Planned next:
 
 - Complete hosted frontend smoke validation after the dev Terraform remote
   state source of truth is fixed.
-- Extend the browser frontend with a dashboard summary UI.
 - Add delivery behavior on top of persisted notifications
 - Add more automated backend and tenant-isolation test coverage
 - Refine operational setup for scheduled workflows and monitoring

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -72,14 +72,14 @@ LeaseFlow is a serverless, multi-tenant rental management MVP on AWS. The archit
   domain and OAuth Authorization Code + PKCE-capable app client settings.
 - Dev Terraform now provides allowlisted browser CORS on the HTTP API for
   approved frontend origins.
-- The browser frontend slice covers sign-in, properties and leases
-  list/create/update flows, due-soon reminder display, and notifications
-  list/mark-read UI.
+- The browser frontend slice covers sign-in, dashboard summaries,
+  properties and leases list/create/update flows, due-soon reminder display,
+  and notifications list/mark-read UI.
 - Terraform now defines a private S3 + CloudFront hosting path for the static
   SPA.
 - Hosted asset upload and browser smoke validation are operator-run release
   validation steps, not CI deployment automation.
-- Dashboard UI is still follow-up work.
+- The dashboard is the authenticated browser app entry point.
 
 ## Operational Runbooks
 

--- a/docs/frontend-mvp-strategy.md
+++ b/docs/frontend-mvp-strategy.md
@@ -19,13 +19,13 @@ local portfolio/demo tool and not the production-like frontend path.
 - The dev Terraform stack now configures allowlisted browser CORS on the HTTP
   API for approved frontend origins.
 - The local browser frontend now exists under `frontend/` with sign-in,
-  properties and leases list/create/update flows, due-soon reminder display,
-  and notifications list/mark-read UI.
+  dashboard summaries, properties and leases list/create/update flows,
+  due-soon reminder display, and notifications list/mark-read UI.
 - The dev Terraform stack now includes an S3 + CloudFront hosting path for the
   static SPA. Asset upload remains a local operator command.
 - Hosted frontend smoke validation is still an operator-run release validation
   item, not an implemented CI deployment path.
-- Dashboard UI is still follow-up work.
+- The dashboard is the authenticated browser app entry point.
 
 ## Chosen Frontend Direction
 
@@ -78,6 +78,7 @@ Current implemented slice:
 
 - sign in / sign out
 - app shell and navigation
+- dashboard summary UI
 - properties list, create, and update flow
 - leases list, create, and update flow
 - due-soon reminder candidate list using the backend default 7-day window
@@ -85,14 +86,12 @@ Current implemented slice:
 
 Later frontend follow-ups:
 
-- dashboard summary UI
 - hosted asset upload and browser smoke validation before release
 
 ## Follow-Up Tickets
 
 - Complete hosted frontend smoke validation after the dev Terraform state
   source of truth is restored.
-- Add dashboard summary UI.
 
 ## Guardrails
 

--- a/docs/mvp-readiness-review.md
+++ b/docs/mvp-readiness-review.md
@@ -137,9 +137,8 @@ Other valid next phases:
 
 - Production-readiness hardening: remote Terraform state, stronger operational alerting, production-like DR design, and stricter runtime controls.
 - AWS SAA-C03 study extraction: turn the project decisions into exam-focused notes about serverless, private networking, RDS, IAM, monitoring, and operational tradeoffs.
-- Frontend MVP: continue the browser frontend in slices, adding dashboard
-  summary UI and hosted validation after auth, properties, leases, reminders,
-  and notifications.
+- Frontend MVP: continue hosted validation after auth, dashboard, properties,
+  leases, reminders, and notifications.
 
 Production-readiness hardening is scoped in
 `docs/production-readiness-hardening.md`.

--- a/docs/mvp-scope.md
+++ b/docs/mvp-scope.md
@@ -21,8 +21,9 @@
 - Infrastructure provisioning with Terraform modules.
 - Dev-focused deployment architecture on AWS Lambda + API Gateway.
 - Real browser frontend slice under `frontend/` with Cognito Hosted UI
-  sign-in/sign-out, protected routes, properties/leases list/create/update
-  flows, due-soon reminder display, and notifications list/mark-read UI.
+  sign-in/sign-out, protected routes, dashboard summaries,
+  properties/leases list/create/update flows, due-soon reminder display, and
+  notifications list/mark-read UI.
 - Terraform-managed static SPA hosting path with private S3 and CloudFront.
   Hosted asset upload and browser smoke validation remain operator-run release
   validation, not a CI deploy pipeline.
@@ -51,6 +52,5 @@
 - Email delivery and external notification integrations.
 - PostgreSQL Row-Level Security (future hardening).
 - NAT Gateway and non-essential managed services.
-- Dashboard summary UI.
 - Notification creation from the browser.
 - Custom domain, CI-based frontend deployment, and production readiness.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -11,13 +11,14 @@ tool.
 - Cognito Hosted UI sign in and sign out
 - OAuth authorization code flow with PKCE
 - protected browser routes
+- authenticated dashboard summary
 - properties list, create, and update
 - leases list, create, and update
 - due-soon reminder candidate list
 - persisted notifications list and mark-read action
 
-This slice does not include a dashboard, notification creation, email delivery,
-or hosted CI deploy automation.
+This slice does not include notification creation, email delivery, or hosted CI
+deploy automation.
 
 ## Prerequisites
 

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { AuthContext, type AuthContextValue } from "./AuthContext";
+import { App } from "./App";
+
+vi.mock("../pages/DashboardPage", () => ({
+  DashboardPage: () => <div>Dashboard page</div>,
+}));
+
+function createAuthValue(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
+  return {
+    completeSignIn: vi.fn(),
+    isAuthenticated: true,
+    markSessionExpired: vi.fn(),
+    session: {
+      accessToken: "access-token",
+      expiresAt: Date.now() + 60_000,
+      idToken: "id-token",
+      tokenType: "Bearer",
+    },
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("App", () => {
+  it("renders the protected dashboard route for authenticated users", () => {
+    render(
+      <AuthContext.Provider value={createAuthValue()}>
+        <MemoryRouter initialEntries={["/dashboard"]}>
+          <App />
+        </MemoryRouter>
+      </AuthContext.Provider>
+    );
+
+    expect(screen.getByText("Dashboard page")).toBeInTheDocument();
+  });
+
+  it("protects the dashboard route from unauthenticated users", () => {
+    render(
+      <AuthContext.Provider
+        value={createAuthValue({
+          isAuthenticated: false,
+          session: null,
+        })}
+      >
+        <MemoryRouter initialEntries={["/dashboard"]}>
+          <App />
+        </MemoryRouter>
+      </AuthContext.Provider>
+    );
+
+    expect(screen.getByRole("button", { name: "Sign in with Cognito" })).toBeInTheDocument();
+    expect(screen.queryByText("Dashboard page")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -2,6 +2,7 @@ import { Route, Routes } from "react-router-dom";
 import { AppShell } from "./AppShell";
 import { ProtectedRoute } from "./ProtectedRoute";
 import { AuthCallbackPage } from "../pages/AuthCallbackPage";
+import { DashboardPage } from "../pages/DashboardPage";
 import { LandingPage } from "../pages/LandingPage";
 import { LeasesPage } from "../pages/LeasesPage";
 import { NotificationsPage } from "../pages/NotificationsPage";
@@ -12,6 +13,16 @@ export function App() {
     <Routes>
       <Route path="/" element={<LandingPage />} />
       <Route path="/auth/callback" element={<AuthCallbackPage />} />
+      <Route
+        path="/dashboard"
+        element={
+          <ProtectedRoute>
+            <AppShell>
+              <DashboardPage />
+            </AppShell>
+          </ProtectedRoute>
+        }
+      />
       <Route
         path="/properties"
         element={

--- a/frontend/src/app/AppShell.test.tsx
+++ b/frontend/src/app/AppShell.test.tsx
@@ -22,7 +22,7 @@ function createAuthValue(overrides: Partial<AuthContextValue> = {}): AuthContext
 }
 
 describe("AppShell", () => {
-  it("shows notifications in authenticated navigation", () => {
+  it("shows dashboard and feature routes in authenticated navigation", () => {
     render(
       <AuthContext.Provider value={createAuthValue()}>
         <MemoryRouter>
@@ -33,6 +33,18 @@ describe("AppShell", () => {
       </AuthContext.Provider>
     );
 
+    expect(screen.getByRole("link", { name: "Dashboard" })).toHaveAttribute(
+      "href",
+      "/dashboard"
+    );
+    expect(screen.getByRole("link", { name: "Properties" })).toHaveAttribute(
+      "href",
+      "/properties"
+    );
+    expect(screen.getByRole("link", { name: "Leases" })).toHaveAttribute(
+      "href",
+      "/leases"
+    );
     expect(screen.getByRole("link", { name: "Notifications" })).toHaveAttribute(
       "href",
       "/notifications"

--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -21,6 +21,14 @@ export function AppShell({ children }: PropsWithChildren) {
           className={({ isActive }) =>
             isActive ? "nav-link nav-link-active" : "nav-link"
           }
+          to="/dashboard"
+        >
+          Dashboard
+        </NavLink>
+        <NavLink
+          className={({ isActive }) =>
+            isActive ? "nav-link nav-link-active" : "nav-link"
+          }
           to="/properties"
         >
           Properties

--- a/frontend/src/app/AuthContext.tsx
+++ b/frontend/src/app/AuthContext.tsx
@@ -42,7 +42,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
         clearAuthSession();
         setSession(null);
       },
-      async signIn(returnPath = "/properties") {
+      async signIn(returnPath = "/dashboard") {
         await redirectToHostedUiSignIn(getRuntimeConfig(), returnPath);
       },
       signOut() {

--- a/frontend/src/features/dashboard/useDashboardPage.test.tsx
+++ b/frontend/src/features/dashboard/useDashboardPage.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthContext, type AuthContextValue } from "../../app/AuthContext";
+import { useDashboardPageState } from "./useDashboardPage";
+
+const fetchMock = vi.fn();
+const navigateMock = vi.fn();
+const markSessionExpired = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom"
+  );
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+function createAuthValue(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
+  return {
+    completeSignIn: vi.fn(),
+    isAuthenticated: true,
+    markSessionExpired,
+    session: {
+      accessToken: "access-token",
+      expiresAt: Date.now() + 60_000,
+      idToken: "id-token",
+      tokenType: "Bearer",
+    },
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    status,
+  });
+}
+
+function renderHookConsumer() {
+  function HookConsumer() {
+    const { error, isLoading, summary } = useDashboardPageState();
+
+    if (isLoading) {
+      return <p>Loading dashboard...</p>;
+    }
+
+    return (
+      <div>
+        {error ? <p>{error}</p> : null}
+        <p>properties={summary.propertyCount}</p>
+        <p>leases={summary.leaseCount}</p>
+        <p>reminders={summary.dueReminderCount}</p>
+        <p>unread={summary.unreadNotificationCount}</p>
+      </div>
+    );
+  }
+
+  return render(
+    <AuthContext.Provider value={createAuthValue()}>
+      <MemoryRouter>
+        <HookConsumer />
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+describe("useDashboardPageState", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    markSessionExpired.mockReset();
+    navigateMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("VITE_API_BASE_URL", "https://api.example.com/dev");
+    vi.stubEnv("VITE_COGNITO_HOSTED_UI_BASE_URL", "https://auth.example.com");
+    vi.stubEnv("VITE_COGNITO_CLIENT_ID", "client-id");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("loads dashboard counts from existing list APIs", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ items: [{ property_id: "property-1" }] }))
+      .mockResolvedValueOnce(jsonResponse({ items: [{ lease_id: "lease-1" }] }))
+      .mockResolvedValueOnce(
+        jsonResponse({ items: [{ lease_id: "lease-1" }, { lease_id: "lease-2" }] })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            { notification_id: "notification-1", read_at: null },
+            { notification_id: "notification-2", read_at: "2026-04-28T10:00:00Z" },
+          ],
+        })
+      );
+
+    renderHookConsumer();
+
+    await waitFor(() => {
+      expect(screen.getByText("properties=1")).toBeInTheDocument();
+    });
+    expect(screen.getByText("leases=1")).toBeInTheDocument();
+    expect(screen.getByText("reminders=2")).toBeInTheDocument();
+    expect(screen.getByText("unread=1")).toBeInTheDocument();
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "https://api.example.com/dev/properties",
+      "https://api.example.com/dev/leases",
+      "https://api.example.com/dev/lease-reminders/due-soon",
+      "https://api.example.com/dev/notifications",
+    ]);
+  });
+
+  it("expires the session and redirects home on unauthorized responses", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ error: "Unauthorized" }, 401))
+      .mockResolvedValueOnce(jsonResponse({ error: "Unauthorized" }, 401))
+      .mockResolvedValueOnce(jsonResponse({ error: "Unauthorized" }, 401))
+      .mockResolvedValueOnce(jsonResponse({ error: "Unauthorized" }, 401));
+
+    renderHookConsumer();
+
+    await waitFor(() => {
+      expect(markSessionExpired).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
+    });
+  });
+});

--- a/frontend/src/features/dashboard/useDashboardPage.ts
+++ b/frontend/src/features/dashboard/useDashboardPage.ts
@@ -1,0 +1,99 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../../app/AuthContext";
+import { ApiError, createApiClient, UnauthorizedApiError } from "../../lib/api";
+import { getRuntimeConfig } from "../../lib/config";
+
+type DashboardSummary = {
+  dueReminderCount: number;
+  leaseCount: number;
+  propertyCount: number;
+  unreadNotificationCount: number;
+};
+
+type DashboardPageState = {
+  error: string | null;
+  isLoading: boolean;
+  summary: DashboardSummary;
+};
+
+const EMPTY_SUMMARY: DashboardSummary = {
+  dueReminderCount: 0,
+  leaseCount: 0,
+  propertyCount: 0,
+  unreadNotificationCount: 0,
+};
+
+export function useDashboardPageState(): DashboardPageState {
+  const auth = useAuth();
+  const navigate = useNavigate();
+  const [summary, setSummary] = useState<DashboardSummary>(EMPTY_SUMMARY);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadDashboard() {
+      if (!auth.session) {
+        return;
+      }
+
+      try {
+        setIsLoading(true);
+        setError(null);
+        const client = createApiClient({
+          config: getRuntimeConfig(),
+          onUnauthorized: auth.markSessionExpired,
+          session: auth.session,
+        });
+        const [properties, leases, dueReminders, notifications] = await Promise.all([
+          client.listProperties(),
+          client.listLeases(),
+          client.listDueLeaseReminders(),
+          client.listNotifications(),
+        ]);
+
+        if (!cancelled) {
+          setSummary({
+            dueReminderCount: dueReminders.items.length,
+            leaseCount: leases.items.length,
+            propertyCount: properties.items.length,
+            unreadNotificationCount: notifications.items.filter(
+              (notification) => notification.read_at === null
+            ).length,
+          });
+        }
+      } catch (errorValue) {
+        if (cancelled) {
+          return;
+        }
+        if (errorValue instanceof UnauthorizedApiError) {
+          navigate("/", { replace: true });
+          return;
+        }
+        setError(
+          errorValue instanceof ApiError
+            ? errorValue.message
+            : "Could not load dashboard."
+        );
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void loadDashboard();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [auth.markSessionExpired, auth.session, navigate]);
+
+  return {
+    error,
+    isLoading,
+    summary,
+  };
+}

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -203,7 +203,7 @@ export async function completeHostedUiSignIn(
   const session = buildStoredSession(tokenResponse);
   saveAuthSession(session);
 
-  const returnPath = getPendingValue(RETURN_PATH_KEY) || "/properties";
+  const returnPath = getPendingValue(RETURN_PATH_KEY) || "/dashboard";
   clearPendingSignIn();
 
   return { returnPath, session };

--- a/frontend/src/pages/AuthCallbackPage.test.tsx
+++ b/frontend/src/pages/AuthCallbackPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { AuthContext, type AuthContextValue } from "../app/AuthContext";
@@ -61,6 +61,8 @@ describe("AuthCallbackPage", () => {
     await waitFor(() => {
       expect(screen.getByText("Callback failed")).toBeInTheDocument();
     });
-    expect(screen.getByRole("button", { name: "Try sign-in again" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Try sign-in again" }));
+
+    expect(authValue.signIn).toHaveBeenCalledWith("/dashboard");
   });
 });

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -44,7 +44,7 @@ export function AuthCallbackPage() {
             <p className="error-text">{error}</p>
             <button
               className="primary-button"
-              onClick={() => auth.signIn("/properties")}
+              onClick={() => auth.signIn("/dashboard")}
               type="button"
             >
               Try sign-in again

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DashboardPage } from "./DashboardPage";
+
+const mockedUseDashboardPageState = vi.fn();
+
+vi.mock("../features/dashboard/useDashboardPage", () => ({
+  useDashboardPageState: () => mockedUseDashboardPageState(),
+}));
+
+describe("DashboardPage", () => {
+  beforeEach(() => {
+    mockedUseDashboardPageState.mockReset();
+    mockedUseDashboardPageState.mockReturnValue({
+      error: null,
+      isLoading: false,
+      summary: {
+        dueReminderCount: 0,
+        leaseCount: 0,
+        propertyCount: 0,
+        unreadNotificationCount: 0,
+      },
+    });
+  });
+
+  it("renders empty summary counts and action links", () => {
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Portfolio overview")).toBeInTheDocument();
+    expect(screen.getByText("0 properties")).toBeInTheDocument();
+    expect(screen.getByText("0 leases")).toBeInTheDocument();
+    expect(screen.getByText("0 due soon")).toBeInTheDocument();
+    expect(screen.getByText("0 unread")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Manage properties" })).toHaveAttribute(
+      "href",
+      "/properties"
+    );
+    expect(screen.getByRole("link", { name: "Manage leases" })).toHaveAttribute(
+      "href",
+      "/leases"
+    );
+    expect(screen.getByRole("link", { name: "Review notifications" })).toHaveAttribute(
+      "href",
+      "/notifications"
+    );
+  });
+
+  it("renders populated summary counts", () => {
+    mockedUseDashboardPageState.mockReturnValue({
+      error: null,
+      isLoading: false,
+      summary: {
+        dueReminderCount: 2,
+        leaseCount: 4,
+        propertyCount: 3,
+        unreadNotificationCount: 1,
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("3 properties")).toBeInTheDocument();
+    expect(screen.getByText("4 leases")).toBeInTheDocument();
+    expect(screen.getByText("2 due soon")).toBeInTheDocument();
+    expect(screen.getByText("1 unread")).toBeInTheDocument();
+  });
+
+  it("renders the existing error message path", () => {
+    mockedUseDashboardPageState.mockReturnValue({
+      error: "Could not load dashboard.",
+      isLoading: false,
+      summary: {
+        dueReminderCount: 0,
+        leaseCount: 0,
+        propertyCount: 0,
+        unreadNotificationCount: 0,
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Could not load dashboard.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,79 @@
+import { Link } from "react-router-dom";
+import { useDashboardPageState } from "../features/dashboard/useDashboardPage";
+
+type SummaryCardProps = {
+  count: number;
+  label: string;
+  supportingText: string;
+};
+
+function SummaryCard({ count, label, supportingText }: SummaryCardProps) {
+  return (
+    <article className="summary-card">
+      <p className="summary-count">
+        {count} {label}
+      </p>
+      <p className="resource-subtitle">{supportingText}</p>
+    </article>
+  );
+}
+
+export function DashboardPage() {
+  const { error, isLoading, summary } = useDashboardPageState();
+
+  return (
+    <section className="dashboard-layout">
+      <article className="panel-card">
+        <div className="section-heading">
+          <p className="eyebrow">Dashboard</p>
+          <h2 className="section-title">Portfolio overview</h2>
+        </div>
+        {isLoading ? (
+          <p className="supporting-copy">Loading dashboard...</p>
+        ) : (
+          <div className="summary-grid">
+            <SummaryCard
+              count={summary.propertyCount}
+              label="properties"
+              supportingText="Tenant-owned rental units currently captured."
+            />
+            <SummaryCard
+              count={summary.leaseCount}
+              label="leases"
+              supportingText="Active lease records linked to properties."
+            />
+            <SummaryCard
+              count={summary.dueReminderCount}
+              label="due soon"
+              supportingText="Lease reminder candidates in the default window."
+            />
+            <SummaryCard
+              count={summary.unreadNotificationCount}
+              label="unread"
+              supportingText="Persisted notifications still awaiting acknowledgement."
+            />
+          </div>
+        )}
+        {error ? <p className="error-text">{error}</p> : null}
+      </article>
+
+      <article className="panel-card">
+        <div className="section-heading">
+          <p className="eyebrow">Next actions</p>
+          <h2 className="section-title">Open the working areas.</h2>
+        </div>
+        <div className="dashboard-actions">
+          <Link className="primary-button dashboard-action-link" to="/properties">
+            Manage properties
+          </Link>
+          <Link className="ghost-button dashboard-action-link" to="/leases">
+            Manage leases
+          </Link>
+          <Link className="ghost-button dashboard-action-link" to="/notifications">
+            Review notifications
+          </Link>
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/frontend/src/pages/LandingPage.test.tsx
+++ b/frontend/src/pages/LandingPage.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { AuthContext, type AuthContextValue } from "../app/AuthContext";
+import { LandingPage } from "./LandingPage";
+
+function createAuthValue(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
+  return {
+    completeSignIn: vi.fn(),
+    isAuthenticated: false,
+    markSessionExpired: vi.fn(),
+    session: null,
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("LandingPage", () => {
+  it("redirects authenticated users to the dashboard", () => {
+    render(
+      <AuthContext.Provider value={createAuthValue({ isAuthenticated: true })}>
+        <MemoryRouter initialEntries={["/"]}>
+          <Routes>
+            <Route element={<LandingPage />} path="/" />
+            <Route element={<div>Dashboard route</div>} path="/dashboard" />
+          </Routes>
+        </MemoryRouter>
+      </AuthContext.Provider>
+    );
+
+    expect(screen.getByText("Dashboard route")).toBeInTheDocument();
+  });
+
+  it("starts sign-in with the dashboard as the default return path", () => {
+    const authValue = createAuthValue();
+
+    render(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter>
+          <LandingPage />
+        </MemoryRouter>
+      </AuthContext.Provider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign in with Cognito" }));
+
+    expect(authValue.signIn).toHaveBeenCalledWith("/dashboard");
+  });
+});

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -8,7 +8,7 @@ export function LandingPage() {
   const [error, setError] = useState<string | null>(null);
 
   if (auth.isAuthenticated) {
-    return <Navigate replace to="/properties" />;
+    return <Navigate replace to="/dashboard" />;
   }
 
   const returnPath =
@@ -17,7 +17,7 @@ export function LandingPage() {
     "from" in location.state &&
     typeof location.state.from === "string"
       ? location.state.from
-      : "/properties";
+      : "/dashboard";
 
   async function handleSignIn() {
     try {
@@ -54,8 +54,9 @@ export function LandingPage() {
           <h2>In scope now</h2>
           <ul className="info-list">
             <li>Hosted UI sign in and sign out</li>
-            <li>Properties list and create</li>
-            <li>Leases list and create</li>
+            <li>Operational dashboard summaries</li>
+            <li>Properties and leases workflows</li>
+            <li>Reminder and notification status</li>
           </ul>
         </article>
         <article className="info-card">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -101,6 +101,11 @@ button {
   align-items: start;
 }
 
+.dashboard-layout {
+  display: grid;
+  gap: 1.5rem;
+}
+
 .eyebrow {
   margin: 0 0 0.6rem;
   color: var(--primary);
@@ -207,9 +212,41 @@ button {
   gap: 0.65rem;
 }
 
+.summary-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
 .resource-list {
   display: grid;
   gap: 1rem;
+}
+
+.summary-card {
+  padding: 1.35rem;
+  border: 1px solid rgba(19, 38, 31, 0.08);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.summary-count {
+  margin: 0 0 0.5rem;
+  font-family: var(--display-font);
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+  font-weight: 700;
+  line-height: 1;
+  color: var(--ink-strong);
+}
+
+.dashboard-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+
+.dashboard-action-link {
+  text-decoration: none;
 }
 
 .resource-card {


### PR DESCRIPTION
## Summary

Closes #112.

Adds a protected authenticated dashboard at `/dashboard` and makes it the default post-login entry point. The dashboard loads existing tenant-scoped frontend API list methods in parallel and renders concise summary cards for properties, leases, due-soon reminders, and unread notifications.

## What Changed

- Added `/dashboard` as a protected route.
- Added `Dashboard` to authenticated navigation before Properties, Leases, and Notifications.
- Changed authenticated landing, default sign-in return path, callback fallback, and retry sign-in path to `/dashboard`.
- Added a dashboard feature hook and page tests for empty, populated, unread-count, error, unauthorized, and link behavior.
- Updated frontend and MVP docs so dashboard is no longer described as a future follow-up.

## Assumptions

- Existing list APIs are sufficient for an MVP operational summary.
- Dashboard shows aggregate counts only and does not show notification message content or tenant identifiers.
- Reminder scan creation remains internal/operator-only and is not exposed in the browser.

## Security Validation

- No `tenant_id` is added to request bodies or query parameters.
- Dashboard data access uses existing authenticated API client methods with bearer auth.
- Tenant context remains backend-enforced from validated Cognito JWT claims.
- Browser code does not use admin auth APIs.

## Cost Validation

No AWS, Terraform, database, Cognito, or backend resources were added or changed. No cost impact is expected.

## Validation

- `cd frontend && npm run lint` passed.
- `cd frontend && npm run test` passed: 14 test files, 43 tests.
- `cd frontend && npm run build` passed.
- `git diff --check` passed.

## Remaining Risks / TODOs

- Manual hosted/local browser verification can be done after merge when the dev stack is available.
- Hosted frontend smoke validation remains separate from this frontend-only PR.