### PR TITLE
chore: add dev setup operator scripts

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -32,6 +32,17 @@ deploy automation.
 
 Copy `.env.example` to `.env.local` and fill the values from Terraform outputs.
 
+What it does: writes `frontend/.env.local` from the deployed dev Terraform
+outputs.
+Target filename/service: `frontend/.env.local`.
+
+```bash
+cd /mnt/c/Repos/LeaseFlow
+bash scripts/dev/write-frontend-env.sh
+```
+
+The manual commands below are useful when troubleshooting individual values.
+
 What it does: reads the deployed API, Cognito, and hosted frontend values as
 named lines so the values are easy to copy without mixing them together.
 Target filename/service: `infra/environments/dev` / Terraform outputs.
@@ -84,6 +95,17 @@ invalidation after env changes.
 
 No browser login email/password exists by default. Create a temporary Cognito
 user in the deployed dev user pool before browser smoke testing.
+
+What it does: creates a temporary Cognito Hosted UI user and prints only the
+local email/password values needed for browser login.
+Target service: Amazon Cognito user pool.
+
+```bash
+cd /mnt/c/Repos/LeaseFlow
+bash scripts/dev/create-demo-user.sh
+```
+
+The manual commands below are useful when troubleshooting user creation.
 
 What it does: loads the Cognito user pool and app client IDs needed for local
 operator setup.
@@ -162,6 +184,17 @@ Then open `http://localhost:5173`.
 Terraform creates the S3 bucket and CloudFront distribution. Frontend asset
 upload remains a local operator step. If any `VITE_*` value changes, rebuild
 and upload the frontend again because the static assets contain those values.
+
+What it does: builds and uploads the hosted frontend, then invalidates
+CloudFront.
+Target service: S3 frontend hosting bucket and CloudFront distribution.
+
+```bash
+cd /mnt/c/Repos/LeaseFlow
+bash scripts/dev/upload-frontend.sh
+```
+
+The manual commands below are useful when troubleshooting hosted upload steps.
 
 What it does: reads hosted frontend deployment outputs.
 Target filename/service: `infra/environments/dev` / Terraform outputs.

--- a/infra/README.md
+++ b/infra/README.md
@@ -41,6 +41,87 @@ the real frontend.
 - Use `frontend/README.md` for browser `.env.local`, Hosted UI troubleshooting,
   and temporary Cognito demo user setup.
 
+## Scripted first-time dev setup
+
+The WSL/Linux operator scripts under `scripts/dev/` package the manual dev
+setup path into small reviewable steps. They do not destroy resources, commit
+files, make RDS public, or hide Terraform approval.
+
+What it does: creates the Terraform remote state bucket and writes the ignored
+dev backend config.
+Target service: Terraform bootstrap state bucket and
+`infra/environments/dev/backend.hcl`.
+
+```bash
+cd /mnt/c/Repos/LeaseFlow
+bash scripts/dev/bootstrap-state.sh
+```
+
+What it does: creates the ignored dev variable file from the example.
+Target filename/service: `infra/environments/dev/terraform.tfvars`.
+
+```bash
+cp infra/environments/dev/terraform.tfvars.example infra/environments/dev/terraform.tfvars
+```
+
+Edit `infra/environments/dev/terraform.tfvars` before applying. At minimum,
+replace `cognito_hosted_ui_domain_prefix` with a globally unique Cognito managed
+domain prefix.
+
+What it does: builds the Linux-compatible backend Lambda artifact.
+Target filename/service: `dist/leaseflow-backend.zip`.
+
+```bash
+bash scripts/dev/build-lambda.sh
+```
+
+What it does: initializes, validates, and interactively applies the dev stack.
+Target service: Terraform-managed LeaseFlow dev environment.
+
+```bash
+bash scripts/dev/apply-stack.sh
+```
+
+What it does: runs deployed DB migrations through the backend Lambda internal
+migration event.
+Target service: AWS Lambda function `leaseflow-dev-backend`.
+
+```bash
+bash scripts/dev/run-migrations.sh
+```
+
+What it does: writes browser frontend `.env.local` from Terraform outputs.
+Target filename/service: `frontend/.env.local`.
+
+```bash
+bash scripts/dev/write-frontend-env.sh
+```
+
+What it does: creates a temporary Cognito browser login user for local Hosted UI
+validation.
+Target service: Amazon Cognito user pool.
+
+```bash
+bash scripts/dev/create-demo-user.sh
+```
+
+What it does: prints the deployed dev outputs as named safe lines.
+Target service: Terraform-managed LeaseFlow dev environment.
+
+```bash
+bash scripts/dev/print-outputs.sh
+```
+
+Optional hosted frontend upload:
+
+What it does: builds `frontend/`, uploads `dist/` to the Terraform-created S3
+bucket, and invalidates CloudFront.
+Target service: S3 frontend hosting bucket and CloudFront distribution.
+
+```bash
+bash scripts/dev/upload-frontend.sh
+```
+
 ## DB password handling
 
 - The dev environment now generates the RDS master password in Terraform.

--- a/scripts/dev/apply-stack.sh
+++ b/scripts/dev/apply-stack.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+require_linux
+require_repo_root
+require_command terraform
+require_dev_backend_config
+require_dev_tfvars
+require_file "${LAMBDA_ARTIFACT}"
+reject_placeholder_dev_tfvars
+
+info "Initializing dev Terraform with remote state"
+terraform -chdir="${DEV_TF_DIR}" init -backend-config=backend.hcl
+
+info "Validating dev Terraform"
+terraform -chdir="${DEV_TF_DIR}" validate
+
+info "Applying dev Terraform interactively"
+terraform -chdir="${DEV_TF_DIR}" apply

--- a/scripts/dev/bootstrap-state.sh
+++ b/scripts/dev/bootstrap-state.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+require_linux
+require_repo_root
+require_command terraform
+
+info "Bootstrapping Terraform remote state with AWS_PROFILE=${AWS_PROFILE} AWS_REGION=${AWS_REGION}"
+terraform -chdir="${BOOTSTRAP_TF_DIR}" init
+terraform -chdir="${BOOTSTRAP_TF_DIR}" apply
+
+info "Writing dev backend config"
+terraform -chdir="${BOOTSTRAP_TF_DIR}" output -raw dev_backend_config > "${DEV_TF_DIR}/backend.hcl"
+
+info "Wrote infra/environments/dev/backend.hcl"

--- a/scripts/dev/build-lambda.sh
+++ b/scripts/dev/build-lambda.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+require_linux
+require_repo_root
+
+export PYTHON_BIN="${PYTHON_BIN:-${LAMBDA_PYTHON:-python3.12}}"
+
+info "Building Lambda artifact with PYTHON_BIN=${PYTHON_BIN}"
+bash "${REPO_ROOT}/scripts/build_lambda_artifact.sh"

--- a/scripts/dev/create-demo-user.sh
+++ b/scripts/dev/create-demo-user.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+require_linux
+require_repo_root
+require_command aws
+require_command python3
+terraform_dev_init
+
+USER_POOL_ID="$(terraform_dev_output cognito_user_pool_id)"
+DEMO_STAMP="${DEMO_STAMP:-$(date -u +%Y%m%d%H%M%S)}"
+DEMO_EMAIL="${DEMO_EMAIL:-browser-demo-${DEMO_STAMP}@example.com}"
+DEMO_TENANT="${DEMO_TENANT:-browser-demo-${DEMO_STAMP}}"
+DEMO_PASSWORD="${DEMO_PASSWORD:-$(python3 - <<'PY'
+import secrets
+import string
+
+chars = string.ascii_letters + string.digits
+print("Lf-" + "".join(secrets.choice(chars) for _ in range(18)) + "!Aa1")
+PY
+)}"
+
+info "Creating temporary Cognito browser demo user"
+aws cognito-idp admin-create-user \
+  --user-pool-id "${USER_POOL_ID}" \
+  --username "${DEMO_EMAIL}" \
+  --user-attributes \
+    Name=email,Value="${DEMO_EMAIL}" \
+    Name=email_verified,Value=true \
+    Name=custom:tenant_id,Value="${DEMO_TENANT}" \
+  --message-action SUPPRESS >/dev/null
+
+aws cognito-idp admin-set-user-password \
+  --user-pool-id "${USER_POOL_ID}" \
+  --username "${DEMO_EMAIL}" \
+  --password "${DEMO_PASSWORD}" \
+  --permanent >/dev/null
+
+printf 'EMAIL=%s\n' "${DEMO_EMAIL}"
+printf 'PASSWORD=%s\n' "${DEMO_PASSWORD}"
+echo "Do not commit or paste these temporary credentials into evidence."

--- a/scripts/dev/lib.sh
+++ b/scripts/dev/lib.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+BOOTSTRAP_TF_DIR="${REPO_ROOT}/infra/bootstrap/terraform_state"
+DEV_TF_DIR="${REPO_ROOT}/infra/environments/dev"
+FRONTEND_DIR="${REPO_ROOT}/frontend"
+LAMBDA_ARTIFACT="${REPO_ROOT}/dist/leaseflow-backend.zip"
+
+export AWS_PROFILE="${AWS_PROFILE:-terraform}"
+export AWS_REGION="${AWS_REGION:-eu-north-1}"
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-${AWS_REGION}}"
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+info() {
+  echo "==> $*"
+}
+
+require_linux() {
+  [[ "$(uname -s)" == "Linux" ]] || die "Run this script in WSL/Linux."
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
+}
+
+require_file() {
+  [[ -f "$1" ]] || die "Missing required file: $1"
+}
+
+require_dir() {
+  [[ -d "$1" ]] || die "Missing required directory: $1"
+}
+
+require_repo_root() {
+  require_dir "${REPO_ROOT}/infra"
+  require_dir "${REPO_ROOT}/backend"
+  require_file "${FRONTEND_DIR}/package.json"
+}
+
+require_dev_backend_config() {
+  require_file "${DEV_TF_DIR}/backend.hcl"
+}
+
+require_dev_tfvars() {
+  require_file "${DEV_TF_DIR}/terraform.tfvars"
+}
+
+reject_placeholder_dev_tfvars() {
+  if grep -q "replace-with-a-unique-dev-prefix" "${DEV_TF_DIR}/terraform.tfvars"; then
+    die "Replace cognito_hosted_ui_domain_prefix in infra/environments/dev/terraform.tfvars first."
+  fi
+}
+
+terraform_dev_init() {
+  require_command terraform
+  require_dev_backend_config
+  terraform -chdir="${DEV_TF_DIR}" init -backend-config=backend.hcl -input=false >/dev/null
+}
+
+terraform_dev_output() {
+  local output_name="$1"
+  terraform -chdir="${DEV_TF_DIR}" output -raw "${output_name}"
+}
+
+print_named_output() {
+  local name="$1"
+  local output_name="$2"
+  printf '%s=%s\n' "${name}" "$(terraform_dev_output "${output_name}")"
+}

--- a/scripts/dev/print-outputs.sh
+++ b/scripts/dev/print-outputs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+require_linux
+require_repo_root
+terraform_dev_init
+
+print_named_output "API_URL" "api_stage_invoke_url"
+print_named_output "COGNITO_HOSTED_UI" "cognito_hosted_ui_base_url"
+print_named_output "COGNITO_CLIENT_ID" "cognito_user_pool_client_id"
+print_named_output "USER_POOL_ID" "cognito_user_pool_id"
+print_named_output "FRONTEND_BUCKET" "frontend_bucket_name"
+print_named_output "FRONTEND_DISTRIBUTION_ID" "frontend_cloudfront_distribution_id"
+print_named_output "FRONTEND_URL" "frontend_cloudfront_url"

--- a/scripts/dev/run-migrations.sh
+++ b/scripts/dev/run-migrations.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+require_linux
+require_repo_root
+require_command aws
+require_command python3
+terraform_dev_init
+
+BACKEND_FUNCTION="${BACKEND_FUNCTION:-leaseflow-dev-backend}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+PAYLOAD_FILE="${TMP_DIR}/migration-payload.json"
+RESPONSE_FILE="${TMP_DIR}/migration-response.json"
+
+cat > "${PAYLOAD_FILE}" <<'JSON'
+{"source":"leaseflow.internal","detail-type":"run_db_migrations","detail":{}}
+JSON
+
+info "Invoking deployed DB migrations through ${BACKEND_FUNCTION}"
+aws lambda invoke \
+  --region "${AWS_REGION}" \
+  --function-name "${BACKEND_FUNCTION}" \
+  --cli-binary-format raw-in-base64-out \
+  --payload "fileb://${PAYLOAD_FILE}" \
+  "${RESPONSE_FILE}" \
+  --query 'StatusCode' \
+  --output text >/dev/null
+
+python3 - "${RESPONSE_FILE}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as response_file:
+    payload = json.load(response_file)
+
+status_code = payload.get("statusCode")
+print(f"MIGRATION_STATUS_CODE={status_code}")
+
+body = payload.get("body")
+if isinstance(body, str):
+    try:
+        body = json.loads(body)
+    except json.JSONDecodeError:
+        body = {}
+
+if isinstance(body, dict):
+    for key in ("previous_revision", "target_revision", "current_revision"):
+        value = body.get(key)
+        if value is not None:
+            print(f"{key.upper()}={value}")
+
+if status_code != 200:
+    sys.exit(1)
+PY

--- a/scripts/dev/upload-frontend.sh
+++ b/scripts/dev/upload-frontend.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+require_linux
+require_repo_root
+require_command aws
+require_command npm
+require_file "${FRONTEND_DIR}/.env.local"
+terraform_dev_init
+
+FRONTEND_BUCKET="$(terraform_dev_output frontend_bucket_name)"
+FRONTEND_DISTRIBUTION_ID="$(terraform_dev_output frontend_cloudfront_distribution_id)"
+FRONTEND_URL="$(terraform_dev_output frontend_cloudfront_url)"
+
+info "Building frontend"
+npm --prefix "${FRONTEND_DIR}" run build
+
+info "Uploading frontend assets"
+aws s3 sync "${FRONTEND_DIR}/dist/" "s3://${FRONTEND_BUCKET}/" --delete
+
+info "Invalidating CloudFront distribution"
+aws cloudfront create-invalidation \
+  --distribution-id "${FRONTEND_DISTRIBUTION_ID}" \
+  --paths "/*" \
+  --query 'Invalidation.{Id:Id,Status:Status}' \
+  --output table
+
+printf 'FRONTEND_URL=%s\n' "${FRONTEND_URL}"

--- a/scripts/dev/write-frontend-env.sh
+++ b/scripts/dev/write-frontend-env.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+require_linux
+require_repo_root
+terraform_dev_init
+
+API_URL="$(terraform_dev_output api_stage_invoke_url)"
+COGNITO_HOSTED_UI="$(terraform_dev_output cognito_hosted_ui_base_url)"
+COGNITO_CLIENT_ID="$(terraform_dev_output cognito_user_pool_client_id)"
+
+cat > "${FRONTEND_DIR}/.env.local" <<EOF
+VITE_API_BASE_URL=${API_URL}
+VITE_COGNITO_HOSTED_UI_BASE_URL=${COGNITO_HOSTED_UI}
+VITE_COGNITO_CLIENT_ID=${COGNITO_CLIENT_ID}
+EOF
+
+info "Wrote frontend/.env.local"
+info "Restart Vite after changing frontend/.env.local."


### PR DESCRIPTION
## Summary

Closes #121.

Adds small WSL/Linux operator scripts for the first-time AWS dev setup and repeated dev validation path. The scripts package existing manual Terraform, Lambda, migration, frontend env, Cognito demo-user, and hosted frontend upload steps without changing application behavior or AWS architecture.

## What Changed

- Added `scripts/dev/lib.sh` with repo-root detection, Linux guard, default `AWS_PROFILE=terraform`, default `AWS_REGION=eu-north-1`, command/file guards, and Terraform output helpers.
- Added explicit operator scripts for bootstrap state, Lambda artifact build, dev stack apply, safe output printing, deployed migrations, frontend env writing, temporary Cognito demo user creation, and hosted frontend upload.
- Updated `infra/README.md` with a script-based first-time dev setup path.
- Updated `frontend/README.md` to point to the script-based env, demo-user, and hosted upload flows while keeping manual troubleshooting commands.

## Assumptions

- Scripts target WSL/Linux first; PowerShell wrappers remain out of scope.
- Several explicit scripts are preferred over one fully automatic setup script.
- Interactive Terraform approval remains the default; no auto-approve path was added.

## Security Validation

- Scripts do not print JWTs, Cognito tokens, SSM values, DB passwords, DB connection strings, or tenant IDs.
- `create-demo-user.sh` sets `custom:tenant_id` but prints only the temporary Hosted UI email and password for local operator use.
- Browser auth remains Cognito Hosted UI + PKCE; Cognito admin CLI usage is documented only for local operator setup.
- No destroy automation, RDS public access change, or git staging/commit behavior was added.

## Cost Validation

No Terraform resources, AWS architecture, backend runtime, frontend runtime, or CI behavior changed. The scripts can create/apply existing dev resources only when the operator explicitly runs the interactive Terraform apply path.

## Validation

- RED check before implementation: `bash -n scripts/dev/*.sh` failed because scripts did not exist.
- `bash -n scripts/dev/*.sh` passed after implementation.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- Manual script/docs review completed for forbidden output, `custom:tenant_id`, no browser admin auth, no destroy automation, and no RDS public access suggestion.

## Remaining Risks / TODOs

- Full AWS execution of the scripts remains optional operator validation and was not run in this docs/scripts PR.
- The scripts are intentionally explicit and manual; they are not a CI deploy pipeline.