### PR TITLE
Add Dependabot cooldown policy and handoff guidance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,39 @@ updates:
     directory: /backend
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     labels:
       - type:chore
       - area:backend
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    labels:
+      - type:chore
+      - area:frontend
     open-pull-requests-limit: 5
 
   - package-ecosystem: terraform
     directory: /infra/environments/dev
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     labels:
       - type:chore
       - area:infra
@@ -22,6 +46,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     labels:
       - type:chore
       - area:ci

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,9 +34,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 5
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
     labels:
       - type:chore
       - area:infra
@@ -48,9 +45,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 5
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
     labels:
       - type:chore
       - area:ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,6 +342,12 @@ When creating a Pull Request (PR):
   - cost validation: explicitly state if new AWS services were added and justify them
   - remaining risks or TODOs
 
+Default commit/PR handoff:
+
+- After finishing ticket implementation, do not commit automatically unless the user explicitly asks for a commit.
+- Instead, provide a proposed commit message and PR description so the developer can review changes in the editor first.
+- If the user explicitly asks to commit, keep the commit focused and use the PR description requirements above.
+
 ### Review priorities
 
 #### Correctness


### PR DESCRIPTION
Closes #133.

## What changed and why

- Added Dependabot npm coverage for `/frontend`.
- Added cooldown policy to Dependabot update entries.
- Added repository agent guidance: do not commit automatically after ticket implementation unless explicitly requested.

## Security validation

- Frontend npm dependency updates are now covered by Dependabot.
- Cooldown reduces dependency update noise and rushed update risk.
- No dependency versions, lockfiles, npm tokens, secrets, JWTs, tenant IDs, or local config were added.

## Cost validation

- No AWS, Terraform resource, backend, database, or runtime frontend behavior changes.
- No new services or deployed resources.

## Validation

- `git diff --check` passed.
- Manually verified Dependabot entries for `pip`, `npm`, `terraform`, and `github-actions`.
- Manually verified npm entry points to `/frontend`.
- Manually verified semver-specific cooldowns are used only for supported ecosystems.
- Manually verified Terraform and GitHub Actions use `default-days` cooldown only.
