### PR TITLE
ci: harden frontend npm installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "1.14.7"
 
       - name: Check Terraform formatting
         run: terraform fmt -check -recursive infra
@@ -115,6 +117,8 @@ jobs:
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "1.14.7"
 
       - name: Initialize module
         working-directory: ${{ matrix.module }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,10 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install frontend dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
+
+      - name: Audit frontend dependencies
+        run: npm audit --audit-level=high
 
       - name: Lint frontend
         run: npm run lint

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -183,8 +183,13 @@ Target filename/service: `frontend/package.json`.
 
 ```bash
 cd frontend
-npm install
+npm ci --ignore-scripts
 ```
+
+`frontend/.npmrc` sets `ignore-scripts=true`, so dependency install lifecycle
+scripts are disabled by default. Explicit project commands such as
+`npm run dev`, `npm run lint`, `npm run test`, and `npm run build` still run
+intentionally.
 
 What it does: starts the local Vite dev server.
 Target filename/service: `frontend/` browser app.
@@ -260,6 +265,14 @@ settings:
 
 ## Checks
 
+What it does: checks installed frontend dependencies for high-severity npm audit
+findings.
+Target filename/service: `frontend/package-lock.json`.
+
+```bash
+npm audit --audit-level=high
+```
+
 What it does: runs the frontend linter.
 Target filename/service: `frontend/`.
 
@@ -289,4 +302,9 @@ npm run build
 - Hosted UI requests `openid email profile` so readable custom attributes can
   be included in the ID token.
 - Session state is stored in `sessionStorage`.
+- Dependency install lifecycle scripts are disabled by default with
+  `ignore-scripts=true`.
+- Review `package-lock.json` diffs when adding npm packages, avoid unnecessary
+  dependencies, and document any deliberate lifecycle-script exception in the
+  PR.
 - Do not commit `.env.local`, tokens, tenant IDs, or any real user data.


### PR DESCRIPTION
Closes #131.

## What changed and why
- Added `frontend/.npmrc` with `ignore-scripts=true` so frontend dependency installs disable npm lifecycle scripts by default.
- Updated the frontend CI install step to run `npm ci --ignore-scripts` explicitly.
- Added `npm audit --audit-level=high` to the frontend CI job.
- Documented the local install command and dependency review policy in `frontend/README.md`.

## Assumptions
- Current frontend dependencies do not require install-time lifecycle scripts for Linux CI or local development.
- If a future dependency requires install scripts, that exception should be reviewed and documented in the PR.

## Security validation
- Install-time dependency lifecycle scripts are disabled by default through `.npmrc` and explicitly in CI.
- Explicit project scripts still run intentionally through `npm run lint`, `npm run test`, and `npm run build`.
- No npm tokens, registry credentials, JWTs, tenant IDs, or secrets were added.

## Cost validation
- No AWS, Terraform, backend, database, or runtime frontend behavior changes.
- No new paid services or deployed resources.

## Validation
- `npm ci --ignore-scripts` passed after rerun; first attempt hit a Windows `EPERM` cleanup lock on `node_modules/.vite-temp`.
- `npm audit --audit-level=high` passed with `0 vulnerabilities`.
- `npm run lint` passed.
- `npm run test` passed: 14 files, 43 tests.
- `npm run build` passed.
- `git diff --check` and `git diff --cached --check` passed.

## Remaining risks / TODOs
- `npm audit` can become noisy if upstream advisories change; if that happens, handle it as a dependency review task instead of disabling the check silently.