### PR TITLE
docs: plan notification email delivery mvp

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,7 @@ Implemented now:
 
 Planned next:
 
-- Publish the `v0.3.0` frontend MVP release checkpoint.
-- Add delivery behavior on top of persisted notifications
+- Plan and implement SES-backed delivery behavior on top of persisted notifications
 - Add more automated backend and tenant-isolation test coverage
 - Refine operational setup for scheduled workflows and monitoring
 

--- a/docs/mvp-scope.md
+++ b/docs/mvp-scope.md
@@ -54,3 +54,12 @@
 - NAT Gateway and non-essential managed services.
 - Notification creation from the browser.
 - Custom domain, CI-based frontend deployment, and production readiness.
+
+## Planned Next Notification Phase
+
+- SES-backed email delivery is the preferred future delivery path.
+- The plan for that phase is documented in
+  `docs/notification-email-delivery-mvp.md`.
+- Email delivery remains out of current scope until the recipient model, SES
+  infrastructure, delivery worker, and sanitized smoke evidence are implemented
+  in follow-up tickets.

--- a/docs/notification-email-delivery-mvp.md
+++ b/docs/notification-email-delivery-mvp.md
@@ -1,0 +1,125 @@
+# Notification Email Delivery MVP
+
+## Purpose
+
+This document defines the next notification phase after the current persisted
+notification UI. The goal is to add production-like email delivery later without
+weakening tenant isolation, exposing internal jobs to the browser, or adding
+uncontrolled AWS cost.
+
+This is a planning document only. Email delivery is not implemented in the
+current MVP.
+
+## Current State
+
+- The internal due reminder scan creates tenant-owned `notifications` rows.
+- Notification creation is idempotent through the existing
+  `tenant_id`, `lease_id`, `type`, and `due_date` uniqueness constraint.
+- The browser frontend can list notifications and mark them read.
+- The browser cannot create notifications, run the reminder scan, or trigger
+  external delivery.
+- There is no recipient/contact data model, email delivery status, SES
+  infrastructure, or email-sending code yet.
+
+## Chosen Direction
+
+- Amazon SES is the preferred future email delivery service for LeaseFlow.
+- Persisted `notifications` remain the source of delivery work; the delivery
+  job must not recalculate reminder candidates independently.
+- Recipient addresses will come from a LeaseFlow-owned tenant-scoped contact
+  model, not from Cognito user enumeration.
+- Email delivery remains a backend/internal workflow. No browser route should
+  trigger scan or delivery execution.
+- The first MVP should support due reminder notification email only. Marketing
+  mail, billing mail, digest preferences, unsubscribe management, and external
+  notification providers are out of scope for the first delivery slice.
+
+## Future Data Model
+
+The first implementation should add a tenant-scoped notification contact model.
+At minimum, it should capture:
+
+- `tenant_id`
+- contact identifier
+- email address
+- enabled/disabled state
+- creation timestamp
+
+The first implementation should also add delivery tracking for notification
+email attempts. This can be a dedicated delivery table or explicit delivery
+columns, but it must support:
+
+- notification relationship
+- tenant scope
+- recipient relationship
+- delivery status
+- attempt count
+- last attempt timestamp
+- sent timestamp
+- non-sensitive failure category or code
+
+Do not store SES raw responses, SMTP transcripts, message bodies, or secrets in
+delivery rows.
+
+## Delivery Flow
+
+The target flow for the later implementation is:
+
+1. EventBridge Scheduler invokes the internal due reminder scan.
+2. The scan creates missing persisted due reminder `notifications` rows.
+3. A backend-only delivery worker selects unsent eligible notification/contact
+   pairs.
+4. The worker sends email through SES.
+5. The worker records delivery success or a sanitized failure category.
+
+Delivery must be idempotent and retry-safe:
+
+- rerunning scan must not duplicate notification rows.
+- rerunning delivery must not send duplicate email for the same
+  notification/contact pair after success.
+- failed attempts may be retried with a bounded attempt limit.
+- read acknowledgement in the browser must not be treated as proof that email
+  was delivered.
+
+## Infrastructure And Cost Boundaries
+
+- Do not add a NAT Gateway by default.
+- The current backend Lambda runs in private subnets. SES delivery therefore
+  needs an explicit private connectivity design before implementation.
+- The preferred private path to evaluate first is an SES SMTP interface VPC
+  endpoint with credentials stored outside the repository.
+- If a future implementation chooses a different SES access path, the PR must
+  justify the network, security, and cost tradeoff explicitly.
+- SES requires verified sending identities. In the SES sandbox, recipient
+  restrictions also apply unless using supported simulator addresses.
+- Sending limits, sandbox removal, bounce/complaint handling, and domain
+  verification are rollout concerns, not browser features.
+
+## Security And Tenant Isolation
+
+- Tenant context must remain backend-derived. Browser request bodies must never
+  define delivery tenant context.
+- Contact rows and delivery rows must be tenant-scoped.
+- Cross-tenant reads or delivery updates must be rejected by tests.
+- Do not log email addresses, notification message contents, tenant IDs,
+  tokens, SMTP credentials, SES credentials, SSM values, DB endpoints, or raw
+  provider responses.
+- Logs should use request/job IDs, aggregate counts, sanitized status values,
+  and non-sensitive failure categories.
+- SES credentials or SMTP credentials must be stored in AWS-managed secret
+  storage and accessed with least-privilege IAM.
+
+## Follow-Up Implementation Tickets
+
+The implementation should be split into separate reviewable tickets:
+
+- Add notification recipient contact model.
+- Add SES dev infrastructure foundation.
+- Implement idempotent notification email delivery.
+- Add SES delivery smoke runbook and sanitized evidence.
+
+## References
+
+- [Amazon SES verified identities](https://docs.aws.amazon.com/ses/latest/dg/verify-addresses-and-domains.html)
+- [Amazon SES production access](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html)
+- [Amazon SES VPC endpoints](https://docs.aws.amazon.com/ses/latest/dg/send-email-set-up-vpc-endpoints.html)

--- a/docs/security-baseline.md
+++ b/docs/security-baseline.md
@@ -157,6 +157,10 @@ Mitigations:
 - Audit events should be stored in PostgreSQL for business and security traceability.
 - Baseline CloudWatch alarms should exist for backend Lambda errors, backend Lambda throttles, HTTP API 5xx responses, and reminder scheduler target failures.
 - Baseline alarms publish to an environment SNS topic; optional dev email delivery starts only after the recipient confirms the SNS subscription email.
+- Future tenant notification email delivery must log only sanitized delivery
+  status, aggregate counts, and non-sensitive failure categories. Do not log
+  recipient email addresses, notification message contents, SMTP credentials,
+  SES credentials, tenant IDs, or raw provider responses.
 
 Examples of auditable events:
 
@@ -213,6 +217,9 @@ The MVP does not require a full incident management platform, but it does requir
 
 - PostgreSQL Row Level Security for defense-in-depth tenant enforcement
 - Cognito MFA rollout for higher-risk roles
+- SES-backed delivery for persisted tenant notifications, with a tenant-scoped
+  recipient model, private connectivity from the backend runtime, and sanitized
+  smoke evidence before release claims.
 - Backup retention review when recovery expectations outgrow the one-day dev window
 - Lightweight alerting for suspicious login or API abuse patterns
 - Periodic dependency and IAM permission review


### PR DESCRIPTION
## Summary

Plans the next notification phase for LeaseFlow: SES-backed email delivery on top of persisted due reminder notifications.

## Changes

- Adds `docs/notification-email-delivery-mvp.md`.
- Documents SES as the preferred future delivery path.
- Defines tenant-scoped notification contacts as the future recipient source.
- Captures idempotency, retry, private connectivity, SES sandbox, and evidence requirements.
- Updates MVP/security/root docs to show email delivery as planned future work, not current behavior.
- Creates follow-up issues #143, #144, #145, and #146.

## Assumptions

- #138 remains docs-only.
- No email delivery is implemented in this PR.
- Recipient emails will come from a LeaseFlow-owned tenant contact model, not Cognito user enumeration.
- SES implementation must respect the current private-subnet/no-NAT direction.

## Security Validation

- Tenant context remains backend-derived from validated Cognito JWT claims.
- No browser action is introduced for reminder scan or delivery.
- Docs explicitly prohibit logging recipient emails, message bodies, tenant IDs, tokens, SES/SMTP credentials, SSM values, DB endpoints, or raw provider responses.

## Cost Validation

- Docs-only change.
- No AWS resources are added.
- Future SES/private connectivity cost risks are called out before implementation.

## Validation

- `git diff --check`
- Manual review for no secrets, JWTs, real emails, tenant IDs, SES credentials, SSM values, DB endpoints, or raw message contents.

## Remaining Risks / TODOs

- Implement follow-up issues #143-#146 before claiming email delivery support.
