### PR TITLE
infra: add SES dev email foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
           - infra/modules/lambda_backend
           - infra/modules/network
           - infra/modules/reminder_scheduler
+          - infra/modules/ses_email_foundation
 
     steps:
       - name: Check out repository

--- a/docs/notification-email-delivery-mvp.md
+++ b/docs/notification-email-delivery-mvp.md
@@ -20,8 +20,10 @@ current MVP.
   external delivery.
 - A tenant-scoped notification contact model exists as the future recipient
   source.
-- There is no email delivery status, SES infrastructure, or email-sending code
-  yet.
+- A dev SES infrastructure foundation exists with an optional sender identity
+  and opt-in SES SMTP VPC endpoint.
+- There is no email delivery status, SMTP credential storage, or email-sending
+  code yet.
 
 ## Chosen Direction
 
@@ -90,14 +92,17 @@ Delivery must be idempotent and retry-safe:
 - Do not add a NAT Gateway by default.
 - The current backend Lambda runs in private subnets. SES delivery therefore
   needs an explicit private connectivity design before implementation.
-- The preferred private path to evaluate first is an SES SMTP interface VPC
-  endpoint with credentials stored outside the repository.
+- The preferred private path is an SES SMTP interface VPC endpoint. Terraform
+  includes this endpoint as disabled-by-default dev infrastructure so it does
+  not create idle endpoint cost before delivery code exists.
 - If a future implementation chooses a different SES access path, the PR must
   justify the network, security, and cost tradeoff explicitly.
 - SES requires verified sending identities. In the SES sandbox, recipient
   restrictions also apply unless using supported simulator addresses.
 - Sending limits, sandbox removal, bounce/complaint handling, and domain
   verification are rollout concerns, not browser features.
+- SMTP credentials are not created yet. A future delivery implementation must
+  define credential storage, rotation, and least-privilege access explicitly.
 
 ## Security And Tenant Isolation
 
@@ -117,8 +122,9 @@ Delivery must be idempotent and retry-safe:
 
 The implementation should be split into separate reviewable tickets:
 
-- Add notification recipient contact model.
-- Add SES dev infrastructure foundation.
+- Add notification recipient contact model. Completed.
+- Add SES dev infrastructure foundation. Completed as disabled-by-default
+  Terraform foundation.
 - Implement idempotent notification email delivery.
 - Add SES delivery smoke runbook and sanitized evidence.
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -10,6 +10,7 @@ Terraform code is split into reusable modules and environment composition.
 - `modules/cognito`: user pool, app client, and managed Hosted UI domain.
 - `modules/frontend_hosting`: private S3 bucket and CloudFront distribution for the SPA.
 - `modules/lambda_backend`: backend Lambda function, IAM role, log group.
+- `modules/ses_email_foundation`: optional SES sender identity and SES SMTP PrivateLink foundation.
 - `modules/reminder_scheduler`: EventBridge Scheduler + IAM role for daily reminder scans.
 - `modules/api_http`: HTTP API, JWT authorizer, route wiring.
 - `environments/dev`: MVP dev environment composition.
@@ -41,6 +42,27 @@ the real frontend.
 - Use `frontend/README.md` for browser `.env.local`, Hosted UI troubleshooting,
   and temporary Cognito demo user setup.
 
+## SES email foundation
+
+The dev stack includes a Terraform foundation for future notification email
+delivery, but it does not send email yet.
+
+- `ses_sender_email` defaults to empty. Set it only when you are ready to
+  verify that sender address in Amazon SES.
+- If set, the sender address exists in local `terraform.tfvars` and Terraform
+  state. Do not commit it or paste it into evidence.
+- `ses_smtp_vpc_endpoint_enabled` defaults to `false`. Keep it disabled until
+  backend email delivery code exists and you intentionally want to test private
+  SMTP connectivity.
+- The SES SMTP endpoint uses AWS PrivateLink when enabled, so Lambda can reach
+  SES from private subnets without adding a NAT Gateway.
+- The endpoint is billable while provisioned because interface VPC endpoint
+  hourly and data-processing charges apply.
+- SES sandbox and verified-identity limits still apply. In sandbox mode, test
+  sending is constrained until identities and production access are handled.
+- Terraform does not create SMTP credentials, IAM users, delivery status tables,
+  browser delivery actions, or production email readiness in this slice.
+
 ## Scripted first-time dev setup
 
 The WSL/Linux operator scripts under `scripts/dev/` package the manual dev
@@ -66,7 +88,8 @@ cp infra/environments/dev/terraform.tfvars.example infra/environments/dev/terraf
 
 Edit `infra/environments/dev/terraform.tfvars` before applying. At minimum,
 replace `cognito_hosted_ui_domain_prefix` with a globally unique Cognito managed
-domain prefix.
+domain prefix. Leave SES variables at their defaults unless you are explicitly
+validating future email delivery infrastructure.
 
 What it does: builds the Linux-compatible backend Lambda artifact.
 Target filename/service: `dist/leaseflow-backend.zip`.
@@ -345,6 +368,7 @@ CI runs Terraform checks without AWS credentials.
   - `20 GB` allocated storage
   - automated backups
 - API Gateway, Lambda, Cognito, SSM Parameter Store, and CloudWatch are still real AWS resources, but for light learning use they are expected to be smaller cost contributors than RDS.
+- The optional SES SMTP interface VPC endpoint is disabled by default. If enabled, it adds PrivateLink endpoint hourly and data-processing charges.
 
 ## Apply and destroy rule
 

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -98,6 +98,19 @@ module "lambda_backend" {
   tags                     = local.common_tags
 }
 
+module "ses_email_foundation" {
+  source = "../../modules/ses_email_foundation"
+
+  name_prefix               = local.name_prefix
+  aws_region                = var.aws_region
+  sender_email              = var.ses_sender_email
+  smtp_vpc_endpoint_enabled = var.ses_smtp_vpc_endpoint_enabled
+  vpc_id                    = module.network.vpc_id
+  private_subnet_ids        = module.network.private_subnet_ids
+  lambda_security_group_id  = module.network.lambda_security_group_id
+  tags                      = local.common_tags
+}
+
 module "reminder_scheduler" {
   source = "../../modules/reminder_scheduler"
 

--- a/infra/environments/dev/outputs.tf
+++ b/infra/environments/dev/outputs.tf
@@ -77,3 +77,23 @@ output "baseline_alarm_email_subscription_configured" {
   description = "Whether a dev baseline alarm email subscription is configured."
   value       = length(aws_sns_topic_subscription.baseline_alarm_email) > 0
 }
+
+output "ses_sender_identity_configured" {
+  description = "Whether an optional SES sender identity is configured for future dev email delivery validation."
+  value       = module.ses_email_foundation.sender_identity_configured
+}
+
+output "ses_smtp_vpc_endpoint_enabled" {
+  description = "Whether the optional SES SMTP interface VPC endpoint is configured."
+  value       = module.ses_email_foundation.smtp_vpc_endpoint_enabled
+}
+
+output "ses_smtp_vpc_endpoint_id" {
+  description = "SES SMTP interface VPC endpoint ID when enabled."
+  value       = module.ses_email_foundation.smtp_vpc_endpoint_id
+}
+
+output "ses_smtp_vpc_endpoint_security_group_id" {
+  description = "SES SMTP interface VPC endpoint security group ID when enabled."
+  value       = module.ses_email_foundation.smtp_vpc_endpoint_security_group_id
+}

--- a/infra/environments/dev/terraform.tfvars.example
+++ b/infra/environments/dev/terraform.tfvars.example
@@ -24,3 +24,12 @@ frontend_hosted_origin = ""
 
 # Optional. AWS sends a confirmation email before SNS starts delivery.
 baseline_alarm_notification_email = ""
+
+# Optional. Creates an SES sender identity verification request for future
+# notification email delivery validation. Keep empty unless you are ready to
+# verify this address in SES.
+ses_sender_email = ""
+
+# Optional. Creates a billable SES SMTP interface VPC endpoint for private
+# subnet delivery validation. Keep false until email delivery code exists.
+ses_smtp_vpc_endpoint_enabled = false

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -122,6 +122,23 @@ variable "baseline_alarm_notification_email" {
   default     = ""
 }
 
+variable "ses_sender_email" {
+  type        = string
+  description = "Optional SES sender email identity for future dev notification email delivery validation."
+  default     = ""
+
+  validation {
+    condition     = trimspace(var.ses_sender_email) == "" || can(regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$", trimspace(var.ses_sender_email)))
+    error_message = "ses_sender_email must be empty or a single email-like value."
+  }
+}
+
+variable "ses_smtp_vpc_endpoint_enabled" {
+  type        = bool
+  description = "Whether to create the SES SMTP interface VPC endpoint for private-subnet email delivery validation."
+  default     = false
+}
+
 variable "tags" {
   type        = map(string)
   description = "Extra tags."

--- a/infra/modules/ses_email_foundation/.terraform.lock.hcl
+++ b/infra/modules/ses_email_foundation/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.43.0"
+  constraints = "~> 6.37"
+  hashes = [
+    "h1:bS/rBRbYawLnmFqawh7iJE3qS8ErHInn6FPeepd8Xkw=",
+    "zh:0fe91026ce8c5178781de6773531dcfcf5280ee139059dc5a0c046f1532cf389",
+    "zh:114001f94c38db8702210eda643ec627fa1929a88f774e17db30bc172df6759e",
+    "zh:1fc668d57c7edd81c06f5705b03517393444fe4988a68a3fd90b5b21fed64a55",
+    "zh:2bc0b4d5b706c3bbe7824bcf410942ee631d3423c23f935a51129832d81e1e17",
+    "zh:3f27e2befae3393df2ba423abba7f64c774d8aa6e0de20d00b35d7cca6f47d65",
+    "zh:410bfc19e1f38b7caabc5e1b9cd2de196bdcaa02c840372be26734775ee0214c",
+    "zh:417181a86499386ffbf4d023b9c5219a0d322751513806e977f146f170f0aebc",
+    "zh:6764d31dbae9656b698a3b9d4a44e4267210375ff9bec3e8716bac4450a06f0d",
+    "zh:86401475746c94b12e90b065b76a77c635a84d9cbfc57eace65131c780bd34c6",
+    "zh:98388ac853abbcb18fdf578c18203f485479610d28329c21deefc573976e4b1d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:afb84c77c569e9979b8287cde33543cff992ca17e62ebe3f2b4a8e69884dbdc5",
+    "zh:c54c64dba350e6856fb8f2813b81d20286a532b02bad5f67da35135c02594407",
+    "zh:d1a46adf1c8f5bf42a1886b06fd25d86981236c933165f0fbc07e4330b77d8d1",
+    "zh:e719e227a676588cdaa5a3e7e3e6b10da26830a566730e8bce2127eec1780f40",
+  ]
+}

--- a/infra/modules/ses_email_foundation/main.tf
+++ b/infra/modules/ses_email_foundation/main.tf
@@ -1,0 +1,49 @@
+locals {
+  sender_email = trimspace(var.sender_email)
+}
+
+resource "aws_sesv2_email_identity" "sender" {
+  count = local.sender_email == "" ? 0 : 1
+
+  email_identity = local.sender_email
+
+  tags = var.tags
+}
+
+resource "aws_security_group" "ses_smtp_vpce" {
+  count = var.smtp_vpc_endpoint_enabled ? 1 : 0
+
+  name        = "${var.name_prefix}-ses-smtp-vpce-sg"
+  description = "LeaseFlow SES SMTP VPC endpoint security group"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description     = "SMTP submission from Lambda SG"
+    from_port       = 587
+    to_port         = 587
+    protocol        = "tcp"
+    security_groups = [var.lambda_security_group_id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-ses-smtp-vpce-sg" })
+}
+
+resource "aws_vpc_endpoint" "ses_smtp" {
+  count = var.smtp_vpc_endpoint_enabled ? 1 : 0
+
+  vpc_id              = var.vpc_id
+  service_name        = "com.amazonaws.${var.aws_region}.email-smtp"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  subnet_ids          = var.private_subnet_ids
+  security_group_ids  = [aws_security_group.ses_smtp_vpce[0].id]
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-ses-smtp-vpce" })
+}

--- a/infra/modules/ses_email_foundation/outputs.tf
+++ b/infra/modules/ses_email_foundation/outputs.tf
@@ -1,0 +1,19 @@
+output "sender_identity_configured" {
+  value       = length(aws_sesv2_email_identity.sender) > 0
+  description = "Whether an SES sender identity is configured."
+}
+
+output "smtp_vpc_endpoint_enabled" {
+  value       = length(aws_vpc_endpoint.ses_smtp) > 0
+  description = "Whether the SES SMTP interface VPC endpoint is configured."
+}
+
+output "smtp_vpc_endpoint_id" {
+  value       = try(aws_vpc_endpoint.ses_smtp[0].id, null)
+  description = "SES SMTP interface VPC endpoint ID when enabled."
+}
+
+output "smtp_vpc_endpoint_security_group_id" {
+  value       = try(aws_security_group.ses_smtp_vpce[0].id, null)
+  description = "SES SMTP interface VPC endpoint security group ID when enabled."
+}

--- a/infra/modules/ses_email_foundation/tests/defaults.tftest.hcl
+++ b/infra/modules/ses_email_foundation/tests/defaults.tftest.hcl
@@ -1,0 +1,127 @@
+mock_provider "aws" {}
+
+variables {
+  name_prefix              = "leaseflow-dev"
+  aws_region               = "eu-north-1"
+  vpc_id                   = "vpc-12345678"
+  private_subnet_ids       = ["subnet-private-1", "subnet-private-2"]
+  lambda_security_group_id = "sg-lambda"
+  tags = {
+    Project = "leaseflow"
+  }
+}
+
+run "defaults_create_no_ses_identity_or_smtp_endpoint" {
+  command = plan
+
+  assert {
+    condition     = length(aws_sesv2_email_identity.sender) == 0
+    error_message = "SES sender identity should not be created by default."
+  }
+
+  assert {
+    condition     = length(aws_security_group.ses_smtp_vpce) == 0
+    error_message = "SES SMTP endpoint security group should not be created by default."
+  }
+
+  assert {
+    condition     = length(aws_vpc_endpoint.ses_smtp) == 0
+    error_message = "SES SMTP VPC endpoint should not be created by default."
+  }
+
+  assert {
+    condition     = output.sender_identity_configured == false
+    error_message = "Sender identity output should be false by default."
+  }
+
+  assert {
+    condition     = output.smtp_vpc_endpoint_enabled == false
+    error_message = "SMTP VPC endpoint output should be false by default."
+  }
+}
+
+run "creates_sender_identity_when_email_configured" {
+  command = plan
+
+  variables {
+    sender_email = "sender@example.test"
+  }
+
+  assert {
+    condition     = length(aws_sesv2_email_identity.sender) == 1
+    error_message = "SES sender identity should be created when sender_email is configured."
+  }
+
+  assert {
+    condition     = aws_sesv2_email_identity.sender[0].email_identity == "sender@example.test"
+    error_message = "SES sender identity should use the configured email."
+  }
+
+  assert {
+    condition     = length(aws_vpc_endpoint.ses_smtp) == 0
+    error_message = "Configuring sender_email should not enable the SMTP VPC endpoint."
+  }
+
+  assert {
+    condition     = output.sender_identity_configured == true
+    error_message = "Sender identity output should be true when sender_email is configured."
+  }
+}
+
+run "creates_opt_in_smtp_private_endpoint" {
+  command = plan
+
+  variables {
+    smtp_vpc_endpoint_enabled = true
+  }
+
+  assert {
+    condition     = length(aws_security_group.ses_smtp_vpce) == 1
+    error_message = "SES SMTP endpoint security group should be created when endpoint is enabled."
+  }
+
+  assert {
+    condition = length([
+      for rule in aws_security_group.ses_smtp_vpce[0].ingress : rule
+      if rule.description == "SMTP submission from Lambda SG"
+      && rule.from_port == 587
+      && rule.to_port == 587
+      && rule.protocol == "tcp"
+      && contains(rule.security_groups, var.lambda_security_group_id)
+    ]) == 1
+    error_message = "SES SMTP endpoint security group should allow TCP 587 from the Lambda security group only."
+  }
+
+  assert {
+    condition     = length(aws_vpc_endpoint.ses_smtp) == 1
+    error_message = "SES SMTP VPC endpoint should be created when enabled."
+  }
+
+  assert {
+    condition     = aws_vpc_endpoint.ses_smtp[0].vpc_endpoint_type == "Interface"
+    error_message = "SES SMTP VPC endpoint should be an interface endpoint."
+  }
+
+  assert {
+    condition     = aws_vpc_endpoint.ses_smtp[0].service_name == "com.amazonaws.eu-north-1.email-smtp"
+    error_message = "SES SMTP VPC endpoint should target the regional email-smtp service."
+  }
+
+  assert {
+    condition     = aws_vpc_endpoint.ses_smtp[0].private_dns_enabled == true
+    error_message = "SES SMTP VPC endpoint should enable private DNS."
+  }
+
+  assert {
+    condition = alltrue([
+      for subnet_id in var.private_subnet_ids :
+      contains(aws_vpc_endpoint.ses_smtp[0].subnet_ids, subnet_id)
+    ])
+    error_message = "SES SMTP VPC endpoint should use the configured private subnets."
+  }
+
+  assert {
+    condition     = output.smtp_vpc_endpoint_enabled == true
+    error_message = "SMTP VPC endpoint output should be true when endpoint is enabled."
+  }
+}

--- a/infra/modules/ses_email_foundation/variables.tf
+++ b/infra/modules/ses_email_foundation/variables.tf
@@ -1,0 +1,52 @@
+variable "name_prefix" {
+  type        = string
+  description = "Prefix for SES email foundation resources."
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region used to build the SES SMTP VPC endpoint service name."
+}
+
+variable "sender_email" {
+  type        = string
+  description = "Optional verified SES sender email identity for dev email delivery validation."
+  default     = ""
+
+  validation {
+    condition     = trimspace(var.sender_email) == "" || can(regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$", trimspace(var.sender_email)))
+    error_message = "sender_email must be empty or a single email-like value."
+  }
+}
+
+variable "smtp_vpc_endpoint_enabled" {
+  type        = bool
+  description = "Whether to create the SES SMTP interface VPC endpoint. Disabled by default to avoid idle dev cost."
+  default     = false
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID for the optional SES SMTP interface endpoint."
+}
+
+variable "private_subnet_ids" {
+  type        = list(string)
+  description = "Private subnet IDs for the optional SES SMTP interface endpoint."
+
+  validation {
+    condition     = length(var.private_subnet_ids) > 0
+    error_message = "Provide at least one private subnet ID."
+  }
+}
+
+variable "lambda_security_group_id" {
+  type        = string
+  description = "Lambda security group allowed to connect to the optional SES SMTP interface endpoint."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Common tags."
+  default     = {}
+}

--- a/infra/modules/ses_email_foundation/versions.tf
+++ b/infra/modules/ses_email_foundation/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.37"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a reusable Terraform SES email foundation module.
- Wire dev with optional SES sender identity and disabled-by-default SES SMTP VPC endpoint.
- Add Terraform tests and include the new module in CI module tests.
- Update docs with SES sandbox, verification, PrivateLink cost, and no-delivery-yet boundaries.

## Security validation
- No SMTP credentials, IAM users, access keys, backend send permissions, or browser delivery actions were added.
- Tenant context remains unchanged and backend/JWT-derived.
- No real emails, tenant IDs, secrets, SSM values, DB endpoints, or raw SES outputs are committed.

## Cost validation
- No NAT Gateway added.
- SES SMTP VPC endpoint defaults to disabled to avoid idle PrivateLink hourly/data-processing cost.
- Optional sender identity defaults to empty.

## Validation
- `terraform fmt -check -recursive infra`
- `terraform test` in `infra/modules/ses_email_foundation`
- `terraform init -backend=false && terraform validate` in `infra/environments/dev`
- `git diff --check`

## Remaining risks / TODOs
- Email delivery code, SMTP credential storage, delivery status tracking, retry/idempotency, and SES smoke evidence remain follow-up work.
