### PR TITLE
feat: add notification contact management

### DIFF
--- a/backend/src/app/handler.py
+++ b/backend/src/app/handler.py
@@ -15,6 +15,11 @@ from app.routes.health import get_health
 from app.routes.lease_reminders import list_due_lease_reminders
 from app.routes.leases import create_lease, list_leases, update_lease
 from app.routes.notification_contact_setup import configure_notification_contact
+from app.routes.notification_contacts import (
+    create_notification_contact,
+    list_notification_contacts,
+    update_notification_contact,
+)
 from app.routes.notification_email_delivery import deliver_notification_emails
 from app.routes.notifications import list_notifications, mark_notification_read
 from app.routes.properties import create_property, list_properties, update_property
@@ -23,6 +28,7 @@ from app.routes.reminder_scans import scan_due_lease_reminders
 setup_logging()
 LOGGER = get_logger(__name__)
 _LEASE_PATH = re.compile(r"^/leases/(?P<lease_id>[^/]+)$")
+_NOTIFICATION_CONTACT_PATH = re.compile(r"^/notification-contacts/(?P<contact_id>[^/]+)$")
 _NOTIFICATION_READ_PATH = re.compile(r"^/notifications/(?P<notification_id>[^/]+)/read$")
 _PROPERTY_PATH = re.compile(r"^/properties/(?P<property_id>[^/]+)$")
 
@@ -70,6 +76,17 @@ def _notification_read_id(path: str) -> UUID | None:
         raise ValueError("Invalid notification ID.") from exc
 
 
+def _notification_contact_id(path: str) -> UUID | None:
+    match = _NOTIFICATION_CONTACT_PATH.fullmatch(path)
+    if match is None:
+        return None
+
+    try:
+        return UUID(match.group("contact_id"))
+    except ValueError as exc:
+        raise ValueError("Invalid notification contact ID.") from exc
+
+
 def _property_id(path: str) -> UUID | None:
     match = _PROPERTY_PATH.fullmatch(path)
     if match is None:
@@ -106,6 +123,7 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             return _response(HTTPStatus.OK, get_health())
 
         lease_id = _lease_id(path) if method == "PATCH" else None
+        notification_contact_id = _notification_contact_id(path) if method == "PATCH" else None
         notification_id = _notification_read_id(path) if method == "PATCH" else None
         property_id = _property_id(path) if method == "PATCH" else None
         settings = load_settings()
@@ -131,6 +149,11 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             and event.get("detail-type") == "configure_notification_contact"
         ):
             return _response(HTTPStatus.OK, configure_notification_contact(event, db))
+        if method == "PATCH" and notification_contact_id is not None:
+            return _response(
+                HTTPStatus.OK,
+                update_notification_contact(event, db, notification_contact_id),
+            )
         if method == "PATCH" and notification_id is not None:
             return _response(HTTPStatus.OK, mark_notification_read(event, db, notification_id))
         if method == "PATCH" and property_id is not None:
@@ -139,6 +162,13 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             return _response(HTTPStatus.OK, update_lease(event, db, lease_id))
         if method == "GET" and path == "/notifications":
             return _response(HTTPStatus.OK, list_notifications(event, db))
+        if method == "GET" and path == "/notification-contacts":
+            return _response(HTTPStatus.OK, list_notification_contacts(event, db))
+        if method == "POST" and path == "/notification-contacts":
+            return _response(
+                HTTPStatus.CREATED,
+                create_notification_contact(event, db, _json_body(event)),
+            )
         if method == "GET" and path == "/lease-reminders/due-soon":
             return _response(HTTPStatus.OK, list_due_lease_reminders(event, db))
         if method == "GET" and path == "/leases":

--- a/backend/src/app/routes/notification_contacts.py
+++ b/backend/src/app/routes/notification_contacts.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from uuid import UUID
+
+from app.auth import extract_auth_context
+from app.db import Database
+from app.models import NotificationContact
+
+_DUPLICATE_MESSAGE = "Notification contact already exists for tenant."
+
+
+def list_notification_contacts(event: dict[str, Any], db: Database) -> dict[str, Any]:
+    auth = extract_auth_context(event)
+    items = db.list_notification_contacts(tenant_id=auth.tenant_id)
+    return {"items": notification_contacts_to_dict(items)}
+
+
+def create_notification_contact(
+    event: dict[str, Any],
+    db: Database,
+    body: dict[str, Any],
+) -> dict[str, Any]:
+    auth = extract_auth_context(event)
+    email = _create_body_email(body)
+
+    try:
+        created = db.create_notification_contact(
+            tenant_id=auth.tenant_id,
+            actor_user_id=auth.user_id,
+            email=email,
+            enabled=True,
+        )
+    except ValueError as exc:
+        if str(exc) != _DUPLICATE_MESSAGE:
+            raise
+        return notification_contact_to_dict(
+            _reenable_disabled_duplicate(
+                db,
+                tenant_id=auth.tenant_id,
+                actor_user_id=auth.user_id,
+                email=email,
+            )
+        )
+
+    return notification_contact_to_dict(created)
+
+
+def update_notification_contact(
+    event: dict[str, Any],
+    db: Database,
+    contact_id: UUID,
+) -> dict[str, Any]:
+    auth = extract_auth_context(event)
+    enabled = _update_body_enabled(event)
+    updated = db.set_notification_contact_enabled(
+        tenant_id=auth.tenant_id,
+        actor_user_id=auth.user_id,
+        contact_id=contact_id,
+        enabled=enabled,
+    )
+    return notification_contact_to_dict(updated)
+
+
+def notification_contact_to_dict(item: NotificationContact) -> dict[str, Any]:
+    return {
+        "contact_id": str(item.contact_id),
+        "email": item.email,
+        "enabled": item.enabled,
+        "created_at": item.created_at.isoformat(),
+    }
+
+
+def notification_contacts_to_dict(
+    items: list[NotificationContact],
+) -> list[dict[str, Any]]:
+    return [notification_contact_to_dict(item) for item in items]
+
+
+def _create_body_email(body: dict[str, Any]) -> str:
+    unsupported_fields = set(body) - {"email"}
+    if unsupported_fields:
+        raise ValueError("Only field 'email' can be provided.")
+
+    email = str(body.get("email", "")).strip()
+    if not email:
+        raise ValueError("Field 'email' is required.")
+    return email
+
+
+def _update_body_enabled(event: dict[str, Any]) -> bool:
+    body = _json_body(event)
+    if set(body) != {"enabled"}:
+        raise ValueError("Only field 'enabled' can be updated.")
+
+    enabled = body["enabled"]
+    if not isinstance(enabled, bool):
+        raise ValueError("Field 'enabled' must be a boolean.")
+    return enabled
+
+
+def _json_body(event: dict[str, Any]) -> dict[str, Any]:
+    raw = event.get("body")
+    if raw in (None, ""):
+        return {}
+
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Invalid JSON request body.") from exc
+
+    if not isinstance(body, dict):
+        raise ValueError("JSON body must be an object.")
+    return body
+
+
+def _reenable_disabled_duplicate(
+    db: Database,
+    *,
+    tenant_id: str,
+    actor_user_id: str,
+    email: str,
+) -> NotificationContact:
+    normalized_email = email.strip().lower()
+    contacts = db.list_notification_contacts(tenant_id=tenant_id)
+
+    for contact in contacts:
+        if contact.email.strip().lower() != normalized_email:
+            continue
+        if contact.enabled:
+            raise ValueError(_DUPLICATE_MESSAGE)
+        return db.set_notification_contact_enabled(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            contact_id=contact.contact_id,
+            enabled=True,
+        )
+
+    raise ValueError(_DUPLICATE_MESSAGE)

--- a/backend/tests/test_handler.py
+++ b/backend/tests/test_handler.py
@@ -740,6 +740,81 @@ def test_configure_notification_contact_accepts_internal_event(monkeypatch) -> N
     }
 
 
+def test_list_notification_contacts_accepts_protected_route(monkeypatch) -> None:
+    settings = SimpleNamespace(log_level="INFO")
+    db = object()
+    monkeypatch.setattr(handler, "load_settings", lambda: settings)
+    monkeypatch.setattr(handler, "Database", lambda loaded_settings: db)
+    monkeypatch.setattr(
+        handler,
+        "list_notification_contacts",
+        lambda event, database: {"items": [{"contact_id": "contact-1"}]},
+        raising=False,
+    )
+
+    event = {
+        "requestContext": {"http": {"method": "GET"}},
+        "rawPath": "/notification-contacts",
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 200
+    assert json.loads(response["body"]) == {"items": [{"contact_id": "contact-1"}]}
+
+
+def test_create_notification_contact_accepts_protected_route(monkeypatch) -> None:
+    settings = SimpleNamespace(log_level="INFO")
+    db = object()
+    monkeypatch.setattr(handler, "load_settings", lambda: settings)
+    monkeypatch.setattr(handler, "Database", lambda loaded_settings: db)
+    monkeypatch.setattr(
+        handler,
+        "create_notification_contact",
+        lambda event, database, body: {"contact_id": "contact-1", "enabled": True},
+        raising=False,
+    )
+
+    event = {
+        "body": '{"email":"contact@example.test"}',
+        "requestContext": {"http": {"method": "POST"}},
+        "rawPath": "/notification-contacts",
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 201
+    assert json.loads(response["body"]) == {"contact_id": "contact-1", "enabled": True}
+
+
+def test_update_notification_contact_accepts_protected_route(monkeypatch) -> None:
+    settings = SimpleNamespace(log_level="INFO")
+    db = object()
+    contact_id = "11111111-1111-1111-1111-111111111111"
+    monkeypatch.setattr(handler, "load_settings", lambda: settings)
+    monkeypatch.setattr(handler, "Database", lambda loaded_settings: db)
+    monkeypatch.setattr(
+        handler,
+        "update_notification_contact",
+        lambda event, database, parsed_contact_id: {
+            "contact_id": str(parsed_contact_id),
+            "enabled": False,
+        },
+        raising=False,
+    )
+
+    event = {
+        "body": '{"enabled": false}',
+        "requestContext": {"http": {"method": "PATCH"}},
+        "rawPath": f"/notification-contacts/{contact_id}",
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 200
+    assert json.loads(response["body"]) == {"contact_id": contact_id, "enabled": False}
+
+
 def test_run_db_migrations_accepts_internal_event(monkeypatch) -> None:
     monkeypatch.setattr(
         handler,

--- a/backend/tests/test_notification_contacts_route.py
+++ b/backend/tests/test_notification_contacts_route.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import UUID
+
+import pytest
+
+from app.auth import AuthError
+
+
+def _contacts_module():
+    return importlib.import_module("app.routes.notification_contacts")
+
+
+@dataclass(slots=True)
+class _ContactRecord:
+    contact_id: UUID
+    tenant_id: str
+    email: str
+    enabled: bool
+    created_at: datetime
+
+
+class _FakeDb:
+    def __init__(self) -> None:
+        self.contacts: list[_ContactRecord] = [
+            _contact(
+                contact_id=UUID("11111111-1111-1111-1111-111111111111"),
+                tenant_id="tenant-auth",
+                email="enabled@example.test",
+                enabled=True,
+            ),
+            _contact(
+                contact_id=UUID("22222222-2222-2222-2222-222222222222"),
+                tenant_id="tenant-auth",
+                email="disabled@example.test",
+                enabled=False,
+            ),
+        ]
+        self.create_calls: list[dict[str, object]] = []
+        self.list_calls: list[str] = []
+        self.update_calls: list[dict[str, object]] = []
+
+    def list_notification_contacts(self, tenant_id: str) -> list[_ContactRecord]:
+        self.list_calls.append(tenant_id)
+        return [contact for contact in self.contacts if contact.tenant_id == tenant_id]
+
+    def create_notification_contact(
+        self,
+        tenant_id: str,
+        actor_user_id: str,
+        email: str,
+        enabled: bool = True,
+    ) -> _ContactRecord:
+        self.create_calls.append(
+            {
+                "tenant_id": tenant_id,
+                "actor_user_id": actor_user_id,
+                "email": email,
+                "enabled": enabled,
+            }
+        )
+        normalized_email = email.strip().lower()
+        if any(
+            contact.tenant_id == tenant_id and contact.email.strip().lower() == normalized_email
+            for contact in self.contacts
+        ):
+            raise ValueError("Notification contact already exists for tenant.")
+        created = _contact(
+            contact_id=UUID("33333333-3333-3333-3333-333333333333"),
+            tenant_id=tenant_id,
+            email=normalized_email,
+            enabled=enabled,
+        )
+        self.contacts.append(created)
+        return created
+
+    def set_notification_contact_enabled(
+        self,
+        tenant_id: str,
+        actor_user_id: str,
+        contact_id: UUID,
+        enabled: bool,
+    ) -> _ContactRecord:
+        self.update_calls.append(
+            {
+                "tenant_id": tenant_id,
+                "actor_user_id": actor_user_id,
+                "contact_id": contact_id,
+                "enabled": enabled,
+            }
+        )
+        for index, contact in enumerate(self.contacts):
+            if contact.tenant_id == tenant_id and contact.contact_id == contact_id:
+                updated = _contact(
+                    contact_id=contact.contact_id,
+                    tenant_id=contact.tenant_id,
+                    email=contact.email,
+                    enabled=enabled,
+                )
+                self.contacts[index] = updated
+                return updated
+        raise LookupError("Notification contact not found for tenant.")
+
+
+def _contact(
+    *,
+    contact_id: UUID,
+    tenant_id: str,
+    email: str,
+    enabled: bool,
+) -> _ContactRecord:
+    return _ContactRecord(
+        contact_id=contact_id,
+        tenant_id=tenant_id,
+        email=email,
+        enabled=enabled,
+        created_at=datetime(2026, 5, 5, tzinfo=UTC),
+    )
+
+
+def _event_with_auth(*, tenant_id: str = "tenant-auth", user_id: str = "user-auth") -> dict:
+    return {
+        "requestContext": {
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "sub": user_id,
+                        "custom:tenant_id": tenant_id,
+                    }
+                }
+            }
+        }
+    }
+
+
+def test_list_notification_contacts_uses_auth_tenant_and_excludes_tenant_id() -> None:
+    contacts = _contacts_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+    event["queryStringParameters"] = {"tenant_id": "tenant-from-client"}
+
+    payload = contacts.list_notification_contacts(event, db)
+
+    assert db.list_calls == ["tenant-auth"]
+    assert payload == {
+        "items": [
+            {
+                "contact_id": "11111111-1111-1111-1111-111111111111",
+                "email": "enabled@example.test",
+                "enabled": True,
+                "created_at": "2026-05-05T00:00:00+00:00",
+            },
+            {
+                "contact_id": "22222222-2222-2222-2222-222222222222",
+                "email": "disabled@example.test",
+                "enabled": False,
+                "created_at": "2026-05-05T00:00:00+00:00",
+            },
+        ]
+    }
+
+
+def test_create_notification_contact_uses_auth_context_and_excludes_tenant_id() -> None:
+    contacts = _contacts_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+
+    payload = contacts.create_notification_contact(event, db, {"email": " New@Example.TEST "})
+
+    assert db.create_calls == [
+        {
+            "tenant_id": "tenant-auth",
+            "actor_user_id": "user-auth",
+            "email": "New@Example.TEST",
+            "enabled": True,
+        }
+    ]
+    assert payload == {
+        "contact_id": "33333333-3333-3333-3333-333333333333",
+        "email": "new@example.test",
+        "enabled": True,
+        "created_at": "2026-05-05T00:00:00+00:00",
+    }
+
+
+def test_create_notification_contact_reenables_disabled_duplicate() -> None:
+    contacts = _contacts_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+
+    payload = contacts.create_notification_contact(event, db, {"email": "DISABLED@example.test"})
+
+    assert db.update_calls == [
+        {
+            "tenant_id": "tenant-auth",
+            "actor_user_id": "user-auth",
+            "contact_id": UUID("22222222-2222-2222-2222-222222222222"),
+            "enabled": True,
+        }
+    ]
+    assert payload["contact_id"] == "22222222-2222-2222-2222-222222222222"
+    assert payload["enabled"] is True
+    assert "tenant_id" not in payload
+
+
+def test_create_notification_contact_rejects_enabled_duplicate() -> None:
+    contacts = _contacts_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+
+    with pytest.raises(ValueError, match="Notification contact already exists for tenant."):
+        contacts.create_notification_contact(event, db, {"email": "ENABLED@example.test"})
+
+
+def test_create_notification_contact_rejects_unsupported_body_fields() -> None:
+    contacts = _contacts_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+
+    with pytest.raises(ValueError, match="Only field 'email' can be provided."):
+        contacts.create_notification_contact(
+            event,
+            db,
+            {"email": "contact@example.test", "tenant_id": "tenant-from-body"},
+        )
+
+
+def test_update_notification_contact_enabled_uses_auth_context_and_excludes_tenant_id() -> None:
+    contacts = _contacts_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+    event["queryStringParameters"] = {"tenant_id": "tenant-from-query"}
+    event["body"] = '{"enabled": false}'
+
+    payload = contacts.update_notification_contact(
+        event,
+        db,
+        UUID("11111111-1111-1111-1111-111111111111"),
+    )
+
+    assert db.update_calls == [
+        {
+            "tenant_id": "tenant-auth",
+            "actor_user_id": "user-auth",
+            "contact_id": UUID("11111111-1111-1111-1111-111111111111"),
+            "enabled": False,
+        }
+    ]
+    assert payload == {
+        "contact_id": "11111111-1111-1111-1111-111111111111",
+        "email": "enabled@example.test",
+        "enabled": False,
+        "created_at": "2026-05-05T00:00:00+00:00",
+    }
+
+
+def test_update_notification_contact_rejects_non_boolean_enabled() -> None:
+    contacts = _contacts_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+    event["body"] = '{"enabled": "false"}'
+
+    with pytest.raises(ValueError, match="Field 'enabled' must be a boolean."):
+        contacts.update_notification_contact(
+            event,
+            db,
+            UUID("11111111-1111-1111-1111-111111111111"),
+        )
+
+
+def test_update_notification_contact_rejects_unsupported_body_fields() -> None:
+    contacts = _contacts_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+    event["body"] = '{"enabled": false, "tenant_id": "tenant-from-body"}'
+
+    with pytest.raises(ValueError, match="Only field 'enabled' can be updated."):
+        contacts.update_notification_contact(
+            event,
+            db,
+            UUID("11111111-1111-1111-1111-111111111111"),
+        )
+
+
+def test_notification_contact_routes_require_jwt_claims() -> None:
+    contacts = _contacts_module()
+    db = _FakeDb()
+
+    with pytest.raises(AuthError, match="Missing JWT claims."):
+        contacts.list_notification_contacts({}, db)
+
+    with pytest.raises(AuthError, match="Missing JWT claims."):
+        contacts.create_notification_contact({}, db, {"email": "contact@example.test"})

--- a/docs/mvp-scope.md
+++ b/docs/mvp-scope.md
@@ -14,6 +14,9 @@
   - `GET /lease-reminders/due-soon`
   - `GET /notifications`
   - `PATCH /notifications/{notification_id}/read`
+  - `GET /notification-contacts`
+  - `POST /notification-contacts`
+  - `PATCH /notification-contacts/{contact_id}`
 - Cognito JWT-based authentication and tenant claim extraction.
 - PostgreSQL persistence for domain data and audit logs.
 - Internal reminder scan flow for creating due-soon notification records.
@@ -25,7 +28,7 @@
 - Real browser frontend slice under `frontend/` with Cognito Hosted UI
   sign-in/sign-out, protected routes, dashboard summaries,
   properties/leases list/create/update flows, due-soon reminder display, and
-  notifications list/mark-read UI.
+  notifications list/mark-read plus notification contact management UI.
 - Terraform-managed static SPA hosting path with private S3 and CloudFront.
   Hosted asset upload and browser smoke validation remain operator-run release
   validation, not a CI deploy pipeline.
@@ -69,4 +72,4 @@
 - SES-backed email delivery internals are documented in
   `docs/notification-email-delivery-mvp.md`.
 - Remaining follow-up work is SES delivery smoke evidence, production-access
-  readiness, and any future contact-management API/UI.
+  readiness, and future delivery operations hardening.

--- a/docs/notification-email-delivery-mvp.md
+++ b/docs/notification-email-delivery-mvp.md
@@ -17,10 +17,10 @@ SES deliverability.
 - Notification creation is idempotent through the existing
   `tenant_id`, `lease_id`, `type`, and `due_date` uniqueness constraint.
 - The browser frontend can list notifications and mark them read.
+- The browser frontend can manage tenant-owned notification contacts.
 - The browser cannot create notifications, run the reminder scan, or trigger
   external delivery.
-- A tenant-scoped notification contact model exists as the future recipient
-  source.
+- Tenant-scoped notification contacts are the recipient source.
 - A dev SES infrastructure foundation exists with an optional sender identity
   and opt-in SES SMTP VPC endpoint.
 - A tenant-scoped `notification_email_deliveries` table tracks delivery status,
@@ -137,6 +137,7 @@ Delivery must be idempotent and retry-safe:
 The implementation should be split into separate reviewable tickets:
 
 - Add notification recipient contact model. Completed.
+- Add tenant notification contact management API/UI. Completed.
 - Add SES dev infrastructure foundation. Completed as disabled-by-default
   Terraform foundation.
 - Implement idempotent notification email delivery. Completed as a

--- a/frontend/src/features/notifications/useNotificationsPage.test.tsx
+++ b/frontend/src/features/notifications/useNotificationsPage.test.tsx
@@ -38,17 +38,29 @@ function createAuthValue(overrides: Partial<AuthContextValue> = {}): AuthContext
 function renderHookConsumer() {
   function HookConsumer() {
     const {
+      createNotificationContact,
       dueReminders,
       error,
       isLoading,
       markNotificationRead,
+      notificationContacts,
       notifications,
       readingNotificationId,
+      updatingContactId,
+      updateNotificationContact,
     } = useNotificationsPageState();
 
     async function handleMarkRead(notificationId: string) {
       try {
         await markNotificationRead(notificationId);
+      } catch {
+        // Page submit/click handlers consume hook rethrows after error state is set.
+      }
+    }
+
+    async function handleToggleContact(contactId: string, enabled: boolean) {
+      try {
+        await updateNotificationContact(contactId, { enabled });
       } catch {
         // Page submit/click handlers consume hook rethrows after error state is set.
       }
@@ -62,6 +74,7 @@ function renderHookConsumer() {
       <div>
         {error ? <p>{error}</p> : null}
         <p>Reminders: {dueReminders.length}</p>
+        <p>Contacts: {notificationContacts.length}</p>
         {notifications.map((notification) => (
           <article key={notification.notification_id}>
             <h2>{notification.title}</h2>
@@ -75,6 +88,25 @@ function renderHookConsumer() {
             </button>
           </article>
         ))}
+        {notificationContacts.map((contact) => (
+          <article key={contact.contact_id}>
+            <h2>{contact.email}</h2>
+            <p>{contact.enabled ? "Enabled" : "Disabled"}</p>
+            <button
+              disabled={updatingContactId === contact.contact_id}
+              onClick={() => void handleToggleContact(contact.contact_id, !contact.enabled)}
+              type="button"
+            >
+              Toggle contact
+            </button>
+          </article>
+        ))}
+        <button
+          onClick={() => void createNotificationContact({ email: "new@example.test" })}
+          type="button"
+        >
+          Add contact
+        </button>
       </div>
     );
   }
@@ -130,6 +162,7 @@ describe("useNotificationsPageState", () => {
           ],
         })
       )
+      .mockResolvedValueOnce(jsonResponse({ items: [] }))
       .mockResolvedValueOnce(
         jsonResponse({
           created_at: "2026-04-28T10:00:00Z",
@@ -172,6 +205,7 @@ describe("useNotificationsPageState", () => {
           ],
         })
       )
+      .mockResolvedValueOnce(jsonResponse({ items: [] }))
       .mockResolvedValueOnce(jsonResponse({ error: "Could not mark read." }, 500));
 
     renderHookConsumer();
@@ -183,5 +217,118 @@ describe("useNotificationsPageState", () => {
       expect(screen.getByText("Could not mark read.")).toBeInTheDocument();
     });
     expect(screen.getByText("Unread")).toBeInTheDocument();
+  });
+
+  it("loads notification contacts with reminders and notifications", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ items: [] }))
+      .mockResolvedValueOnce(jsonResponse({ items: [] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              contact_id: "contact-1",
+              created_at: "2026-05-05T10:00:00Z",
+              email: "ops@example.test",
+              enabled: true,
+            },
+          ],
+        })
+      );
+
+    renderHookConsumer();
+
+    await screen.findByText("ops@example.test");
+    expect(screen.getByText("Enabled")).toBeInTheDocument();
+  });
+
+  it("adds a created notification contact to local state", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ items: [] }))
+      .mockResolvedValueOnce(jsonResponse({ items: [] }))
+      .mockResolvedValueOnce(jsonResponse({ items: [] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          contact_id: "contact-2",
+          created_at: "2026-05-05T11:00:00Z",
+          email: "new@example.test",
+          enabled: true,
+        })
+      );
+
+    renderHookConsumer();
+
+    await screen.findByText("Contacts: 0");
+    fireEvent.click(screen.getByRole("button", { name: "Add contact" }));
+
+    await screen.findByText("new@example.test");
+    const [, init] = fetchMock.mock.calls[3];
+    expect(JSON.parse(String(init.body))).toEqual({ email: "new@example.test" });
+    expect(JSON.parse(String(init.body))).not.toHaveProperty("tenant_id");
+  });
+
+  it("updates local notification contact state after enablement changes", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ items: [] }))
+      .mockResolvedValueOnce(jsonResponse({ items: [] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              contact_id: "contact-1",
+              created_at: "2026-05-05T10:00:00Z",
+              email: "ops@example.test",
+              enabled: true,
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          contact_id: "contact-1",
+          created_at: "2026-05-05T10:00:00Z",
+          email: "ops@example.test",
+          enabled: false,
+        })
+      );
+
+    renderHookConsumer();
+
+    await screen.findByText("ops@example.test");
+    fireEvent.click(screen.getByRole("button", { name: "Toggle contact" }));
+
+    await screen.findByText("Disabled");
+    const [, init] = fetchMock.mock.calls[3];
+    expect(JSON.parse(String(init.body))).toEqual({ enabled: false });
+    expect(JSON.parse(String(init.body))).not.toHaveProperty("tenant_id");
+  });
+
+  it("preserves visible contact state and exposes an error when update fails", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ items: [] }))
+      .mockResolvedValueOnce(jsonResponse({ items: [] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              contact_id: "contact-1",
+              created_at: "2026-05-05T10:00:00Z",
+              email: "ops@example.test",
+              enabled: true,
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ error: "Could not update notification contact." }, 500)
+      );
+
+    renderHookConsumer();
+
+    await screen.findByText("ops@example.test");
+    fireEvent.click(screen.getByRole("button", { name: "Toggle contact" }));
+
+    await screen.findByText("Could not update notification contact.");
+    expect(screen.getByText("Enabled")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/notifications/useNotificationsPage.ts
+++ b/frontend/src/features/notifications/useNotificationsPage.ts
@@ -4,28 +4,40 @@ import { useAuth } from "../../app/AuthContext";
 import {
   ApiError,
   createApiClient,
+  type CreateNotificationContactInput,
   type LeaseReminderCandidate,
+  type NotificationContact,
   type NotificationItem,
   UnauthorizedApiError,
+  type UpdateNotificationContactInput,
 } from "../../lib/api";
 import { getRuntimeConfig } from "../../lib/config";
 
 type NotificationsPageState = {
+  createNotificationContact: (input: CreateNotificationContactInput) => Promise<void>;
   dueReminders: LeaseReminderCandidate[];
   error: string | null;
   isLoading: boolean;
   markNotificationRead: (notificationId: string) => Promise<void>;
+  notificationContacts: NotificationContact[];
   notifications: NotificationItem[];
   readingNotificationId: string | null;
+  updatingContactId: string | null;
+  updateNotificationContact: (
+    contactId: string,
+    input: UpdateNotificationContactInput
+  ) => Promise<void>;
 };
 
 export function useNotificationsPageState(): NotificationsPageState {
   const auth = useAuth();
   const navigate = useNavigate();
   const [dueReminders, setDueReminders] = useState<LeaseReminderCandidate[]>([]);
+  const [notificationContacts, setNotificationContacts] = useState<NotificationContact[]>([]);
   const [notifications, setNotifications] = useState<NotificationItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [readingNotificationId, setReadingNotificationId] = useState<string | null>(null);
+  const [updatingContactId, setUpdatingContactId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -44,13 +56,15 @@ export function useNotificationsPageState(): NotificationsPageState {
           onUnauthorized: auth.markSessionExpired,
           session: auth.session,
         });
-        const [remindersResponse, notificationsResponse] = await Promise.all([
+        const [remindersResponse, notificationsResponse, contactsResponse] = await Promise.all([
           client.listDueLeaseReminders(),
           client.listNotifications(),
+          client.listNotificationContacts(),
         ]);
         if (!cancelled) {
           setDueReminders(remindersResponse.items);
           setNotifications(notificationsResponse.items);
+          setNotificationContacts(contactsResponse.items);
         }
       } catch (errorValue) {
         if (cancelled) {
@@ -118,12 +132,98 @@ export function useNotificationsPageState(): NotificationsPageState {
     }
   }
 
+  async function createNotificationContact(input: CreateNotificationContactInput) {
+    if (!auth.session) {
+      navigate("/", { replace: true });
+      return;
+    }
+
+    setError(null);
+
+    try {
+      const client = createApiClient({
+        config: getRuntimeConfig(),
+        onUnauthorized: auth.markSessionExpired,
+        session: auth.session,
+      });
+      const created = await client.createNotificationContact(input);
+      setNotificationContacts((current) => upsertContact(current, created));
+    } catch (errorValue) {
+      if (errorValue instanceof UnauthorizedApiError) {
+        navigate("/", { replace: true });
+        return;
+      }
+      setError(
+        errorValue instanceof ApiError
+          ? errorValue.message
+          : "Could not create notification contact."
+      );
+      throw errorValue;
+    }
+  }
+
+  async function updateNotificationContact(
+    contactId: string,
+    input: UpdateNotificationContactInput
+  ) {
+    if (!auth.session) {
+      navigate("/", { replace: true });
+      return;
+    }
+
+    setUpdatingContactId(contactId);
+    setError(null);
+
+    try {
+      const client = createApiClient({
+        config: getRuntimeConfig(),
+        onUnauthorized: auth.markSessionExpired,
+        session: auth.session,
+      });
+      const updated = await client.updateNotificationContact(contactId, input);
+      setNotificationContacts((current) => upsertContact(current, updated));
+    } catch (errorValue) {
+      if (errorValue instanceof UnauthorizedApiError) {
+        navigate("/", { replace: true });
+        return;
+      }
+      setError(
+        errorValue instanceof ApiError
+          ? errorValue.message
+          : "Could not update notification contact."
+      );
+      throw errorValue;
+    } finally {
+      setUpdatingContactId(null);
+    }
+  }
+
   return {
+    createNotificationContact,
     dueReminders,
     error,
     isLoading,
     markNotificationRead,
+    notificationContacts,
     notifications,
     readingNotificationId,
+    updatingContactId,
+    updateNotificationContact,
   };
+}
+
+function upsertContact(
+  current: NotificationContact[],
+  updated: NotificationContact
+): NotificationContact[] {
+  const existingIndex = current.findIndex(
+    (contact) => contact.contact_id === updated.contact_id
+  );
+  if (existingIndex === -1) {
+    return [updated, ...current];
+  }
+
+  return current.map((contact) =>
+    contact.contact_id === updated.contact_id ? updated : contact
+  );
 }

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -138,4 +138,53 @@ describe("createApiClient", () => {
     const [, init] = fetchMock.mock.calls[0];
     expect(init.body).toBeUndefined();
   });
+
+  it("lists notification contacts without tenant query params", async () => {
+    const client = createApiClient(clientOptions);
+
+    await client.listNotificationContacts();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/dev/notification-contacts",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer id-token",
+        }),
+      })
+    );
+  });
+
+  it("creates a notification contact without tenant_id", async () => {
+    const client = createApiClient(clientOptions);
+
+    await client.createNotificationContact({ email: "ops@example.test" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/dev/notification-contacts",
+      expect.objectContaining({
+        method: "POST",
+      })
+    );
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(String(init.body))).toEqual({ email: "ops@example.test" });
+    expect(JSON.parse(String(init.body))).not.toHaveProperty("tenant_id");
+  });
+
+  it("updates a notification contact without tenant_id", async () => {
+    const client = createApiClient(clientOptions);
+
+    await client.updateNotificationContact("contact-1", { enabled: false });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/dev/notification-contacts/contact-1",
+      expect.objectContaining({
+        method: "PATCH",
+      })
+    );
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(String(init.body))).toEqual({ enabled: false });
+    expect(JSON.parse(String(init.body))).not.toHaveProperty("tenant_id");
+  });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -40,6 +40,13 @@ export type NotificationItem = {
   type: string;
 };
 
+export type NotificationContact = {
+  contact_id: string;
+  created_at: string;
+  email: string;
+  enabled: boolean;
+};
+
 export type CreatePropertyInput = {
   address: string;
   name: string;
@@ -60,6 +67,14 @@ export type UpdateLeaseInput = {
   rent_due_day_of_month: number;
   resident_name: string;
   start_date: string;
+};
+
+export type CreateNotificationContactInput = {
+  email: string;
+};
+
+export type UpdateNotificationContactInput = {
+  enabled: boolean;
 };
 
 type ListResponse<T> = {
@@ -133,6 +148,12 @@ export function createApiClient({ config, onUnauthorized, session }: ApiClientOp
         method: "POST",
       });
     },
+    createNotificationContact(input: CreateNotificationContactInput) {
+      return request<NotificationContact>("/notification-contacts", {
+        body: JSON.stringify(input),
+        method: "POST",
+      });
+    },
     createProperty(input: CreatePropertyInput) {
       return request<Property>("/properties", {
         body: JSON.stringify(input),
@@ -147,6 +168,9 @@ export function createApiClient({ config, onUnauthorized, session }: ApiClientOp
     },
     listNotifications() {
       return request<ListResponse<NotificationItem>>("/notifications");
+    },
+    listNotificationContacts() {
+      return request<ListResponse<NotificationContact>>("/notification-contacts");
     },
     listProperties() {
       return request<ListResponse<Property>>("/properties");
@@ -164,6 +188,15 @@ export function createApiClient({ config, onUnauthorized, session }: ApiClientOp
         body: JSON.stringify(input),
         method: "PATCH",
       });
+    },
+    updateNotificationContact(contactId: string, input: UpdateNotificationContactInput) {
+      return request<NotificationContact>(
+        `/notification-contacts/${encodeURIComponent(contactId)}`,
+        {
+          body: JSON.stringify(input),
+          method: "PATCH",
+        }
+      );
     },
     updateProperty(propertyId: string, input: UpdatePropertyInput) {
       return request<Property>(`/properties/${encodeURIComponent(propertyId)}`, {

--- a/frontend/src/pages/NotificationsPage.test.tsx
+++ b/frontend/src/pages/NotificationsPage.test.tsx
@@ -15,12 +15,16 @@ describe("NotificationsPage", () => {
     markNotificationRead.mockResolvedValue(undefined);
     mockedUseNotificationsPageState.mockReset();
     mockedUseNotificationsPageState.mockReturnValue({
+      createNotificationContact: vi.fn(),
       dueReminders: [],
       error: null,
       isLoading: false,
       markNotificationRead,
+      notificationContacts: [],
       notifications: [],
       readingNotificationId: null,
+      updatingContactId: null,
+      updateNotificationContact: vi.fn(),
     });
   });
 
@@ -45,8 +49,11 @@ describe("NotificationsPage", () => {
       error: null,
       isLoading: false,
       markNotificationRead,
+      notificationContacts: [],
       notifications: [],
       readingNotificationId: null,
+      updatingContactId: null,
+      updateNotificationContact: vi.fn(),
     });
 
     render(<NotificationsPage />);
@@ -68,6 +75,7 @@ describe("NotificationsPage", () => {
       error: null,
       isLoading: false,
       markNotificationRead,
+      notificationContacts: [],
       notifications: [
         {
           created_at: "2026-04-28T10:00:00Z",
@@ -81,6 +89,8 @@ describe("NotificationsPage", () => {
         },
       ],
       readingNotificationId: null,
+      updatingContactId: null,
+      updateNotificationContact: vi.fn(),
     });
 
     render(<NotificationsPage />);
@@ -101,6 +111,7 @@ describe("NotificationsPage", () => {
       error: null,
       isLoading: false,
       markNotificationRead,
+      notificationContacts: [],
       notifications: [
         {
           created_at: "2026-04-28T10:00:00Z",
@@ -114,6 +125,8 @@ describe("NotificationsPage", () => {
         },
       ],
       readingNotificationId: null,
+      updatingContactId: null,
+      updateNotificationContact: vi.fn(),
     });
 
     render(<NotificationsPage />);
@@ -129,6 +142,7 @@ describe("NotificationsPage", () => {
       error: "Could not mark notification as read.",
       isLoading: false,
       markNotificationRead,
+      notificationContacts: [],
       notifications: [
         {
           created_at: "2026-04-28T10:00:00Z",
@@ -142,6 +156,8 @@ describe("NotificationsPage", () => {
         },
       ],
       readingNotificationId: null,
+      updatingContactId: null,
+      updateNotificationContact: vi.fn(),
     });
 
     render(<NotificationsPage />);
@@ -154,5 +170,135 @@ describe("NotificationsPage", () => {
     expect(screen.getByText("Rent due soon")).toBeInTheDocument();
     expect(screen.getByText("Unread")).toBeInTheDocument();
     expect(screen.getByText("Could not mark notification as read.")).toBeInTheDocument();
+  });
+
+  it("renders the notification contact empty state", () => {
+    render(<NotificationsPage />);
+
+    expect(screen.getByText("No notification contacts yet")).toBeInTheDocument();
+  });
+
+  it("renders enabled and disabled notification contacts with actions", () => {
+    mockedUseNotificationsPageState.mockReturnValue({
+      createNotificationContact: vi.fn(),
+      dueReminders: [],
+      error: null,
+      isLoading: false,
+      markNotificationRead,
+      notificationContacts: [
+        {
+          contact_id: "contact-1",
+          created_at: "2026-05-05T10:00:00Z",
+          email: "enabled@example.test",
+          enabled: true,
+        },
+        {
+          contact_id: "contact-2",
+          created_at: "2026-05-05T11:00:00Z",
+          email: "disabled@example.test",
+          enabled: false,
+        },
+      ],
+      notifications: [],
+      readingNotificationId: null,
+      updatingContactId: null,
+      updateNotificationContact: vi.fn(),
+    });
+
+    render(<NotificationsPage />);
+
+    expect(screen.getByText("enabled@example.test")).toBeInTheDocument();
+    expect(screen.getByText("disabled@example.test")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Disable enabled@example.test" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Enable disabled@example.test" })).toBeInTheDocument();
+  });
+
+  it("submits a new notification contact and clears the input on success", async () => {
+    const createNotificationContact = vi.fn().mockResolvedValue(undefined);
+    mockedUseNotificationsPageState.mockReturnValue({
+      createNotificationContact,
+      dueReminders: [],
+      error: null,
+      isLoading: false,
+      markNotificationRead,
+      notificationContacts: [],
+      notifications: [],
+      readingNotificationId: null,
+      updatingContactId: null,
+      updateNotificationContact: vi.fn(),
+    });
+
+    render(<NotificationsPage />);
+
+    const input = screen.getByLabelText("Contact email");
+    fireEvent.change(input, { target: { value: "ops@example.test" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add contact" }));
+
+    await waitFor(() => {
+      expect(createNotificationContact).toHaveBeenCalledWith({
+        email: "ops@example.test",
+      });
+    });
+    expect(input).toHaveValue("");
+  });
+
+  it("preserves contact email input when create fails", async () => {
+    const createNotificationContact = vi.fn().mockRejectedValue(new Error("Create failed"));
+    mockedUseNotificationsPageState.mockReturnValue({
+      createNotificationContact,
+      dueReminders: [],
+      error: "Could not create notification contact.",
+      isLoading: false,
+      markNotificationRead,
+      notificationContacts: [],
+      notifications: [],
+      readingNotificationId: null,
+      updatingContactId: null,
+      updateNotificationContact: vi.fn(),
+    });
+
+    render(<NotificationsPage />);
+
+    const input = screen.getByLabelText("Contact email");
+    fireEvent.change(input, { target: { value: "ops@example.test" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add contact" }));
+
+    await waitFor(() => {
+      expect(createNotificationContact).toHaveBeenCalledTimes(1);
+    });
+    expect(input).toHaveValue("ops@example.test");
+    expect(screen.getByText("Could not create notification contact.")).toBeInTheDocument();
+  });
+
+  it("toggles a notification contact enabled state", async () => {
+    const updateNotificationContact = vi.fn().mockResolvedValue(undefined);
+    mockedUseNotificationsPageState.mockReturnValue({
+      createNotificationContact: vi.fn(),
+      dueReminders: [],
+      error: null,
+      isLoading: false,
+      markNotificationRead,
+      notificationContacts: [
+        {
+          contact_id: "contact-1",
+          created_at: "2026-05-05T10:00:00Z",
+          email: "enabled@example.test",
+          enabled: true,
+        },
+      ],
+      notifications: [],
+      readingNotificationId: null,
+      updatingContactId: null,
+      updateNotificationContact,
+    });
+
+    render(<NotificationsPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Disable enabled@example.test" }));
+
+    await waitFor(() => {
+      expect(updateNotificationContact).toHaveBeenCalledWith("contact-1", {
+        enabled: false,
+      });
+    });
   });
 });

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -1,5 +1,6 @@
+import { useState } from "react";
 import { useNotificationsPageState } from "../features/notifications/useNotificationsPage";
-import type { NotificationItem } from "../lib/api";
+import type { NotificationContact, NotificationItem } from "../lib/api";
 
 function formatDaysUntilDue(days: number) {
   if (days === 0) {
@@ -13,13 +14,18 @@ function formatDaysUntilDue(days: number) {
 
 export function NotificationsPage() {
   const {
+    createNotificationContact,
     dueReminders,
     error,
     isLoading,
     markNotificationRead,
+    notificationContacts,
     notifications,
     readingNotificationId,
+    updatingContactId,
+    updateNotificationContact,
   } = useNotificationsPageState();
+  const [contactEmail, setContactEmail] = useState("");
 
   async function handleMarkRead(notification: NotificationItem) {
     try {
@@ -29,8 +35,89 @@ export function NotificationsPage() {
     }
   }
 
+  async function handleCreateContact(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const email = contactEmail.trim();
+    if (!email) {
+      return;
+    }
+
+    try {
+      await createNotificationContact({ email });
+      setContactEmail("");
+    } catch {
+      // The hook already exposes the user-facing error message.
+    }
+  }
+
+  async function handleToggleContact(contact: NotificationContact) {
+    try {
+      await updateNotificationContact(contact.contact_id, { enabled: !contact.enabled });
+    } catch {
+      // The hook already exposes the user-facing error message.
+    }
+  }
+
   return (
     <section className="page-grid notifications-grid">
+      <article className="panel-card">
+        <div className="section-heading">
+          <p className="eyebrow">Email recipients</p>
+          <h2 className="section-title">Notification contacts.</h2>
+        </div>
+        <form className="stack-form" onSubmit={handleCreateContact}>
+          <label className="field-label" htmlFor="notification-contact-email">
+            Contact email
+          </label>
+          <input
+            id="notification-contact-email"
+            name="email"
+            onChange={(event) => setContactEmail(event.target.value)}
+            placeholder="recipient@example.com"
+            type="email"
+            value={contactEmail}
+          />
+          <button className="primary-button" disabled={!contactEmail.trim()} type="submit">
+            Add contact
+          </button>
+        </form>
+        {isLoading ? (
+          <p className="supporting-copy">Loading notification contacts...</p>
+        ) : notificationContacts.length === 0 ? (
+          <div className="empty-state">
+            <h3>No notification contacts yet</h3>
+            <p>Add an enabled recipient before running SES delivery smoke.</p>
+          </div>
+        ) : (
+          <ul className="resource-list">
+            {notificationContacts.map((contact) => (
+              <li className="resource-card" key={contact.contact_id}>
+                <div>
+                  <p className="resource-title">{contact.email}</p>
+                  <p className="resource-meta">
+                    Created {new Date(contact.created_at).toLocaleDateString("en-GB")}
+                  </p>
+                </div>
+                <div className="resource-actions">
+                  <span className={contact.enabled ? "status-pill" : "status-pill status-pill-unread"}>
+                    {contact.enabled ? "Enabled" : "Disabled"}
+                  </span>
+                  <button
+                    aria-label={`${contact.enabled ? "Disable" : "Enable"} ${contact.email}`}
+                    className="ghost-button resource-edit-button"
+                    disabled={updatingContactId === contact.contact_id}
+                    onClick={() => void handleToggleContact(contact)}
+                    type="button"
+                  >
+                    {contact.enabled ? "Disable" : "Enable"}
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </article>
+
       <article className="panel-card">
         <div className="section-heading">
           <p className="eyebrow">Due reminders</p>

--- a/infra/modules/api_http/defaults.tftest.hcl
+++ b/infra/modules/api_http/defaults.tftest.hcl
@@ -41,6 +41,21 @@ run "exposes_backend_route_parity" {
   }
 
   assert {
+    condition     = aws_apigatewayv2_route.list_notification_contacts.route_key == "GET /notification-contacts"
+    error_message = "API module should expose GET /notification-contacts."
+  }
+
+  assert {
+    condition     = aws_apigatewayv2_route.create_notification_contact.route_key == "POST /notification-contacts"
+    error_message = "API module should expose POST /notification-contacts."
+  }
+
+  assert {
+    condition     = aws_apigatewayv2_route.update_notification_contact.route_key == "PATCH /notification-contacts/{contact_id}"
+    error_message = "API module should expose PATCH /notification-contacts/{contact_id}."
+  }
+
+  assert {
     condition     = aws_apigatewayv2_route.mark_notification_read.route_key == "PATCH /notifications/{notification_id}/read"
     error_message = "API module should expose PATCH /notifications/{notification_id}/read."
   }
@@ -63,6 +78,21 @@ run "exposes_backend_route_parity" {
   assert {
     condition     = aws_apigatewayv2_route.list_notifications.authorization_type == "JWT"
     error_message = "Notification route should require JWT auth."
+  }
+
+  assert {
+    condition     = aws_apigatewayv2_route.list_notification_contacts.authorization_type == "JWT"
+    error_message = "Notification contact list route should require JWT auth."
+  }
+
+  assert {
+    condition     = aws_apigatewayv2_route.create_notification_contact.authorization_type == "JWT"
+    error_message = "Notification contact create route should require JWT auth."
+  }
+
+  assert {
+    condition     = aws_apigatewayv2_route.update_notification_contact.authorization_type == "JWT"
+    error_message = "Notification contact update route should require JWT auth."
   }
 
   assert {

--- a/infra/modules/api_http/main.tf
+++ b/infra/modules/api_http/main.tf
@@ -92,6 +92,30 @@ resource "aws_apigatewayv2_route" "list_notifications" {
   authorizer_id      = aws_apigatewayv2_authorizer.jwt.id
 }
 
+resource "aws_apigatewayv2_route" "list_notification_contacts" {
+  api_id             = aws_apigatewayv2_api.this.id
+  route_key          = "GET /notification-contacts"
+  target             = "integrations/${aws_apigatewayv2_integration.backend.id}"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.jwt.id
+}
+
+resource "aws_apigatewayv2_route" "create_notification_contact" {
+  api_id             = aws_apigatewayv2_api.this.id
+  route_key          = "POST /notification-contacts"
+  target             = "integrations/${aws_apigatewayv2_integration.backend.id}"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.jwt.id
+}
+
+resource "aws_apigatewayv2_route" "update_notification_contact" {
+  api_id             = aws_apigatewayv2_api.this.id
+  route_key          = "PATCH /notification-contacts/{contact_id}"
+  target             = "integrations/${aws_apigatewayv2_integration.backend.id}"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.jwt.id
+}
+
 resource "aws_apigatewayv2_route" "mark_notification_read" {
   api_id             = aws_apigatewayv2_api.this.id
   route_key          = "PATCH /notifications/{notification_id}/read"


### PR DESCRIPTION
## What changed

Adds tenant-scoped notification contact management for authenticated users.

- Adds protected backend routes for listing, creating, and enabling/disabling notification contacts.
- Adds API Gateway JWT routes for `/notification-contacts`.
- Extends the frontend API client and Notifications page with contact management UI.
- Updates docs to move contact management into current MVP scope.

## Security validation

Tenant context is derived only from validated Cognito JWT claims. Browser request bodies do not include `tenant_id`, and contact API responses omit `tenant_id`.

Contact emails are visible only inside the authenticated tenant management UI. Audit metadata still avoids email addresses.

## Cost validation

No new AWS services or resources beyond API Gateway route definitions. No SES, SMTP credential, scheduler, or delivery behavior changes.

## Validation

- Backend tests passed.
- Frontend lint, tests, and build passed.
- API Gateway Terraform module tests passed.
- Dev Terraform validate passed.
- `git diff --check` passed.

## Remaining risks

Browser contact management does not trigger reminder scans or email delivery. SES production readiness and delivery operations remain separate work.
