### PR TITLE
chore: add dev demo data seed script

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -105,6 +105,22 @@ cd /mnt/c/Repos/LeaseFlow
 bash scripts/dev/create-demo-user.sh
 ```
 
+`create-demo-user.sh` creates an empty tenant for manual browser testing. If you
+want a ready portfolio/demo tenant with synthetic properties, leases, and
+notifications, use the seed script instead:
+
+What it does: creates a temporary Cognito login user and synthetic demo data
+through the deployed dev API.
+Target service: Amazon Cognito and LeaseFlow deployed dev API.
+
+```bash
+cd /mnt/c/Repos/LeaseFlow
+bash scripts/dev/seed-demo-data.sh
+```
+
+Seeded data is disposable dev/demo data. It is removed when the dev database is
+destroyed with the stack.
+
 The manual commands below are useful when troubleshooting user creation.
 
 What it does: loads the Cognito user pool and app client IDs needed for local

--- a/infra/README.md
+++ b/infra/README.md
@@ -90,6 +90,16 @@ Target service: AWS Lambda function `leaseflow-dev-backend`.
 bash scripts/dev/run-migrations.sh
 ```
 
+Optional seeded demo tenant:
+
+What it does: creates a temporary Cognito login user plus synthetic properties,
+leases, and reminder notifications through the deployed dev API.
+Target service: Amazon Cognito, API Gateway, Lambda, and private RDS.
+
+```bash
+bash scripts/dev/seed-demo-data.sh
+```
+
 What it does: writes browser frontend `.env.local` from Terraform outputs.
 Target filename/service: `frontend/.env.local`.
 

--- a/scripts/dev/seed-demo-data.sh
+++ b/scripts/dev/seed-demo-data.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+require_linux
+require_repo_root
+require_command aws
+require_command curl
+require_command python3
+terraform_dev_init
+
+API_URL="$(terraform_dev_output api_stage_invoke_url)"
+API_URL="${API_URL%/}"
+USER_POOL_ID="$(terraform_dev_output cognito_user_pool_id)"
+APP_CLIENT_ID="$(terraform_dev_output cognito_user_pool_client_id)"
+BACKEND_FUNCTION="${BACKEND_FUNCTION:-leaseflow-dev-backend}"
+
+SEED_STAMP="${SEED_STAMP:-$(date -u +%Y%m%d%H%M%S)}"
+SEED_EMAIL="${SEED_EMAIL:-seed-demo-${SEED_STAMP}@example.com}"
+SEED_TENANT="${SEED_TENANT:-seed-demo-${SEED_STAMP}}"
+SEED_PASSWORD="${SEED_PASSWORD:-$(python3 - <<'PY'
+import secrets
+import string
+
+chars = string.ascii_letters + string.digits
+print("Lf-" + "".join(secrets.choice(chars) for _ in range(18)) + "!Aa1")
+PY
+)}"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+json_field() {
+  local file_path="$1"
+  local field_name="$2"
+  python3 - "${file_path}" "${field_name}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as response_file:
+    payload = json.load(response_file)
+
+value = payload[sys.argv[2]]
+print(value)
+PY
+}
+
+api_post_json() {
+  local route="$1"
+  local payload_file="$2"
+  local response_file="$3"
+  local status_code
+
+  status_code="$(
+    curl -sS \
+      -X POST \
+      -H "Authorization: Bearer ${ID_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d @"${payload_file}" \
+      -o "${response_file}" \
+      -w "%{http_code}" \
+      "${API_URL}${route}"
+  )"
+
+  if [[ "${status_code}" != "201" ]]; then
+    die "POST ${route} failed with HTTP ${status_code}."
+  fi
+}
+
+write_property_payload() {
+  local payload_file="$1"
+  local name="$2"
+  local address="$3"
+
+  python3 - "${payload_file}" "${name}" "${address}" <<'PY'
+import json
+import sys
+
+payload = {
+    "name": sys.argv[2],
+    "address": sys.argv[3],
+}
+
+with open(sys.argv[1], "w", encoding="utf-8") as payload_file:
+    json.dump(payload, payload_file)
+PY
+}
+
+write_lease_payload() {
+  local payload_file="$1"
+  local property_id="$2"
+  local resident_name="$3"
+  local rent_due_day="$4"
+  local start_date="$5"
+  local end_date="$6"
+
+  python3 - \
+    "${payload_file}" \
+    "${property_id}" \
+    "${resident_name}" \
+    "${rent_due_day}" \
+    "${start_date}" \
+    "${end_date}" <<'PY'
+import json
+import sys
+
+payload = {
+    "property_id": sys.argv[2],
+    "resident_name": sys.argv[3],
+    "rent_due_day_of_month": int(sys.argv[4]),
+    "start_date": sys.argv[5],
+    "end_date": sys.argv[6],
+}
+
+with open(sys.argv[1], "w", encoding="utf-8") as payload_file:
+    json.dump(payload, payload_file)
+PY
+}
+
+info "Creating temporary Cognito seed user"
+aws cognito-idp admin-create-user \
+  --user-pool-id "${USER_POOL_ID}" \
+  --username "${SEED_EMAIL}" \
+  --user-attributes \
+    Name=email,Value="${SEED_EMAIL}" \
+    Name=email_verified,Value=true \
+    Name=custom:tenant_id,Value="${SEED_TENANT}" \
+  --message-action SUPPRESS >/dev/null
+
+aws cognito-idp admin-set-user-password \
+  --user-pool-id "${USER_POOL_ID}" \
+  --username "${SEED_EMAIL}" \
+  --password "${SEED_PASSWORD}" \
+  --permanent >/dev/null
+
+ID_TOKEN="$(
+  aws cognito-idp admin-initiate-auth \
+    --user-pool-id "${USER_POOL_ID}" \
+    --client-id "${APP_CLIENT_ID}" \
+    --auth-flow ADMIN_USER_PASSWORD_AUTH \
+    --auth-parameters USERNAME="${SEED_EMAIL}",PASSWORD="${SEED_PASSWORD}" \
+    --query 'AuthenticationResult.IdToken' \
+    --output text
+)"
+
+[[ -n "${ID_TOKEN}" && "${ID_TOKEN}" != "None" ]] || die "Could not obtain Cognito ID token."
+
+TODAY="$(date -u +%Y-%m-%d)"
+START_DATE="$(date -u -d "-7 days" +%Y-%m-%d)"
+END_DATE="$(date -u -d "+120 days" +%Y-%m-%d)"
+RENT_DUE_DAY="$(date -u +%-d)"
+FUTURE_RENT_DUE_DAY="$(python3 - "${RENT_DUE_DAY}" <<'PY'
+import sys
+
+day = int(sys.argv[1])
+print(20 if day <= 10 else 5)
+PY
+)"
+
+PROPERTY_ONE_PAYLOAD="${TMP_DIR}/property-one.json"
+PROPERTY_ONE_RESPONSE="${TMP_DIR}/property-one-response.json"
+PROPERTY_TWO_PAYLOAD="${TMP_DIR}/property-two.json"
+PROPERTY_TWO_RESPONSE="${TMP_DIR}/property-two-response.json"
+LEASE_ONE_PAYLOAD="${TMP_DIR}/lease-one.json"
+LEASE_ONE_RESPONSE="${TMP_DIR}/lease-one-response.json"
+LEASE_TWO_PAYLOAD="${TMP_DIR}/lease-two.json"
+LEASE_TWO_RESPONSE="${TMP_DIR}/lease-two-response.json"
+REMINDER_SCAN_PAYLOAD="${TMP_DIR}/reminder-scan.json"
+REMINDER_SCAN_RESPONSE="${TMP_DIR}/reminder-scan-response.json"
+
+write_property_payload "${PROPERTY_ONE_PAYLOAD}" "Demo Harbor Flats" "Demo Harbor Street 12"
+api_post_json "/properties" "${PROPERTY_ONE_PAYLOAD}" "${PROPERTY_ONE_RESPONSE}"
+PROPERTY_ONE_ID="$(json_field "${PROPERTY_ONE_RESPONSE}" "property_id")"
+
+write_property_payload "${PROPERTY_TWO_PAYLOAD}" "Demo Forest Homes" "Demo Forest Road 8"
+api_post_json "/properties" "${PROPERTY_TWO_PAYLOAD}" "${PROPERTY_TWO_RESPONSE}"
+PROPERTY_TWO_ID="$(json_field "${PROPERTY_TWO_RESPONSE}" "property_id")"
+
+write_lease_payload \
+  "${LEASE_ONE_PAYLOAD}" \
+  "${PROPERTY_ONE_ID}" \
+  "Demo Resident One" \
+  "${RENT_DUE_DAY}" \
+  "${START_DATE}" \
+  "${END_DATE}"
+api_post_json "/leases" "${LEASE_ONE_PAYLOAD}" "${LEASE_ONE_RESPONSE}"
+
+write_lease_payload \
+  "${LEASE_TWO_PAYLOAD}" \
+  "${PROPERTY_TWO_ID}" \
+  "Demo Resident Two" \
+  "${FUTURE_RENT_DUE_DAY}" \
+  "${TODAY}" \
+  "${END_DATE}"
+api_post_json "/leases" "${LEASE_TWO_PAYLOAD}" "${LEASE_TWO_RESPONSE}"
+
+python3 - "${REMINDER_SCAN_PAYLOAD}" "${SEED_TENANT}" "${TODAY}" <<'PY'
+import json
+import sys
+
+payload = {
+    "source": "leaseflow.internal",
+    "detail-type": "scan_due_lease_reminders",
+    "detail": {
+        "tenant_id": sys.argv[2],
+        "days": 7,
+        "as_of_date": sys.argv[3],
+    },
+}
+
+with open(sys.argv[1], "w", encoding="utf-8") as payload_file:
+    json.dump(payload, payload_file)
+PY
+
+aws lambda invoke \
+  --region "${AWS_REGION}" \
+  --function-name "${BACKEND_FUNCTION}" \
+  --cli-binary-format raw-in-base64-out \
+  --payload "fileb://${REMINDER_SCAN_PAYLOAD}" \
+  "${REMINDER_SCAN_RESPONSE}" \
+  --query 'StatusCode' \
+  --output text >/dev/null
+
+python3 - "${REMINDER_SCAN_RESPONSE}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as response_file:
+    payload = json.load(response_file)
+
+status_code = payload.get("statusCode")
+body = payload.get("body")
+if isinstance(body, str):
+    try:
+        body = json.loads(body)
+    except json.JSONDecodeError:
+        body = {}
+
+if not isinstance(body, dict):
+    body = {}
+
+print(f"REMINDER_SCAN_STATUS_CODE={status_code}")
+print(f"REMINDER_CANDIDATE_COUNT={body.get('candidate_count', 0)}")
+print(f"NOTIFICATION_CREATED_COUNT={body.get('created_count', 0)}")
+print(f"NOTIFICATION_DUPLICATE_COUNT={body.get('duplicate_count', 0)}")
+
+if status_code != 200:
+    sys.exit(1)
+PY
+
+printf 'EMAIL=%s\n' "${SEED_EMAIL}"
+printf 'PASSWORD=%s\n' "${SEED_PASSWORD}"
+printf 'PROPERTY_CREATED_COUNT=%s\n' "2"
+printf 'LEASE_CREATED_COUNT=%s\n' "2"
+echo "Seed data is synthetic and disposable. Do not commit or paste credentials into evidence."


### PR DESCRIPTION
## Summary

Closes #125.

Adds a WSL/Linux operator script that seeds a deployed dev stack with synthetic demo data through existing authenticated API flows. The script creates a temporary Cognito user, obtains an ID token locally, creates properties and leases via HTTP API calls, and runs the internal reminder scan to create persisted notifications.

## What Changed

- Added `scripts/dev/seed-demo-data.sh`.
- Reused existing `scripts/dev/lib.sh` helpers for repo detection, Linux guard, Terraform init, AWS defaults, and Terraform outputs.
- Seed flow creates a temporary Cognito login user with `custom:tenant_id`, creates two synthetic properties, creates two synthetic leases, and invokes the reminder scan for persisted notifications.
- Updated `infra/README.md` with the optional seeded demo tenant step after migrations.
- Updated `frontend/README.md` to distinguish empty demo-user setup from seeded demo data setup.

## Assumptions

- Seed data is synthetic and disposable.
- The script creates a fresh seed tenant/user per run rather than trying to be idempotent.
- Keeping the seed Cognito user is intentional so the operator can log in through Hosted UI and view the seeded tenant in the browser.
- Reminder scan creation is included so Dashboard and Notifications are useful immediately.

## Security Validation

- The script does not send `tenant_id` in property or lease API request bodies.
- `custom:tenant_id` is used only for Cognito user setup and the internal reminder scan event.
- The script does not print JWTs, Cognito tokens, tenant IDs, property IDs, lease IDs, raw API responses, DB values, SSM values, or connection strings.
- Browser auth remains Hosted UI + PKCE; Cognito admin auth is used only inside the local operator script to obtain a protected API token.
- No destroy automation or RDS public access changes were added.

## Cost Validation

No AWS resources, Terraform resources, backend runtime, frontend runtime, or CI behavior changed. Running the script creates only temporary Cognito user state and small synthetic tenant-scoped database rows in an already deployed dev stack.

## Validation

- RED check before implementation: explicit `test -f scripts/dev/seed-demo-data.sh && bash -n scripts/dev/seed-demo-data.sh` failed because the script did not exist.
- `bash -n scripts/dev/*.sh` passed after implementation.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- Manual review completed for no token/tenant/raw response output and no `tenant_id` in API request bodies.

## Remaining Risks / TODOs

- Live AWS execution was not run in this PR; it remains optional operator validation when a dev stack is available.
- Seeded rows are intentionally disposable and are removed when the dev database is destroyed.