### PR TITLE
docs: finalize v0.3.0 release draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For the real browser frontend slice:
 
 ```bash
 cd frontend
-npm install
+npm ci --ignore-scripts
 npm run dev
 ```
 
@@ -84,8 +84,8 @@ Implemented now:
 
 Planned next:
 
-- Complete hosted frontend smoke validation after the dev Terraform remote
-  state source of truth is fixed.
+- Complete or explicitly gate hosted frontend smoke validation for the
+  `v0.3.0` release checkpoint.
 - Add delivery behavior on top of persisted notifications
 - Add more automated backend and tenant-isolation test coverage
 - Refine operational setup for scheduled workflows and monitoring

--- a/docs/frontend-mvp-strategy.md
+++ b/docs/frontend-mvp-strategy.md
@@ -86,12 +86,13 @@ Current implemented slice:
 
 Later frontend follow-ups:
 
-- hosted asset upload and browser smoke validation before release
+- hosted asset upload and browser smoke validation remains an operator-run
+  release check until a CI deploy path is intentionally added
 
 ## Follow-Up Tickets
 
-- Complete hosted frontend smoke validation after the dev Terraform state
-  source of truth is restored.
+- Complete or explicitly gate hosted frontend smoke validation for the
+  `v0.3.0` release checkpoint.
 
 ## Guardrails
 

--- a/docs/releases/v0.3.0-draft.md
+++ b/docs/releases/v0.3.0-draft.md
@@ -1,47 +1,93 @@
 # v0.3.0 - Frontend MVP Slice
 
-Draft status: release preparation only. Do not create the `v0.3.0` tag or GitHub Release until the final checklist is complete.
+Draft status: release preparation only. Do not create the `v0.3.0` tag or
+GitHub Release until the final checklist is complete and the release action is
+explicitly approved.
 
 ## Summary
 
-`v0.3.0` is planned as the first frontend-era LeaseFlow release checkpoint. It builds on the validated `v0.2.0` backend and infrastructure MVP by adding a real browser frontend slice, browser-safe Cognito auth, CORS support, frontend CI checks, and a Terraform-managed S3 + CloudFront hosting path.
+`v0.3.0` is the first frontend-era LeaseFlow release checkpoint. It builds on
+the validated `v0.2.0` backend and infrastructure MVP by adding a real browser
+frontend, browser-safe Cognito auth, CORS support, frontend CI checks, dev
+operator scripts, and a Terraform-managed S3 + CloudFront hosting path.
 
-This is still a dev/portfolio MVP release. It must not be described as production-ready.
+This is still a dev/portfolio MVP release. It must not be described as
+production-ready.
 
 ## Included Scope Since v0.2.0
 
-- Frontend MVP strategy documented, including the separation between `demo-client` operator tooling and the real browser frontend.
-- Cognito Hosted UI, OAuth authorization code + PKCE, and API Gateway browser CORS support added for approved frontend origins.
+- Frontend MVP strategy documented, including the separation between
+  `demo-client` operator tooling and the real browser frontend.
+- Cognito Hosted UI, OAuth authorization code + PKCE, and API Gateway browser
+  CORS support added for approved frontend origins.
 - React + Vite + TypeScript browser frontend added under `frontend/`.
-- Browser sign-in/sign-out, protected navigation, properties list/create, and leases list/create implemented.
-- Hosted UI scope corrected so Cognito ID tokens can include readable custom attributes such as `custom:tenant_id`.
-- S3 + CloudFront frontend hosting infrastructure path added with private S3 and CloudFront Origin Access Control.
-- Frontend build, test, and lint checks added to CI.
-- Frontend form failure behavior and lease list text rendering polished.
+- Browser sign-in/sign-out, protected navigation, dashboard summaries,
+  properties and leases list/create/update flows, due-soon reminder display,
+  and notifications list/mark-read UI implemented.
+- Hosted UI scope corrected so Cognito ID tokens can include readable custom
+  attributes such as `custom:tenant_id`.
+- S3 + CloudFront frontend hosting infrastructure path added with private S3
+  and CloudFront Origin Access Control.
+- Local dev operator scripts added for first-time AWS setup, frontend env file
+  generation, hosted asset upload, demo user creation, demo data seeding, and
+  tenant data export/import.
+- Frontend build, test, lint, and high-level npm audit checks added to CI.
+- Frontend npm installs hardened with install lifecycle scripts disabled by
+  default, plus Dependabot npm coverage and conservative update cooldowns.
 - MVP documentation synced with the implemented frontend and hosting state.
 
 ## Important Boundaries
 
-- Hosted frontend browser smoke validation has not passed yet. It remains blocked by #114, which must restore the dev Terraform remote state source of truth before #108 can be completed end to end.
-- The S3 + CloudFront path exists in Terraform, but hosted asset upload and browser validation are still operator-run, not a CI deploy pipeline.
-- There is no custom domain, Route 53 setup, ACM certificate, WAF, SSR layer, Lambda@Edge customization, or production deployment strategy in this release.
-- Dashboard, due reminders UI, notifications UI, and browser update flows for properties and leases remain follow-up work.
-- Tenant isolation remains backend-enforced: tenant context comes from validated Cognito JWT claims, not from browser request body input.
-- The browser frontend must not use Cognito admin auth APIs or token-paste flows.
+- Hosted frontend browser smoke validation is not proven complete in committed
+  evidence. The current evidence records that the smoke run was blocked before
+  S3 upload, CloudFront invalidation, or hosted browser validation completed.
+- The S3 + CloudFront path exists in Terraform, but hosted asset upload and
+  browser validation are operator-run release checks, not a CI deploy pipeline.
+- There is no custom domain, Route 53 setup, ACM certificate, WAF, SSR layer,
+  Lambda@Edge customization, or production deployment strategy in this release.
+- Email delivery and external notification integrations remain follow-up work.
+- PostgreSQL row-level security is not enabled yet; app-level tenant isolation
+  remains the current MVP approach.
+- The browser can read due reminder candidates and notification records, but it
+  does not create notifications or run the internal reminder scan.
+- Tenant isolation remains backend-enforced: tenant context comes from
+  validated Cognito JWT claims, not from browser request body input.
+- The browser frontend must not use Cognito admin auth APIs or token-paste
+  flows.
 
 ## Draft Release Notes
 
-This release marks LeaseFlow's transition from a backend-only cloud MVP to a small but real browser MVP.
+This release marks LeaseFlow's transition from a backend-only cloud MVP to a
+small but real browser MVP.
 
-The frontend now uses Cognito Hosted UI with OAuth authorization code + PKCE and calls the tenant-protected API directly from the browser. The first browser slice focuses on core flows only: sign-in, sign-out, properties, and leases. Broader product areas such as dashboard summaries, reminder views, notifications, update flows, and production hosting polish are intentionally deferred.
+The frontend now uses Cognito Hosted UI with OAuth authorization code + PKCE
+and calls the tenant-protected API directly from the browser. The browser app
+includes the authenticated dashboard, property and lease create/update flows,
+due-soon reminder visibility, and persisted notification read acknowledgement.
 
-The infrastructure now includes the foundation for static SPA hosting on private S3 behind CloudFront, and API Gateway CORS is configured for approved frontend origins. However, the hosted browser path is not yet release-validated because the dev Terraform remote state source of truth needs to be fixed before assets can be uploaded and tested safely.
+The infrastructure now includes the foundation for static SPA hosting on
+private S3 behind CloudFront, and API Gateway CORS is configured for approved
+frontend origins. Hosted deployment remains an operator-run workflow rather
+than an automated CI deployment path.
+
+The dev workflow is easier to repeat through local operator scripts for
+Terraform bootstrap, stack apply, migrations, frontend env generation, hosted
+upload, demo user creation, synthetic demo data, and tenant data portability.
+Frontend supply-chain checks now also cover npm install hardening, high-level
+audit, and Dependabot npm updates.
 
 ## Final Release Checklist
 
-- #114 is resolved and `terraform output` returns the expected dev frontend hosting outputs from the configured remote backend.
-- #108 hosted frontend smoke validation is rerun and passes from the CloudFront origin.
+- `v0.3.0` tag and GitHub Release do not already exist.
+- Hosted frontend smoke validation is either completed with sanitized evidence
+  or the final release notes explicitly keep hosted smoke as an unproven
+  operator validation item.
 - `main` is clean and all required CI checks pass.
-- Release notes are reviewed for no secrets, JWTs, authorization headers, session storage values, Cognito user emails, tenant IDs, SSM values, DB endpoints, connection strings, property data, resident data, notification text, raw response bodies, or screenshots with sensitive values.
-- The final GitHub Release keeps the dev/portfolio MVP framing and does not claim production readiness.
-- Only after the above items pass, create tag `v0.3.0` and publish the GitHub Release.
+- Release notes are reviewed for no secrets, JWTs, authorization headers,
+  session storage values, Cognito user emails, tenant IDs, SSM values, DB
+  endpoints, connection strings, property data, resident data, notification
+  text, raw response bodies, or screenshots with sensitive values.
+- The final GitHub Release keeps the dev/portfolio MVP framing and does not
+  claim production readiness.
+- Only after the above items pass and the release action is explicitly
+  approved, create tag `v0.3.0` and publish the GitHub Release.


### PR DESCRIPTION
## Summary

Updates the v0.3.0 release draft and related docs so the release checkpoint reflects the current frontend MVP state.

## Changes

- Updated `docs/releases/v0.3.0-draft.md` with the implemented frontend-era scope.
- Kept hosted frontend smoke validation truthfully gated because committed evidence does not prove it passed.
- Updated stale README/frontend strategy wording around frontend install and hosted validation follow-up.
- Did not create the `v0.3.0` tag or GitHub Release.

## Assumptions

- v0.3.0 remains a dev/portfolio MVP checkpoint, not a production release.
- Hosted smoke must either get sanitized passing evidence or remain explicitly unproven in final release notes.
- Release tagging/publishing happens only after explicit approval.

## Security Validation

- Tenant isolation wording remains unchanged: tenant context comes from validated Cognito JWT claims, not browser request bodies.
- No secrets, JWTs, auth headers, emails, tenant IDs, DB endpoints, SSM values, raw responses, or screenshots were added.

## Cost Validation

- Docs-only change.
- No AWS, Terraform, runtime, backend, frontend behavior, or CI resource changes.

## Validation

- `git diff --check`
- Confirmed `v0.3.0` tag is absent.
- Confirmed latest `main` CI run is successful.

## Remaining Risks / TODOs

- Final release action is still gated by explicit approval.
- Hosted browser smoke remains unproven unless new sanitized passing evidence is added before release.
