### PR TITLE
docs: clarify frontend auth setup

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,19 +25,31 @@ deploy automation.
 - Node.js 20+
 - npm
 - a deployed dev stack with Hosted UI and browser CORS configured
+- Terraform and AWS CLI access to the dev stack for reading outputs
+- Python 3 for generating temporary browser smoke-test passwords
 
 ## Environment
 
 Copy `.env.example` to `.env.local` and fill the values from Terraform outputs.
 
-What it does: reads the deployed API and Cognito values for the browser frontend.
+What it does: reads the deployed API, Cognito, and hosted frontend values as
+named lines so the values are easy to copy without mixing them together.
 Target filename/service: `infra/environments/dev` / Terraform outputs.
 
 ```bash
 cd /mnt/c/Repos/LeaseFlow/infra/environments/dev
-terraform output -raw api_stage_invoke_url
-terraform output -raw cognito_hosted_ui_base_url
-terraform output -raw cognito_user_pool_client_id
+export AWS_PROFILE=terraform
+export AWS_REGION=eu-north-1
+
+export API_URL=$(terraform output -raw api_stage_invoke_url)
+export COGNITO_HOSTED_UI=$(terraform output -raw cognito_hosted_ui_base_url)
+export COGNITO_CLIENT_ID=$(terraform output -raw cognito_user_pool_client_id)
+export FRONTEND_URL=$(terraform output -raw frontend_cloudfront_url)
+
+printf 'API_URL=%s\n' "$API_URL"
+printf 'COGNITO_HOSTED_UI=%s\n' "$COGNITO_HOSTED_UI"
+printf 'COGNITO_CLIENT_ID=%s\n' "$COGNITO_CLIENT_ID"
+printf 'FRONTEND_URL=%s\n' "$FRONTEND_URL"
 ```
 
 Required env vars:
@@ -45,6 +57,86 @@ Required env vars:
 - `VITE_API_BASE_URL`
 - `VITE_COGNITO_HOSTED_UI_BASE_URL`
 - `VITE_COGNITO_CLIENT_ID`
+
+What it does: writes the local Vite environment file from the Terraform output
+values loaded above.
+Target filename/service: `frontend/.env.local`.
+
+```bash
+cd /mnt/c/Repos/LeaseFlow/frontend
+cat > .env.local <<EOF
+VITE_API_BASE_URL=${API_URL}
+VITE_COGNITO_HOSTED_UI_BASE_URL=${COGNITO_HOSTED_UI}
+VITE_COGNITO_CLIENT_ID=${COGNITO_CLIENT_ID}
+EOF
+```
+
+The `.env.local` values must match the Terraform outputs exactly. A wrong
+`VITE_COGNITO_CLIENT_ID` can make Cognito Hosted UI redirect to
+`invalid_request` before the login page is shown.
+
+Restart the Vite dev server after changing `.env.local`; Vite reads these
+values at startup. Hosted CloudFront builds embed the same Vite env values at
+build time, so hosted validation requires a rebuild, S3 sync, and CloudFront
+invalidation after env changes.
+
+## Temporary browser login user
+
+No browser login email/password exists by default. Create a temporary Cognito
+user in the deployed dev user pool before browser smoke testing.
+
+What it does: loads the Cognito user pool and app client IDs needed for local
+operator setup.
+Target filename/service: `infra/environments/dev` / Terraform outputs.
+
+```bash
+cd /mnt/c/Repos/LeaseFlow/infra/environments/dev
+export AWS_PROFILE=terraform
+export AWS_REGION=eu-north-1
+
+export USER_POOL_ID=$(terraform output -raw cognito_user_pool_id)
+export COGNITO_CLIENT_ID=$(terraform output -raw cognito_user_pool_client_id)
+```
+
+What it does: creates a temporary dev-only Cognito user with the required tenant
+claim for Hosted UI browser login.
+Target service: Amazon Cognito user pool.
+
+```bash
+export DEMO_STAMP=$(date -u +%Y%m%d%H%M%S)
+export DEMO_EMAIL="browser-demo-${DEMO_STAMP}@example.com"
+export DEMO_TENANT="browser-demo-${DEMO_STAMP}"
+export DEMO_PASSWORD=$(python3 -c "import secrets,string; chars=string.ascii_letters+string.digits; print('Lf-'+''.join(secrets.choice(chars) for _ in range(18))+'!Aa1')")
+
+aws cognito-idp admin-create-user \
+  --user-pool-id "$USER_POOL_ID" \
+  --username "$DEMO_EMAIL" \
+  --user-attributes \
+    Name=email,Value="$DEMO_EMAIL" \
+    Name=email_verified,Value=true \
+    Name=custom:tenant_id,Value="$DEMO_TENANT" \
+  --message-action SUPPRESS
+
+aws cognito-idp admin-set-user-password \
+  --user-pool-id "$USER_POOL_ID" \
+  --username "$DEMO_EMAIL" \
+  --password "$DEMO_PASSWORD" \
+  --permanent
+```
+
+What it does: prints only the local temporary credentials you need to type into
+Cognito Hosted UI.
+Target service: local terminal only.
+
+```bash
+printf 'DEMO_EMAIL=%s\n' "$DEMO_EMAIL"
+printf 'DEMO_PASSWORD=%s\n' "$DEMO_PASSWORD"
+```
+
+Do not commit or paste the temporary email, password, tenant value, JWTs, or
+session storage values into evidence. Cognito passwords cannot be retrieved
+later; if you lose the password, set a new one with `admin-set-user-password`.
+The browser frontend must still use Hosted UI login, not admin auth APIs.
 
 ## Run
 
@@ -68,7 +160,8 @@ Then open `http://localhost:5173`.
 ## Hosted dev deploy
 
 Terraform creates the S3 bucket and CloudFront distribution. Frontend asset
-upload remains a local operator step.
+upload remains a local operator step. If any `VITE_*` value changes, rebuild
+and upload the frontend again because the static assets contain those values.
 
 What it does: reads hosted frontend deployment outputs.
 Target filename/service: `infra/environments/dev` / Terraform outputs.
@@ -99,6 +192,22 @@ aws cloudfront create-invalidation \
 ```
 
 Then open the value of `FRONTEND_URL`.
+
+## Hosted UI `invalid_request` checklist
+
+If Cognito redirects to `/error?error=invalid_request` before the login page,
+compare the browser authorize URL against Terraform outputs and app client
+settings:
+
+- `client_id` exactly matches `terraform output -raw cognito_user_pool_client_id`.
+- `redirect_uri` is `http://localhost:5173/auth/callback` for local Vite or
+  `${FRONTEND_URL}/auth/callback` for CloudFront.
+- `scope` is exactly `openid email profile`.
+- Hosted UI base URL exactly matches
+  `terraform output -raw cognito_hosted_ui_base_url`.
+- Cognito app client has OAuth code flow enabled.
+- Cognito app client allows callback and logout URLs for the current origin.
+- Cognito app client allows scopes `openid`, `email`, and `profile`.
 
 ## Checks
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -38,6 +38,8 @@ the real frontend.
 - Terraform creates the hosting bucket/distribution; `aws s3 sync` uploads
   built frontend assets.
 - The existing `demo-client` remains a separate local demo/operator tool.
+- Use `frontend/README.md` for browser `.env.local`, Hosted UI troubleshooting,
+  and temporary Cognito demo user setup.
 
 ## DB password handling
 


### PR DESCRIPTION
## Summary

Closes #120.

Clarifies browser frontend local auth setup so Terraform outputs, `.env.local`, Cognito Hosted UI values, and temporary demo user creation are easier to follow during manual validation.

## What Changed

- Updated `frontend/README.md` to print Terraform outputs as named values instead of raw back-to-back output.
- Added explicit `.env.local` mapping for the existing Vite env vars.
- Documented that Vite must be restarted after `.env.local` changes.
- Documented that CloudFront-hosted builds embed Vite env values at build time and require rebuild, S3 sync, and invalidation after env changes.
- Added operator-only temporary Cognito demo user setup with `custom:tenant_id` and password reset guidance.
- Added a Hosted UI `invalid_request` troubleshooting checklist.
- Added a short infra README cross-link to keep browser auth setup centralized in the frontend docs.

## Assumptions

- This remains docs-only.
- Browser auth continues to use Cognito Hosted UI authorization code + PKCE with `openid email profile`.
- Temporary Cognito users are for dev/operator validation only.

## Security Validation

- No browser admin auth flow was added; admin Cognito commands are documented only for local operator setup.
- Tenant context remains documented as coming from validated Cognito JWT claims, not request body input.
- Temporary users are documented with required `custom:tenant_id`.
- No JWTs, real Cognito emails, tenant IDs, SSM values, DB endpoints, or raw tokens were added.

## Cost Validation

No AWS, Terraform, backend, frontend runtime, or CI behavior changed. No cost impact is expected.

## Validation

- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- Manual doc review completed for secrets, Hosted UI scope wording, and admin-auth browser separation.

## Remaining Risks / TODOs

- The documented temporary demo user flow is still manual operator setup.
- Hosted browser smoke validation remains separate from this docs-only PR.