### PR TITLE
fix: reject blank JWT auth claims

### DIFF
--- a/backend/src/app/auth.py
+++ b/backend/src/app/auth.py
@@ -12,9 +12,9 @@ def extract_auth_context(event: dict) -> AuthContext:
     if not claims:
         raise AuthError("Missing JWT claims.")
 
-    user_id = claims.get("sub")
-    tenant_id = claims.get("custom:tenant_id")
+    user_id = str(claims.get("sub") or "").strip()
+    tenant_id = str(claims.get("custom:tenant_id") or "").strip()
     if not user_id or not tenant_id:
         raise AuthError("JWT must include 'sub' and 'custom:tenant_id' claims.")
 
-    return AuthContext(user_id=str(user_id), tenant_id=str(tenant_id))
+    return AuthContext(user_id=user_id, tenant_id=tenant_id)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -3,19 +3,25 @@ import pytest
 from app.auth import AuthError, extract_auth_context
 
 
-def test_extract_auth_context_success() -> None:
-    event = {
+def _event_with_claims(claims: dict[str, str]) -> dict:
+    return {
         "requestContext": {
             "authorizer": {
                 "jwt": {
-                    "claims": {
-                        "sub": "user-123",
-                        "custom:tenant_id": "tenant-123",
-                    }
+                    "claims": claims,
                 }
             }
         }
     }
+
+
+def test_extract_auth_context_success() -> None:
+    event = _event_with_claims(
+        {
+            "sub": "user-123",
+            "custom:tenant_id": "tenant-123",
+        }
+    )
     auth = extract_auth_context(event)
     assert auth.user_id == "user-123"
     assert auth.tenant_id == "tenant-123"
@@ -24,3 +30,27 @@ def test_extract_auth_context_success() -> None:
 def test_extract_auth_context_missing_claims() -> None:
     with pytest.raises(AuthError):
         extract_auth_context({"requestContext": {}})
+
+
+@pytest.mark.parametrize(
+    "claims",
+    [
+        {"custom:tenant_id": "tenant-123"},
+        {"sub": "user-123"},
+    ],
+)
+def test_extract_auth_context_rejects_missing_required_claim(claims: dict[str, str]) -> None:
+    with pytest.raises(AuthError, match="JWT must include 'sub' and 'custom:tenant_id' claims."):
+        extract_auth_context(_event_with_claims(claims))
+
+
+@pytest.mark.parametrize(
+    "claims",
+    [
+        {"sub": "   ", "custom:tenant_id": "tenant-123"},
+        {"sub": "user-123", "custom:tenant_id": "   "},
+    ],
+)
+def test_extract_auth_context_rejects_blank_required_claim(claims: dict[str, str]) -> None:
+    with pytest.raises(AuthError, match="JWT must include 'sub' and 'custom:tenant_id' claims."):
+        extract_auth_context(_event_with_claims(claims))

--- a/backend/tests/test_handler.py
+++ b/backend/tests/test_handler.py
@@ -4,6 +4,15 @@ from types import SimpleNamespace
 from app import handler
 
 
+class _PropertiesDb:
+    def __init__(self) -> None:
+        self.list_calls: list[str] = []
+
+    def list_properties(self, tenant_id: str) -> list:
+        self.list_calls.append(tenant_id)
+        return []
+
+
 def test_health_endpoint() -> None:
     event = {
         "rawPath": "/health",
@@ -60,6 +69,71 @@ def test_list_properties_accepts_stage_prefixed_raw_path(monkeypatch) -> None:
 
     assert response["statusCode"] == 200
     assert json.loads(response["body"]) == {"items": []}
+
+
+def test_protected_route_rejects_missing_tenant_claim(monkeypatch) -> None:
+    monkeypatch.setattr(
+        handler,
+        "load_settings",
+        lambda: SimpleNamespace(log_level="INFO"),
+    )
+    monkeypatch.setattr(handler, "Database", lambda settings: _PropertiesDb())
+
+    event = {
+        "rawPath": "/dev/properties",
+        "queryStringParameters": {"tenant_id": "tenant-from-client"},
+        "requestContext": {
+            "stage": "dev",
+            "http": {"method": "GET"},
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": "user-123",
+                    }
+                }
+            },
+        },
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 400
+    assert json.loads(response["body"]) == {
+        "error": "JWT must include 'sub' and 'custom:tenant_id' claims."
+    }
+
+
+def test_handler_uses_jwt_tenant_not_query_tenant_for_protected_route(monkeypatch) -> None:
+    fake_db = _PropertiesDb()
+    monkeypatch.setattr(
+        handler,
+        "load_settings",
+        lambda: SimpleNamespace(log_level="INFO"),
+    )
+    monkeypatch.setattr(handler, "Database", lambda settings: fake_db)
+
+    event = {
+        "rawPath": "/dev/properties",
+        "queryStringParameters": {"tenant_id": "tenant-from-client"},
+        "requestContext": {
+            "stage": "dev",
+            "http": {"method": "GET"},
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": "user-123",
+                        "custom:tenant_id": "tenant-from-jwt",
+                    }
+                }
+            },
+        },
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 200
+    assert json.loads(response["body"]) == {"items": []}
+    assert fake_db.list_calls == ["tenant-from-jwt"]
 
 
 def test_list_leases_accepts_stage_prefixed_raw_path(monkeypatch) -> None:

--- a/backend/tests/test_leases_route.py
+++ b/backend/tests/test_leases_route.py
@@ -462,6 +462,30 @@ def test_update_lease_rejects_unsupported_fields() -> None:
     assert db.update_calls == []
 
 
+def test_update_lease_rejects_body_tenant_id() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+    event = _event_with_auth(tenant_id="tenant-auth", user_id="user-auth")
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Only fields 'resident_name', 'rent_due_day_of_month', "
+            "'start_date', and 'end_date' can be updated."
+        ),
+    ):
+        leases.update_lease(
+            {
+                **event,
+                "body": '{"tenant_id":"tenant-body-should-be-rejected"}',
+            },
+            db,
+            UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        )
+
+    assert db.update_calls == []
+
+
 def test_update_lease_rejects_blank_trimmed_resident_name() -> None:
     leases = _leases_module()
     db = _FakeDb()

--- a/backend/tests/test_notifications_route.py
+++ b/backend/tests/test_notifications_route.py
@@ -122,6 +122,7 @@ def test_mark_notification_read_uses_auth_tenant_and_returns_updated_record() ->
     notification_id = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
     event = _event_with_auth(tenant_id="tenant-auth", user_id="user-auth")
     event["queryStringParameters"] = {"tenant_id": "tenant-from-client-should-be-ignored"}
+    event["body"] = '{"tenant_id":"tenant-from-body-should-be-ignored"}'
 
     payload = notifications.mark_notification_read(event, db, notification_id)
 


### PR DESCRIPTION
## Summary

Expands backend tenant-isolation regression coverage and hardens auth claim extraction.

## Changes

- Reject blank or whitespace-only `sub` and `custom:tenant_id` JWT claims.
- Add auth tests for missing and blank required claims.
- Add handler regression coverage proving protected routes use JWT tenant context, not client query input.
- Add lease PATCH regression coverage for `tenant_id` body override attempts.
- Add notification mark-read coverage proving body/query `tenant_id` is ignored.

## Assumptions

- Application-layer tenant isolation remains the MVP model.
- PostgreSQL RLS remains future hardening, not part of this PR.
- Internal reminder scan behavior remains unchanged.

## Security Validation

Tenant isolation remains derived from validated Cognito JWT claims only. Tests cover missing/blank tenant claims, query/body tenant override attempts, and route-level behavior for leases and notifications.

## Cost Validation

No AWS, Terraform, infrastructure, database schema, or service changes. No cost impact.

## Validation

- `python -m pytest -q tests/test_auth.py tests/test_handler.py tests/test_properties_route.py tests/test_leases_route.py tests/test_notifications_route.py tests/test_lease_reminders_route.py`
- `python -m pytest -q`
- `python -m pytest -q tests/test_db_integration.py` skipped because integration env was not enabled
- `git diff --check`

## Remaining Risks / TODOs

- Full PostgreSQL integration validation should be run separately in the prepared WSL/local DB environment.
