### PR TITLE
feat: add operator notification contact setup path

### DIFF
--- a/backend/src/app/db.py
+++ b/backend/src/app/db.py
@@ -34,6 +34,7 @@ class Database:
         actor_user_id: str,
         email: str,
         enabled: bool = True,
+        audit_source: str = "api",
     ) -> NotificationContact:
         normalized_email = _normalize_notification_contact_email(email)
         if not normalized_email:
@@ -66,7 +67,7 @@ class Database:
                             "notification_contact.create",
                             "notification_contact",
                             contact_row["contact_id"],
-                            json.dumps({"source": "api", "enabled": enabled}),
+                            json.dumps({"source": audit_source, "enabled": enabled}),
                         ),
                     )
         except psycopg.errors.UniqueViolation as exc:
@@ -104,6 +105,7 @@ class Database:
         actor_user_id: str,
         contact_id: UUID,
         enabled: bool,
+        audit_source: str = "api",
     ) -> NotificationContact:
         contact_sql = """
             UPDATE notification_contacts
@@ -132,7 +134,7 @@ class Database:
                         "notification_contact.update",
                         "notification_contact",
                         contact_id,
-                        json.dumps({"source": "api", "enabled": enabled}),
+                        json.dumps({"source": audit_source, "enabled": enabled}),
                     ),
                 )
 

--- a/backend/src/app/handler.py
+++ b/backend/src/app/handler.py
@@ -14,6 +14,7 @@ from app.routes.db_migrations import run_db_migrations
 from app.routes.health import get_health
 from app.routes.lease_reminders import list_due_lease_reminders
 from app.routes.leases import create_lease, list_leases, update_lease
+from app.routes.notification_contact_setup import configure_notification_contact
 from app.routes.notification_email_delivery import deliver_notification_emails
 from app.routes.notifications import list_notifications, mark_notification_read
 from app.routes.properties import create_property, list_properties, update_property
@@ -125,6 +126,11 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             and event.get("detail-type") == "deliver_notification_emails"
         ):
             return _response(HTTPStatus.OK, deliver_notification_emails(event, db, settings))
+        if (
+            event.get("source") == "leaseflow.internal"
+            and event.get("detail-type") == "configure_notification_contact"
+        ):
+            return _response(HTTPStatus.OK, configure_notification_contact(event, db))
         if method == "PATCH" and notification_id is not None:
             return _response(HTTPStatus.OK, mark_notification_read(event, db, notification_id))
         if method == "PATCH" and property_id is not None:

--- a/backend/src/app/routes/notification_contact_setup.py
+++ b/backend/src/app/routes/notification_contact_setup.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.db import Database
+
+_INTERNAL_ACTOR = "leaseflow.internal"
+_DUPLICATE_MESSAGE = "Notification contact already exists for tenant."
+
+
+def configure_notification_contact(event: dict[str, Any], db: Database) -> dict[str, bool]:
+    detail = event.get("detail") or {}
+    tenant_id = _required_detail(detail, "tenant_id", "Notification contact tenant_id is required.")
+    email = _required_detail(detail, "email", "Notification contact email is required.")
+
+    try:
+        db.create_notification_contact(
+            tenant_id=tenant_id,
+            actor_user_id=_INTERNAL_ACTOR,
+            email=email,
+            enabled=True,
+            audit_source=_INTERNAL_ACTOR,
+        )
+    except ValueError as exc:
+        if str(exc) != _DUPLICATE_MESSAGE:
+            raise
+        return _configure_existing_contact(db, tenant_id=tenant_id, email=email)
+
+    return _payload(created=True, updated=False, enabled=True)
+
+
+def _configure_existing_contact(
+    db: Database,
+    *,
+    tenant_id: str,
+    email: str,
+) -> dict[str, bool]:
+    normalized_email = email.strip().lower()
+    contacts = db.list_notification_contacts(tenant_id=tenant_id)
+
+    for contact in contacts:
+        if contact.email.strip().lower() != normalized_email:
+            continue
+        if contact.enabled:
+            return _payload(created=False, updated=False, enabled=True)
+        db.set_notification_contact_enabled(
+            tenant_id=tenant_id,
+            actor_user_id=_INTERNAL_ACTOR,
+            contact_id=contact.contact_id,
+            enabled=True,
+            audit_source=_INTERNAL_ACTOR,
+        )
+        return _payload(created=False, updated=True, enabled=True)
+
+    raise ValueError(_DUPLICATE_MESSAGE)
+
+
+def _required_detail(detail: dict[str, Any], key: str, error_message: str) -> str:
+    value = str(detail.get(key, "")).strip()
+    if not value:
+        raise ValueError(error_message)
+    return value
+
+
+def _payload(*, created: bool, updated: bool, enabled: bool) -> dict[str, bool]:
+    return {
+        "configured": True,
+        "created": created,
+        "updated": updated,
+        "enabled": enabled,
+    }

--- a/backend/tests/test_db_integration.py
+++ b/backend/tests/test_db_integration.py
@@ -1490,6 +1490,44 @@ def test_create_notification_contact_stores_normalized_email_and_audit_log(
         _cleanup_test_tenant(integration_settings, tenant_id)
 
 
+def test_create_notification_contact_supports_internal_audit_source(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = "leaseflow.internal"
+
+    try:
+        created = db.create_notification_contact(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            email=f"internal-contact-{uuid4().hex[:8]}@example.com",
+            audit_source="leaseflow.internal",
+        )
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            audit_rows = conn.execute(
+                """
+                SELECT actor_user_id, metadata
+                FROM audit_logs
+                WHERE tenant_id = %s
+                  AND entity_id = %s
+                  AND action = 'notification_contact.create'
+                """,
+                (tenant_id, created.contact_id),
+            ).fetchall()
+
+        assert len(audit_rows) == 1
+        assert audit_rows[0]["actor_user_id"] == actor_user_id
+        assert audit_rows[0]["metadata"] == {
+            "source": "leaseflow.internal",
+            "enabled": True,
+        }
+        assert "email" not in audit_rows[0]["metadata"]
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+
+
 def test_create_notification_contact_rejects_blank_email(
     integration_settings: Settings,
 ) -> None:

--- a/backend/tests/test_handler.py
+++ b/backend/tests/test_handler.py
@@ -703,6 +703,43 @@ def test_deliver_notification_emails_accepts_internal_event(monkeypatch) -> None
     }
 
 
+def test_configure_notification_contact_accepts_internal_event(monkeypatch) -> None:
+    settings = SimpleNamespace(log_level="INFO")
+    db = object()
+    monkeypatch.setattr(handler, "load_settings", lambda: settings)
+    monkeypatch.setattr(handler, "Database", lambda loaded_settings: db)
+    monkeypatch.setattr(
+        handler,
+        "configure_notification_contact",
+        lambda event, database: {
+            "configured": True,
+            "created": True,
+            "updated": False,
+            "enabled": True,
+        },
+        raising=False,
+    )
+
+    event = {
+        "source": "leaseflow.internal",
+        "detail-type": "configure_notification_contact",
+        "detail": {
+            "tenant_id": "tenant-123",
+            "email": "recipient@example.test",
+        },
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 200
+    assert json.loads(response["body"]) == {
+        "configured": True,
+        "created": True,
+        "updated": False,
+        "enabled": True,
+    }
+
+
 def test_run_db_migrations_accepts_internal_event(monkeypatch) -> None:
     monkeypatch.setattr(
         handler,

--- a/backend/tests/test_notification_contact_setup_route.py
+++ b/backend/tests/test_notification_contact_setup_route.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from uuid import UUID
+
+import pytest
+
+
+def _route_module():
+    return importlib.import_module("app.routes.notification_contact_setup")
+
+
+@dataclass(slots=True)
+class _Contact:
+    contact_id: UUID
+    tenant_id: str
+    email: str
+    enabled: bool
+    created_at: datetime
+
+
+class _FakeDb:
+    def __init__(self, contacts: list[_Contact] | None = None) -> None:
+        self.contacts = contacts or []
+        self.create_calls: list[tuple[str, str, str, bool, str]] = []
+        self.list_calls: list[tuple[str, bool]] = []
+        self.enable_calls: list[tuple[str, str, UUID, bool, str]] = []
+
+    def create_notification_contact(
+        self,
+        tenant_id: str,
+        actor_user_id: str,
+        email: str,
+        enabled: bool = True,
+        audit_source: str = "api",
+    ) -> _Contact:
+        self.create_calls.append((tenant_id, actor_user_id, email, enabled, audit_source))
+        normalized_email = email.strip().lower()
+        if any(contact.email == normalized_email for contact in self.contacts):
+            raise ValueError("Notification contact already exists for tenant.")
+
+        contact = _contact(
+            tenant_id=tenant_id,
+            email=normalized_email,
+            enabled=enabled,
+        )
+        self.contacts.append(contact)
+        return contact
+
+    def list_notification_contacts(
+        self,
+        tenant_id: str,
+        enabled_only: bool = False,
+    ) -> list[_Contact]:
+        self.list_calls.append((tenant_id, enabled_only))
+        contacts = [contact for contact in self.contacts if contact.tenant_id == tenant_id]
+        if enabled_only:
+            return [contact for contact in contacts if contact.enabled]
+        return contacts
+
+    def set_notification_contact_enabled(
+        self,
+        tenant_id: str,
+        actor_user_id: str,
+        contact_id: UUID,
+        enabled: bool,
+        audit_source: str = "api",
+    ) -> _Contact:
+        self.enable_calls.append(
+            (tenant_id, actor_user_id, contact_id, enabled, audit_source)
+        )
+        for index, contact in enumerate(self.contacts):
+            if contact.tenant_id == tenant_id and contact.contact_id == contact_id:
+                updated = _Contact(
+                    contact_id=contact.contact_id,
+                    tenant_id=contact.tenant_id,
+                    email=contact.email,
+                    enabled=enabled,
+                    created_at=contact.created_at,
+                )
+                self.contacts[index] = updated
+                return updated
+        raise LookupError("Notification contact not found for tenant.")
+
+
+def _event(
+    *,
+    tenant_id: str | None = "tenant-auth",
+    email: str | None = " Contact.One+SES@Example.COM ",
+) -> dict:
+    detail = {}
+    if tenant_id is not None:
+        detail["tenant_id"] = tenant_id
+    if email is not None:
+        detail["email"] = email
+    return {
+        "source": "leaseflow.internal",
+        "detail-type": "configure_notification_contact",
+        "detail": detail,
+    }
+
+
+def _contact(
+    *,
+    tenant_id: str = "tenant-auth",
+    email: str = "contact.one+ses@example.com",
+    enabled: bool = True,
+) -> _Contact:
+    return _Contact(
+        contact_id=UUID("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+        tenant_id=tenant_id,
+        email=email,
+        enabled=enabled,
+        created_at=datetime(2026, 5, 4, tzinfo=timezone.utc),
+    )
+
+
+def test_configure_notification_contact_creates_enabled_contact_with_safe_payload() -> None:
+    route = _route_module()
+    db = _FakeDb()
+
+    payload = route.configure_notification_contact(_event(), db)
+
+    assert db.create_calls == [
+        (
+            "tenant-auth",
+            "leaseflow.internal",
+            "Contact.One+SES@Example.COM",
+            True,
+            "leaseflow.internal",
+        )
+    ]
+    assert payload == {
+        "configured": True,
+        "created": True,
+        "updated": False,
+        "enabled": True,
+    }
+    assert "tenant-auth" not in str(payload)
+    assert "contact.one+ses@example.com" not in str(payload)
+    assert "cccccccc" not in str(payload)
+
+
+def test_configure_notification_contact_reenables_disabled_existing_contact() -> None:
+    route = _route_module()
+    existing = _contact(enabled=False)
+    db = _FakeDb([existing])
+
+    payload = route.configure_notification_contact(_event(), db)
+
+    assert db.create_calls == [
+        (
+            "tenant-auth",
+            "leaseflow.internal",
+            "Contact.One+SES@Example.COM",
+            True,
+            "leaseflow.internal",
+        )
+    ]
+    assert db.list_calls == [("tenant-auth", False)]
+    assert db.enable_calls == [
+        (
+            "tenant-auth",
+            "leaseflow.internal",
+            existing.contact_id,
+            True,
+            "leaseflow.internal",
+        )
+    ]
+    assert payload == {
+        "configured": True,
+        "created": False,
+        "updated": True,
+        "enabled": True,
+    }
+
+
+def test_configure_notification_contact_leaves_enabled_existing_contact_unchanged() -> None:
+    route = _route_module()
+    db = _FakeDb([_contact(enabled=True)])
+
+    payload = route.configure_notification_contact(_event(), db)
+
+    assert db.list_calls == [("tenant-auth", False)]
+    assert db.enable_calls == []
+    assert payload == {
+        "configured": True,
+        "created": False,
+        "updated": False,
+        "enabled": True,
+    }
+
+
+@pytest.mark.parametrize(
+    ("event", "message"),
+    [
+        (_event(tenant_id=None), "Notification contact tenant_id is required."),
+        (_event(tenant_id="   "), "Notification contact tenant_id is required."),
+        (_event(email=None), "Notification contact email is required."),
+        (_event(email="   "), "Notification contact email is required."),
+    ],
+)
+def test_configure_notification_contact_rejects_missing_or_blank_input(
+    event: dict,
+    message: str,
+) -> None:
+    route = _route_module()
+
+    with pytest.raises(ValueError, match=message):
+        route.configure_notification_contact(event, _FakeDb())

--- a/backend/tests/test_notification_contact_setup_route.py
+++ b/backend/tests/test_notification_contact_setup_route.py
@@ -68,9 +68,7 @@ class _FakeDb:
         enabled: bool,
         audit_source: str = "api",
     ) -> _Contact:
-        self.enable_calls.append(
-            (tenant_id, actor_user_id, contact_id, enabled, audit_source)
-        )
+        self.enable_calls.append((tenant_id, actor_user_id, contact_id, enabled, audit_source))
         for index, contact in enumerate(self.contacts):
             if contact.tenant_id == tenant_id and contact.contact_id == contact_id:
                 updated = _Contact(

--- a/backend/tests/test_notification_contact_setup_route.py
+++ b/backend/tests/test_notification_contact_setup_route.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import importlib
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from uuid import UUID
 
 import pytest
@@ -111,7 +111,7 @@ def _contact(
         tenant_id=tenant_id,
         email=email,
         enabled=enabled,
-        created_at=datetime(2026, 5, 4, tzinfo=timezone.utc),
+        created_at=datetime(2026, 5, 4, tzinfo=UTC),
     )
 
 

--- a/docs/runbooks/ses-notification-email-delivery-smoke-test.md
+++ b/docs/runbooks/ses-notification-email-delivery-smoke-test.md
@@ -24,17 +24,13 @@ monitoring, a browser feature, or an automated scheduler.
 - Disable delivery and the SES SMTP VPC endpoint after validation unless more
   dev testing is planned.
 
-## Current Limitation
+## Contact Setup Path
 
 Successful smoke validation requires an enabled `notification_contacts` row for
-the smoke tenant. The current app has the DB model and backend data-access
-methods, but no browser route, public API, or internal operator event for
-creating contacts.
-
-If the controlled dev tenant does not already have an enabled contact row, stop
-this runbook and create a separate follow-up ticket for a safe operator contact
-setup path. Do not work around this by making RDS public or committing local DB
-payloads.
+the smoke tenant. Use the dev/operator script in this runbook to configure that
+contact through the backend internal Lambda event. Do not work around contact
+setup by making RDS public, using direct DB access, or adding browser controls
+for scan or delivery.
 
 ## Preconditions
 
@@ -175,12 +171,23 @@ Expected result:
 
 - `$SMOKE_TENANT` is set locally but not printed into evidence.
 - The tenant has due-soon reminder source data.
-- The tenant already has at least one enabled `notification_contacts` row.
+- The target Cognito username is known locally for contact setup.
 
-Stop condition:
+Configure one enabled notification contact for the smoke tenant:
 
-- If no enabled contact exists for this tenant, stop. Do not mark smoke as
-  passed.
+```bash
+cd /mnt/c/Repos/LeaseFlow
+export CONTACT_COGNITO_USERNAME="$SMOKE_COGNITO_USERNAME"
+export CONTACT_EMAIL="<verified-recipient-email>"
+
+bash scripts/dev/create-notification-contact.sh
+```
+
+Expected result:
+
+- The script prints safe status lines such as `CONTACT_CONFIGURED=true`.
+- No recipient email, Cognito username, tenant ID, contact ID, token, SSM value,
+  DB endpoint, or raw Lambda response is printed into evidence.
 
 ## Step 5: Load Safe Dev Runtime Values
 

--- a/scripts/dev/create-notification-contact.sh
+++ b/scripts/dev/create-notification-contact.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+require_linux
+require_repo_root
+require_command aws
+require_command python3
+terraform_dev_init
+
+CONTACT_COGNITO_USERNAME="${CONTACT_COGNITO_USERNAME:-}"
+CONTACT_EMAIL="${CONTACT_EMAIL:-}"
+BACKEND_FUNCTION="${BACKEND_FUNCTION:-leaseflow-dev-backend}"
+
+[[ -n "${CONTACT_COGNITO_USERNAME}" ]] || die "Set CONTACT_COGNITO_USERNAME to the existing Cognito username for the smoke tenant."
+[[ -n "${CONTACT_EMAIL}" ]] || die "Set CONTACT_EMAIL to the verified SES smoke recipient email."
+
+USER_POOL_ID="$(terraform_dev_output cognito_user_pool_id)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+PAYLOAD_FILE="${TMP_DIR}/notification-contact-payload.json"
+RESPONSE_FILE="${TMP_DIR}/notification-contact-response.json"
+
+CONTACT_TENANT="$(
+  aws cognito-idp admin-get-user \
+    --user-pool-id "${USER_POOL_ID}" \
+    --username "${CONTACT_COGNITO_USERNAME}" \
+    --query 'UserAttributes[?Name==`custom:tenant_id`].Value | [0]' \
+    --output text
+)"
+
+[[ -n "${CONTACT_TENANT}" && "${CONTACT_TENANT}" != "None" ]] || die "Could not resolve custom:tenant_id for CONTACT_COGNITO_USERNAME."
+
+python3 - "${PAYLOAD_FILE}" "${CONTACT_TENANT}" "${CONTACT_EMAIL}" <<'PY'
+import json
+import sys
+
+payload = {
+    "source": "leaseflow.internal",
+    "detail-type": "configure_notification_contact",
+    "detail": {
+        "tenant_id": sys.argv[2],
+        "email": sys.argv[3],
+    },
+}
+
+with open(sys.argv[1], "w", encoding="utf-8") as payload_file:
+    json.dump(payload, payload_file)
+PY
+
+info "Configuring notification contact through ${BACKEND_FUNCTION}"
+aws lambda invoke \
+  --region "${AWS_REGION}" \
+  --function-name "${BACKEND_FUNCTION}" \
+  --cli-binary-format raw-in-base64-out \
+  --payload "fileb://${PAYLOAD_FILE}" \
+  "${RESPONSE_FILE}" \
+  --query 'StatusCode' \
+  --output text >/dev/null
+
+python3 - "${RESPONSE_FILE}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as response_file:
+    payload = json.load(response_file)
+
+status_code = payload.get("statusCode")
+print(f"CONTACT_SETUP_STATUS_CODE={status_code}")
+
+body = payload.get("body")
+if isinstance(body, str):
+    try:
+        body = json.loads(body)
+    except json.JSONDecodeError:
+        body = {}
+
+if isinstance(body, dict):
+    for source_key, output_key in (
+        ("configured", "CONTACT_CONFIGURED"),
+        ("created", "CONTACT_CREATED"),
+        ("updated", "CONTACT_UPDATED"),
+        ("enabled", "CONTACT_ENABLED"),
+    ):
+        if source_key in body:
+            print(f"{output_key}={str(body[source_key]).lower()}")
+
+if status_code != 200:
+    sys.exit(1)
+PY
+
+echo "Do not commit or paste CONTACT_EMAIL, CONTACT_COGNITO_USERNAME, or tenant values into evidence."


### PR DESCRIPTION
## Summary
Adds a dev/operator-only notification contact setup path for SES smoke validation.

Changes:
- adds internal `configure_notification_contact` Lambda event
- creates or re-enables an enabled tenant-scoped notification contact
- adds `scripts/dev/create-notification-contact.sh`
- updates SES smoke runbook to use the safe operator setup path
- keeps payload output sanitized: no tenant ID, email, contact ID, raw DB values, or raw Lambda response

## Validation
- `python -m pytest -q tests/test_notification_contact_setup_route.py tests/test_handler.py -k "notification_contact"`
- `python -m pytest -q`
- `bash -n scripts/dev/*.sh`
- `git diff --check`

DB integration contact tests were skipped in the current local environment.

## Security Validation
Tenant context is still not accepted from browser/API clients. The new path is internal Lambda-event only and intended for operator use. Audit metadata does not include email addresses, and the script prints only safe status fields.

## Cost Validation
No Terraform resources, AWS services, SES behavior, or infrastructure changes were added.

## Remaining Risks
SES smoke still requires operator-provided verified recipient details and deployed migrations/config. This ticket only adds the safe contact setup path.
