### PR TITLE
feat: add notification contact data model

### DIFF
--- a/backend/migrations/versions/20260430_0007_add_notification_contacts.py
+++ b/backend/migrations/versions/20260430_0007_add_notification_contacts.py
@@ -1,0 +1,60 @@
+"""Add tenant-scoped notification contacts."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "20260430_0007"
+down_revision = "20260409_0006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notification_contacts",
+        sa.Column(
+            "contact_id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("tenant_id", sa.Text(), nullable=False),
+        sa.Column("email", sa.Text(), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "length(btrim(email)) > 0",
+            name="ck_notification_contacts_email_not_blank",
+        ),
+    )
+    op.execute(
+        """
+        CREATE UNIQUE INDEX uq_notification_contacts_tenant_email_lower
+        ON notification_contacts (tenant_id, lower(email))
+        """
+    )
+    op.create_index(
+        "ix_notification_contacts_tenant_enabled",
+        "notification_contacts",
+        ["tenant_id", "enabled"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_notification_contacts_tenant_enabled", table_name="notification_contacts")
+    op.drop_index(
+        "uq_notification_contacts_tenant_email_lower",
+        table_name="notification_contacts",
+    )
+    op.drop_table("notification_contacts")

--- a/backend/src/app/db.py
+++ b/backend/src/app/db.py
@@ -12,12 +12,129 @@ from psycopg.rows import dict_row
 from psycopg.sql import SQL, Identifier
 
 from app.config import Settings
-from app.models import Lease, LeaseReminderCandidate, Notification, Property, ReminderScanResult
+from app.models import (
+    Lease,
+    LeaseReminderCandidate,
+    Notification,
+    NotificationContact,
+    Property,
+    ReminderScanResult,
+)
 
 
 class Database:
     def __init__(self, settings: Settings) -> None:
         self._dsn = settings.db_dsn()
+
+    def create_notification_contact(
+        self,
+        tenant_id: str,
+        actor_user_id: str,
+        email: str,
+        enabled: bool = True,
+    ) -> NotificationContact:
+        normalized_email = _normalize_notification_contact_email(email)
+        if not normalized_email:
+            raise ValueError("Notification contact email must not be empty.")
+
+        contact_sql = """
+            INSERT INTO notification_contacts (tenant_id, email, enabled)
+            VALUES (%s, %s, %s)
+            RETURNING contact_id, tenant_id, email, enabled, created_at
+        """
+        audit_sql = """
+            INSERT INTO audit_logs (
+                tenant_id, actor_user_id, action, entity_type, entity_id, metadata
+            ) VALUES (%s, %s, %s, %s, %s, %s::jsonb)
+        """
+        try:
+            with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+                with conn.transaction():
+                    contact_row = conn.execute(
+                        contact_sql,
+                        (tenant_id, normalized_email, enabled),
+                    ).fetchone()
+                    if not contact_row:
+                        raise RuntimeError("Failed to create notification contact.")
+                    conn.execute(
+                        audit_sql,
+                        (
+                            tenant_id,
+                            actor_user_id,
+                            "notification_contact.create",
+                            "notification_contact",
+                            contact_row["contact_id"],
+                            json.dumps({"source": "api", "enabled": enabled}),
+                        ),
+                    )
+        except psycopg.errors.UniqueViolation as exc:
+            raise ValueError("Notification contact already exists for tenant.") from exc
+
+        return self._row_to_notification_contact(contact_row)
+
+    def list_notification_contacts(
+        self,
+        tenant_id: str,
+        enabled_only: bool = False,
+    ) -> list[NotificationContact]:
+        sql = """
+            SELECT contact_id, tenant_id, email, enabled, created_at
+            FROM notification_contacts
+            WHERE tenant_id = %s
+        """
+        params: tuple[object, ...]
+        if enabled_only:
+            sql += """
+              AND enabled = true
+            """
+        sql += """
+            ORDER BY created_at DESC, contact_id DESC
+        """
+        params = (tenant_id,)
+
+        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+            rows = conn.execute(sql, params).fetchall()
+        return [self._row_to_notification_contact(row) for row in rows]
+
+    def set_notification_contact_enabled(
+        self,
+        tenant_id: str,
+        actor_user_id: str,
+        contact_id: UUID,
+        enabled: bool,
+    ) -> NotificationContact:
+        contact_sql = """
+            UPDATE notification_contacts
+            SET enabled = %s
+            WHERE tenant_id = %s AND contact_id = %s
+            RETURNING contact_id, tenant_id, email, enabled, created_at
+        """
+        audit_sql = """
+            INSERT INTO audit_logs (
+                tenant_id, actor_user_id, action, entity_type, entity_id, metadata
+            ) VALUES (%s, %s, %s, %s, %s, %s::jsonb)
+        """
+        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+            with conn.transaction():
+                contact_row = conn.execute(
+                    contact_sql,
+                    (enabled, tenant_id, contact_id),
+                ).fetchone()
+                if contact_row is None:
+                    raise LookupError("Notification contact not found for tenant.")
+                conn.execute(
+                    audit_sql,
+                    (
+                        tenant_id,
+                        actor_user_id,
+                        "notification_contact.update",
+                        "notification_contact",
+                        contact_id,
+                        json.dumps({"source": "api", "enabled": enabled}),
+                    ),
+                )
+
+        return self._row_to_notification_contact(contact_row)
 
     def create_due_lease_reminder_notifications(
         self,
@@ -538,6 +655,16 @@ class Database:
             read_at=row["read_at"],
         )
 
+    @staticmethod
+    def _row_to_notification_contact(row: dict[str, Any]) -> NotificationContact:
+        return NotificationContact(
+            contact_id=row["contact_id"],
+            tenant_id=row["tenant_id"],
+            email=row["email"],
+            enabled=row["enabled"],
+            created_at=row["created_at"],
+        )
+
 
 def notification_to_dict(item: Notification) -> dict[str, Any]:
     return {
@@ -627,3 +754,7 @@ def _rent_due_soon_message(days_until_due: int) -> str:
     if days_until_due == 1:
         return "Rent is due in 1 day."
     return f"Rent is due in {days_until_due} days."
+
+
+def _normalize_notification_contact_email(email: str) -> str:
+    return email.strip().lower()

--- a/backend/src/app/models.py
+++ b/backend/src/app/models.py
@@ -61,6 +61,15 @@ class Notification:
 
 
 @dataclass(slots=True)
+class NotificationContact:
+    contact_id: UUID
+    tenant_id: str
+    email: str
+    enabled: bool
+    created_at: datetime
+
+
+@dataclass(slots=True)
 class ReminderScanResult:
     tenant_id: str | None
     as_of_date: date

--- a/backend/tests/test_db_integration.py
+++ b/backend/tests/test_db_integration.py
@@ -32,6 +32,7 @@ def _cleanup_test_tenant(settings: Settings, tenant_id: str) -> None:
     with psycopg.connect(settings.db_dsn(), row_factory=dict_row) as conn:
         with conn.transaction():
             conn.execute("DELETE FROM notifications WHERE tenant_id = %s", (tenant_id,))
+            conn.execute("DELETE FROM notification_contacts WHERE tenant_id = %s", (tenant_id,))
             conn.execute("DELETE FROM audit_logs WHERE tenant_id = %s", (tenant_id,))
             conn.execute("DELETE FROM leases WHERE tenant_id = %s", (tenant_id,))
             conn.execute("DELETE FROM properties WHERE tenant_id = %s", (tenant_id,))
@@ -1427,6 +1428,237 @@ def test_mark_notification_read_rejects_cross_tenant_access(
                 tenant_id=tenant_id,
                 notification_id=notification_id,
             )
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+        _cleanup_test_tenant(integration_settings, other_tenant_id)
+
+
+def test_create_notification_contact_stores_normalized_email_and_audit_log(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+
+    try:
+        created = db.create_notification_contact(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            email="  Contact.One+Rent@Example.COM  ",
+        )
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            contact_rows = conn.execute(
+                """
+                SELECT contact_id, tenant_id, email, enabled
+                FROM notification_contacts
+                WHERE tenant_id = %s AND contact_id = %s
+                """,
+                (tenant_id, created.contact_id),
+            ).fetchall()
+            audit_rows = conn.execute(
+                """
+                SELECT tenant_id, actor_user_id, action, entity_type, entity_id, metadata
+                FROM audit_logs
+                WHERE tenant_id = %s
+                  AND entity_id = %s
+                  AND action = 'notification_contact.create'
+                """,
+                (tenant_id, created.contact_id),
+            ).fetchall()
+
+        assert created.tenant_id == tenant_id
+        assert created.email == "contact.one+rent@example.com"
+        assert created.enabled is True
+
+        assert len(contact_rows) == 1
+        assert contact_rows[0]["email"] == "contact.one+rent@example.com"
+        assert contact_rows[0]["enabled"] is True
+
+        assert len(audit_rows) == 1
+        assert audit_rows[0]["tenant_id"] == tenant_id
+        assert audit_rows[0]["actor_user_id"] == actor_user_id
+        assert audit_rows[0]["entity_type"] == "notification_contact"
+        assert audit_rows[0]["entity_id"] == created.contact_id
+        assert audit_rows[0]["metadata"] == {"source": "api", "enabled": True}
+        assert "email" not in audit_rows[0]["metadata"]
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+
+
+def test_create_notification_contact_rejects_blank_email(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+
+    try:
+        with pytest.raises(ValueError, match="Notification contact email must not be empty."):
+            db.create_notification_contact(
+                tenant_id=tenant_id,
+                actor_user_id=actor_user_id,
+                email="   ",
+            )
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+
+
+def test_list_notification_contacts_returns_requested_tenant_and_filters_enabled(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    other_tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+
+    try:
+        enabled = db.create_notification_contact(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            email=f"enabled-{uuid4().hex[:8]}@example.com",
+        )
+        disabled = db.create_notification_contact(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            email=f"disabled-{uuid4().hex[:8]}@example.com",
+            enabled=False,
+        )
+        db.create_notification_contact(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            email=enabled.email,
+        )
+
+        all_contacts = db.list_notification_contacts(tenant_id=tenant_id)
+        enabled_contacts = db.list_notification_contacts(tenant_id=tenant_id, enabled_only=True)
+
+        assert {item.contact_id for item in all_contacts} == {
+            enabled.contact_id,
+            disabled.contact_id,
+        }
+        assert {item.email for item in all_contacts} == {enabled.email, disabled.email}
+        assert [item.contact_id for item in enabled_contacts] == [enabled.contact_id]
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+        _cleanup_test_tenant(integration_settings, other_tenant_id)
+
+
+def test_create_notification_contact_rejects_duplicate_email_case_insensitive_per_tenant(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    other_tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+
+    try:
+        created = db.create_notification_contact(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            email="Recipient.Dupe@Example.COM",
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="Notification contact already exists for tenant.",
+        ):
+            db.create_notification_contact(
+                tenant_id=tenant_id,
+                actor_user_id=actor_user_id,
+                email=" recipient.dupe@example.com ",
+            )
+
+        other_created = db.create_notification_contact(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            email="recipient.dupe@example.com",
+        )
+
+        assert created.email == "recipient.dupe@example.com"
+        assert other_created.email == "recipient.dupe@example.com"
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+        _cleanup_test_tenant(integration_settings, other_tenant_id)
+
+
+def test_set_notification_contact_enabled_updates_tenant_contact_and_audit_log(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+
+    try:
+        created = db.create_notification_contact(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            email=f"toggle-{uuid4().hex[:8]}@example.com",
+        )
+
+        updated = db.set_notification_contact_enabled(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            contact_id=created.contact_id,
+            enabled=False,
+        )
+        enabled_contacts = db.list_notification_contacts(tenant_id=tenant_id, enabled_only=True)
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            audit_rows = conn.execute(
+                """
+                SELECT tenant_id, actor_user_id, action, entity_type, entity_id, metadata
+                FROM audit_logs
+                WHERE tenant_id = %s
+                  AND entity_id = %s
+                  AND action = 'notification_contact.update'
+                """,
+                (tenant_id, created.contact_id),
+            ).fetchall()
+
+        assert updated.contact_id == created.contact_id
+        assert updated.enabled is False
+        assert enabled_contacts == []
+
+        assert len(audit_rows) == 1
+        assert audit_rows[0]["tenant_id"] == tenant_id
+        assert audit_rows[0]["actor_user_id"] == actor_user_id
+        assert audit_rows[0]["entity_type"] == "notification_contact"
+        assert audit_rows[0]["entity_id"] == created.contact_id
+        assert audit_rows[0]["metadata"] == {"source": "api", "enabled": False}
+        assert "email" not in audit_rows[0]["metadata"]
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+
+
+def test_set_notification_contact_enabled_rejects_cross_tenant_access(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    other_tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+
+    try:
+        other_contact = db.create_notification_contact(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            email=f"cross-tenant-{uuid4().hex[:8]}@example.com",
+        )
+
+        with pytest.raises(LookupError, match="Notification contact not found for tenant."):
+            db.set_notification_contact_enabled(
+                tenant_id=tenant_id,
+                actor_user_id=actor_user_id,
+                contact_id=other_contact.contact_id,
+                enabled=False,
+            )
+
+        other_contacts = db.list_notification_contacts(tenant_id=other_tenant_id)
+
+        assert len(other_contacts) == 1
+        assert other_contacts[0].contact_id == other_contact.contact_id
+        assert other_contacts[0].enabled is True
     finally:
         _cleanup_test_tenant(integration_settings, tenant_id)
         _cleanup_test_tenant(integration_settings, other_tenant_id)

--- a/docs/notification-email-delivery-mvp.md
+++ b/docs/notification-email-delivery-mvp.md
@@ -18,8 +18,10 @@ current MVP.
 - The browser frontend can list notifications and mark them read.
 - The browser cannot create notifications, run the reminder scan, or trigger
   external delivery.
-- There is no recipient/contact data model, email delivery status, SES
-  infrastructure, or email-sending code yet.
+- A tenant-scoped notification contact model exists as the future recipient
+  source.
+- There is no email delivery status, SES infrastructure, or email-sending code
+  yet.
 
 ## Chosen Direction
 
@@ -36,8 +38,7 @@ current MVP.
 
 ## Future Data Model
 
-The first implementation should add a tenant-scoped notification contact model.
-At minimum, it should capture:
+The first implementation added a tenant-scoped notification contact model with:
 
 - `tenant_id`
 - contact identifier
@@ -45,9 +46,12 @@ At minimum, it should capture:
 - enabled/disabled state
 - creation timestamp
 
-The first implementation should also add delivery tracking for notification
-email attempts. This can be a dedicated delivery table or explicit delivery
-columns, but it must support:
+Disabled contacts remain stored but must be excluded from delivery candidate
+selection.
+
+Future work should add delivery tracking for notification email attempts. This
+can be a dedicated delivery table or explicit delivery columns, but it must
+support:
 
 - notification relationship
 - tenant scope


### PR DESCRIPTION
## Summary

Adds a DB-only tenant-scoped notification contact model for future SES notification delivery.

## Changes

- Added `notification_contacts` table migration.
- Added `NotificationContact` backend model.
- Added DB data-access methods for creating, listing, and enabling/disabling contacts.
- Enforced case-insensitive per-tenant email uniqueness.
- Normalized stored contact emails by trimming and lowercasing.
- Added integration coverage for tenant isolation, enabled filtering, duplicate handling, cross-tenant update rejection, and sanitized audit metadata.
- Updated notification email delivery planning docs to reflect that the contact model now exists.

## Assumptions

- #143 is DB/data-access only.
- Contact management API/UI is a later ticket.
- SES infrastructure, delivery tracking, and email sending remain out of scope.
- PostgreSQL RLS remains future hardening.

## Security Validation

Tenant context is still passed by backend-authenticated context only. No browser route or request-body `tenant_id` handling was added. Cross-tenant contact updates are covered by integration tests. Audit metadata intentionally excludes email addresses.

## Cost Validation

No AWS, Terraform, SES, Lambda, or infrastructure changes. No cost impact.

## Validation

- `python -m pytest -q`
- `python -m pytest -q tests/test_db_integration.py -k notification_contact --tb=short`
- `python -m pytest -q tests/test_db_integration.py --tb=short`
- `python -m alembic current`
- `python -m ruff check src tests migrations`
- `git diff --check`

## Remaining Risks / TODOs

- Contact HTTP API/UI remains follow-up work.
- SES delivery status tracking and idempotent delivery remain follow-up work.
- Local Windows DB validation may require `DB_HOST=127.0.0.1` instead of `localhost` to avoid slow IPv6 timeout behavior.
