### PR TITLE
docs: finalize v0.3.0 release evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,7 @@ Implemented now:
 
 Planned next:
 
-- Complete or explicitly gate hosted frontend smoke validation for the
-  `v0.3.0` release checkpoint.
+- Publish the `v0.3.0` frontend MVP release checkpoint.
 - Add delivery behavior on top of persisted notifications
 - Add more automated backend and tenant-isolation test coverage
 - Refine operational setup for scheduled workflows and monitoring

--- a/docs/frontend-mvp-strategy.md
+++ b/docs/frontend-mvp-strategy.md
@@ -23,8 +23,9 @@ local portfolio/demo tool and not the production-like frontend path.
   due-soon reminder display, and notifications list/mark-read UI.
 - The dev Terraform stack now includes an S3 + CloudFront hosting path for the
   static SPA. Asset upload remains a local operator command.
-- Hosted frontend smoke validation is still an operator-run release validation
-  item, not an implemented CI deployment path.
+- Hosted frontend smoke validation has passed from the CloudFront origin, but
+  hosted deployment remains an operator-run path, not an implemented CI
+  deployment path.
 - The dashboard is the authenticated browser app entry point.
 
 ## Chosen Frontend Direction
@@ -86,13 +87,13 @@ Current implemented slice:
 
 Later frontend follow-ups:
 
-- hosted asset upload and browser smoke validation remains an operator-run
-  release check until a CI deploy path is intentionally added
+- CI-based hosted frontend deployment when the project needs deployment
+  automation beyond the current operator-run path
 
 ## Follow-Up Tickets
 
-- Complete or explicitly gate hosted frontend smoke validation for the
-  `v0.3.0` release checkpoint.
+- Add CI-based hosted frontend deployment if deployment automation becomes a
+  release goal.
 
 ## Guardrails
 

--- a/docs/releases/v0.3.0-draft.md
+++ b/docs/releases/v0.3.0-draft.md
@@ -38,9 +38,8 @@ production-ready.
 
 ## Important Boundaries
 
-- Hosted frontend browser smoke validation is not proven complete in committed
-  evidence. The current evidence records that the smoke run was blocked before
-  S3 upload, CloudFront invalidation, or hosted browser validation completed.
+- Hosted frontend browser smoke validation passed on 2026-04-30 with sanitized
+  evidence recorded in `docs/runbooks/evidence/hosted-frontend-smoke-test-2026-04-30.md`.
 - The S3 + CloudFront path exists in Terraform, but hosted asset upload and
   browser validation are operator-run release checks, not a CI deploy pipeline.
 - There is no custom domain, Route 53 setup, ACM certificate, WAF, SSR layer,
@@ -67,8 +66,9 @@ due-soon reminder visibility, and persisted notification read acknowledgement.
 
 The infrastructure now includes the foundation for static SPA hosting on
 private S3 behind CloudFront, and API Gateway CORS is configured for approved
-frontend origins. Hosted deployment remains an operator-run workflow rather
-than an automated CI deployment path.
+frontend origins. Hosted deployment has been smoke-tested from the CloudFront
+origin, but remains an operator-run workflow rather than an automated CI
+deployment path.
 
 The dev workflow is easier to repeat through local operator scripts for
 Terraform bootstrap, stack apply, migrations, frontend env generation, hosted
@@ -79,9 +79,7 @@ audit, and Dependabot npm updates.
 ## Final Release Checklist
 
 - `v0.3.0` tag and GitHub Release do not already exist.
-- Hosted frontend smoke validation is either completed with sanitized evidence
-  or the final release notes explicitly keep hosted smoke as an unproven
-  operator validation item.
+- Hosted frontend smoke validation is completed with sanitized evidence.
 - `main` is clean and all required CI checks pass.
 - Release notes are reviewed for no secrets, JWTs, authorization headers,
   session storage values, Cognito user emails, tenant IDs, SSM values, DB


### PR DESCRIPTION
## Summary

Finalizes the v0.3.0 release documentation after hosted frontend smoke validation passed and sanitized evidence was committed.

## Changes

- Updates the v0.3.0 release draft to reference the passing hosted frontend smoke evidence.
- Updates README planned next steps now that hosted smoke validation is complete.
- Updates frontend strategy wording so hosted deployment remains operator-run, while CI deployment stays a future follow-up.

## Assumptions

- v0.3.0 remains a dev/portfolio MVP checkpoint, not a production release.
- Hosted deployment remains manual/operator-run, not CI-driven.
- Release tagging and GitHub Release publishing happen after this PR is merged and main CI is green.

## Security Validation

- Tenant isolation wording remains unchanged: tenant context comes from validated Cognito JWT claims, not browser request bodies.
- No JWTs, authorization headers, Cognito emails, tenant IDs, SSM values, DB endpoints, raw response bodies, or sensitive screenshots are included.

## Cost Validation

- Docs-only change.
- No AWS, Terraform, backend, frontend runtime, database, or CI resource changes.

## Validation

- git diff --check
- Hosted frontend smoke evidence exists in docs/runbooks/evidence/hosted-frontend-smoke-test-2026-04-30.md

## Remaining Risks / TODOs

- Create the v0.3.0 tag and GitHub Release only after this PR is merged and main CI passes.