### PR TITLE
feat: expose notification email delivery status

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ Implemented now:
 - Local portfolio demo client for the deployed MVP flow
 - Real browser frontend slice with Hosted UI auth, dashboard summaries,
   properties and leases list/create/update flows, due-soon reminders, and
-  notifications mark-read UI
+  notifications mark-read UI with safe aggregate email delivery status
 - Terraform-managed S3 + CloudFront hosting path for the frontend SPA
 
 Planned next:
 
-- Add SES delivery smoke runbook/evidence and production-readiness guardrails
+- Refine SES production-readiness guardrails and delivery operations
 - Add more automated backend and tenant-isolation test coverage
 - Refine operational setup for scheduled workflows and monitoring
 

--- a/backend/src/app/db.py
+++ b/backend/src/app/db.py
@@ -19,6 +19,7 @@ from app.models import (
     NotificationContact,
     NotificationEmailDelivery,
     NotificationEmailDeliveryPreparationResult,
+    NotificationEmailDeliverySummary,
     Property,
     ReminderScanResult,
 )
@@ -390,22 +391,52 @@ class Database:
 
     def list_notifications(self, tenant_id: str) -> list[Notification]:
         sql = """
+            WITH delivery_summary AS (
+                SELECT
+                    tenant_id,
+                    notification_id,
+                    COUNT(*)::int AS delivery_total_count,
+                    COUNT(*) FILTER (WHERE status = 'pending')::int AS delivery_pending_count,
+                    COUNT(*) FILTER (WHERE status = 'sent')::int AS delivery_sent_count,
+                    COUNT(*) FILTER (WHERE status = 'failed')::int AS delivery_failed_count,
+                    MAX(last_attempt_at) AS delivery_latest_attempt_at,
+                    MAX(sent_at) AS delivery_latest_sent_at,
+                    (
+                        array_agg(
+                            last_error_code
+                            ORDER BY last_attempt_at DESC NULLS LAST, updated_at DESC
+                        ) FILTER (WHERE last_error_code IS NOT NULL)
+                    )[1] AS delivery_last_error_code
+                FROM notification_email_deliveries
+                WHERE tenant_id = %s
+                GROUP BY tenant_id, notification_id
+            )
             SELECT
-                notification_id,
-                tenant_id,
-                lease_id,
-                type,
-                title,
-                message,
-                due_date,
-                created_at,
-                read_at
-            FROM notifications
-            WHERE tenant_id = %s
-            ORDER BY created_at DESC
+                n.notification_id,
+                n.tenant_id,
+                n.lease_id,
+                n.type,
+                n.title,
+                n.message,
+                n.due_date,
+                n.created_at,
+                n.read_at,
+                COALESCE(ds.delivery_total_count, 0) AS delivery_total_count,
+                COALESCE(ds.delivery_pending_count, 0) AS delivery_pending_count,
+                COALESCE(ds.delivery_sent_count, 0) AS delivery_sent_count,
+                COALESCE(ds.delivery_failed_count, 0) AS delivery_failed_count,
+                ds.delivery_latest_attempt_at,
+                ds.delivery_latest_sent_at,
+                ds.delivery_last_error_code
+            FROM notifications n
+            LEFT JOIN delivery_summary ds
+              ON ds.tenant_id = n.tenant_id
+             AND ds.notification_id = n.notification_id
+            WHERE n.tenant_id = %s
+            ORDER BY n.created_at DESC
         """
         with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
-            rows = conn.execute(sql, (tenant_id,)).fetchall()
+            rows = conn.execute(sql, (tenant_id, tenant_id)).fetchall()
         return [self._row_to_notification(row) for row in rows]
 
     def mark_notification_read(
@@ -431,6 +462,14 @@ class Database:
         with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
             with conn.transaction():
                 row = conn.execute(sql, (tenant_id, notification_id)).fetchone()
+                if row is not None:
+                    row.update(
+                        self._notification_email_delivery_summary_row(
+                            conn,
+                            tenant_id=tenant_id,
+                            notification_id=notification_id,
+                        )
+                    )
 
         if row is None:
             raise LookupError("Notification not found for tenant.")
@@ -852,6 +891,50 @@ class Database:
             due_date=row["due_date"],
             created_at=row["created_at"],
             read_at=row["read_at"],
+            delivery_summary=Database._row_to_notification_email_delivery_summary(row),
+        )
+
+    @staticmethod
+    def _notification_email_delivery_summary_row(
+        conn: psycopg.Connection[dict[str, Any]],
+        *,
+        tenant_id: str,
+        notification_id: UUID,
+    ) -> dict[str, Any]:
+        sql = """
+            SELECT
+                COUNT(*)::int AS delivery_total_count,
+                COUNT(*) FILTER (WHERE status = 'pending')::int AS delivery_pending_count,
+                COUNT(*) FILTER (WHERE status = 'sent')::int AS delivery_sent_count,
+                COUNT(*) FILTER (WHERE status = 'failed')::int AS delivery_failed_count,
+                MAX(last_attempt_at) AS delivery_latest_attempt_at,
+                MAX(sent_at) AS delivery_latest_sent_at,
+                (
+                    array_agg(
+                        last_error_code
+                        ORDER BY last_attempt_at DESC NULLS LAST, updated_at DESC
+                    ) FILTER (WHERE last_error_code IS NOT NULL)
+                )[1] AS delivery_last_error_code
+            FROM notification_email_deliveries
+            WHERE tenant_id = %s AND notification_id = %s
+        """
+        row = conn.execute(sql, (tenant_id, notification_id)).fetchone()
+        if row is None:
+            return {}
+        return row
+
+    @staticmethod
+    def _row_to_notification_email_delivery_summary(
+        row: dict[str, Any],
+    ) -> NotificationEmailDeliverySummary:
+        return NotificationEmailDeliverySummary(
+            total_count=row.get("delivery_total_count", 0),
+            pending_count=row.get("delivery_pending_count", 0),
+            sent_count=row.get("delivery_sent_count", 0),
+            failed_count=row.get("delivery_failed_count", 0),
+            latest_attempt_at=row.get("delivery_latest_attempt_at"),
+            latest_sent_at=row.get("delivery_latest_sent_at"),
+            last_error_code=row.get("delivery_last_error_code"),
         )
 
     @staticmethod
@@ -888,7 +971,6 @@ class Database:
 def notification_to_dict(item: Notification) -> dict[str, Any]:
     return {
         "notification_id": str(item.notification_id),
-        "tenant_id": item.tenant_id,
         "lease_id": str(item.lease_id),
         "type": item.type,
         "title": item.title,
@@ -896,6 +978,19 @@ def notification_to_dict(item: Notification) -> dict[str, Any]:
         "due_date": item.due_date.isoformat(),
         "created_at": item.created_at.isoformat(),
         "read_at": item.read_at.isoformat() if item.read_at else None,
+        "delivery_summary": {
+            "total_count": item.delivery_summary.total_count,
+            "pending_count": item.delivery_summary.pending_count,
+            "sent_count": item.delivery_summary.sent_count,
+            "failed_count": item.delivery_summary.failed_count,
+            "latest_attempt_at": item.delivery_summary.latest_attempt_at.isoformat()
+            if item.delivery_summary.latest_attempt_at
+            else None,
+            "latest_sent_at": item.delivery_summary.latest_sent_at.isoformat()
+            if item.delivery_summary.latest_sent_at
+            else None,
+            "last_error_code": item.delivery_summary.last_error_code,
+        },
     }
 
 

--- a/backend/src/app/models.py
+++ b/backend/src/app/models.py
@@ -48,6 +48,17 @@ class LeaseReminderCandidate:
 
 
 @dataclass(slots=True)
+class NotificationEmailDeliverySummary:
+    total_count: int
+    pending_count: int
+    sent_count: int
+    failed_count: int
+    latest_attempt_at: datetime | None
+    latest_sent_at: datetime | None
+    last_error_code: str | None
+
+
+@dataclass(slots=True)
 class Notification:
     notification_id: UUID
     tenant_id: str
@@ -58,6 +69,7 @@ class Notification:
     due_date: date
     created_at: datetime
     read_at: datetime | None
+    delivery_summary: NotificationEmailDeliverySummary
 
 
 @dataclass(slots=True)

--- a/backend/tests/test_db_integration.py
+++ b/backend/tests/test_db_integration.py
@@ -10,7 +10,7 @@ from psycopg.rows import dict_row
 from psycopg.sql import SQL, Identifier, Literal
 
 from app.config import Settings, load_settings
-from app.db import Database
+from app.db import Database, notification_to_dict
 
 
 def _integration_enabled() -> bool:
@@ -2103,6 +2103,127 @@ def test_notification_email_delivery_rejects_cross_tenant_status_update(
                 delivery_id=other_delivery.delivery_id,
                 error_code="smtp_transient_error",
             )
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+        _cleanup_test_tenant(integration_settings, other_tenant_id)
+
+
+def test_list_notifications_includes_tenant_scoped_email_delivery_summary(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    other_tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+
+    try:
+        property_record = db.create_property(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Delivery Summary HQ {uuid4().hex[:8]}",
+            address=f"Delivery Summary Street {uuid4().hex[:8]}",
+        )
+        other_property = db.create_property(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"Other Delivery Summary HQ {uuid4().hex[:8]}",
+            address=f"Other Delivery Summary Street {uuid4().hex[:8]}",
+        )
+        db.create_lease(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=property_record.property_id,
+            resident_name=f"Delivery Summary User {uuid4().hex[:8]}",
+            rent_due_day_of_month=5,
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+        )
+        db.create_lease(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=other_property.property_id,
+            resident_name=f"Other Delivery Summary User {uuid4().hex[:8]}",
+            rent_due_day_of_month=5,
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+        )
+        contact_one = db.create_notification_contact(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            email=f"summary-one-{uuid4().hex[:8]}@example.com",
+        )
+        contact_two = db.create_notification_contact(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            email=f"summary-two-{uuid4().hex[:8]}@example.com",
+        )
+        db.create_notification_contact(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            email=f"summary-other-{uuid4().hex[:8]}@example.com",
+        )
+        db.create_due_lease_reminder_notifications(
+            tenant_id=tenant_id,
+            as_of_date=date(2026, 4, 3),
+            days=7,
+        )
+        db.create_due_lease_reminder_notifications(
+            tenant_id=other_tenant_id,
+            as_of_date=date(2026, 4, 3),
+            days=7,
+        )
+        db.create_missing_notification_email_deliveries(tenant_id=tenant_id)
+        db.create_missing_notification_email_deliveries(tenant_id=other_tenant_id)
+
+        notifications = db.list_notifications(tenant_id=tenant_id)
+        summary = notifications[0].delivery_summary
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            conn.execute(
+                """
+                UPDATE notification_email_deliveries
+                SET status = 'sent',
+                    attempt_count = 1,
+                    last_attempt_at = '2026-05-04T10:00:00+00:00'::timestamptz,
+                    sent_at = '2026-05-04T10:00:00+00:00'::timestamptz,
+                    updated_at = '2026-05-04T10:00:00+00:00'::timestamptz
+                WHERE tenant_id = %s AND contact_id = %s
+                """,
+                (tenant_id, contact_one.contact_id),
+            )
+            conn.execute(
+                """
+                UPDATE notification_email_deliveries
+                SET status = 'failed',
+                    attempt_count = 1,
+                    last_attempt_at = '2026-05-04T11:00:00+00:00'::timestamptz,
+                    last_error_code = 'smtp_network_error',
+                    updated_at = '2026-05-04T11:00:00+00:00'::timestamptz
+                WHERE tenant_id = %s AND contact_id = %s
+                """,
+                (tenant_id, contact_two.contact_id),
+            )
+
+        notifications = db.list_notifications(tenant_id=tenant_id)
+        summary = notifications[0].delivery_summary
+
+        assert len(notifications) == 1
+        assert summary.total_count == 2
+        assert summary.pending_count == 0
+        assert summary.sent_count == 1
+        assert summary.failed_count == 1
+        assert summary.latest_attempt_at is not None
+        assert summary.latest_attempt_at.isoformat() == "2026-05-04T11:00:00+00:00"
+        assert summary.latest_sent_at is not None
+        assert summary.latest_sent_at.isoformat() == "2026-05-04T10:00:00+00:00"
+        assert summary.last_error_code == "smtp_network_error"
+
+        serialized = notification_to_dict(notifications[0])
+        assert "tenant_id" not in serialized
+        assert "contact_id" not in str(serialized)
+        assert "recipient_email" not in str(serialized)
+        assert contact_one.email not in str(summary)
+        assert contact_two.email not in str(summary)
     finally:
         _cleanup_test_tenant(integration_settings, tenant_id)
         _cleanup_test_tenant(integration_settings, other_tenant_id)

--- a/backend/tests/test_notifications_route.py
+++ b/backend/tests/test_notifications_route.py
@@ -15,6 +15,17 @@ def _notifications_module():
 
 
 @dataclass(slots=True)
+class _DeliverySummaryRecord:
+    total_count: int
+    pending_count: int
+    sent_count: int
+    failed_count: int
+    latest_attempt_at: datetime | None
+    latest_sent_at: datetime | None
+    last_error_code: str | None
+
+
+@dataclass(slots=True)
 class _NotificationRecord:
     notification_id: UUID
     tenant_id: str
@@ -25,6 +36,7 @@ class _NotificationRecord:
     due_date: date
     created_at: datetime
     read_at: datetime | None
+    delivery_summary: _DeliverySummaryRecord
 
 
 class _FakeDb:
@@ -45,6 +57,15 @@ class _FakeDb:
                 due_date=date(2026, 4, 9),
                 created_at=datetime(2026, 4, 7, tzinfo=UTC),
                 read_at=None,
+                delivery_summary=_DeliverySummaryRecord(
+                    total_count=2,
+                    pending_count=0,
+                    sent_count=1,
+                    failed_count=1,
+                    latest_attempt_at=datetime(2026, 4, 8, 12, 0, tzinfo=UTC),
+                    latest_sent_at=datetime(2026, 4, 8, 10, 0, tzinfo=UTC),
+                    last_error_code="smtp_network_error",
+                ),
             )
         ]
 
@@ -64,6 +85,15 @@ class _FakeDb:
             due_date=date(2026, 4, 9),
             created_at=datetime(2026, 4, 7, tzinfo=UTC),
             read_at=datetime(2026, 4, 8, 10, 30, tzinfo=UTC),
+            delivery_summary=_DeliverySummaryRecord(
+                total_count=0,
+                pending_count=0,
+                sent_count=0,
+                failed_count=0,
+                latest_attempt_at=None,
+                latest_sent_at=None,
+                last_error_code=None,
+            ),
         )
 
 
@@ -95,7 +125,6 @@ def test_list_notifications_uses_auth_tenant_not_client_input() -> None:
         "items": [
             {
                 "notification_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-                "tenant_id": "tenant-auth",
                 "lease_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                 "type": "rent_due_soon",
                 "title": "Rent due soon",
@@ -103,9 +132,22 @@ def test_list_notifications_uses_auth_tenant_not_client_input() -> None:
                 "due_date": "2026-04-09",
                 "created_at": "2026-04-07T00:00:00+00:00",
                 "read_at": None,
+                "delivery_summary": {
+                    "total_count": 2,
+                    "pending_count": 0,
+                    "sent_count": 1,
+                    "failed_count": 1,
+                    "latest_attempt_at": "2026-04-08T12:00:00+00:00",
+                    "latest_sent_at": "2026-04-08T10:00:00+00:00",
+                    "last_error_code": "smtp_network_error",
+                },
             }
         ]
     }
+    serialized = payload["items"][0]
+    assert "tenant_id" not in serialized
+    assert "contact_id" not in str(serialized)
+    assert "recipient_email" not in str(serialized)
 
 
 def test_list_notifications_requires_jwt_claims() -> None:
@@ -129,7 +171,6 @@ def test_mark_notification_read_uses_auth_tenant_and_returns_updated_record() ->
     assert db.read_calls == [("tenant-auth", notification_id)]
     assert payload == {
         "notification_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-        "tenant_id": "tenant-auth",
         "lease_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
         "type": "rent_due_soon",
         "title": "Rent due soon",
@@ -137,6 +178,15 @@ def test_mark_notification_read_uses_auth_tenant_and_returns_updated_record() ->
         "due_date": "2026-04-09",
         "created_at": "2026-04-07T00:00:00+00:00",
         "read_at": "2026-04-08T10:30:00+00:00",
+        "delivery_summary": {
+            "total_count": 0,
+            "pending_count": 0,
+            "sent_count": 0,
+            "failed_count": 0,
+            "latest_attempt_at": None,
+            "latest_sent_at": None,
+            "last_error_code": None,
+        },
     }
 
 

--- a/docs/mvp-scope.md
+++ b/docs/mvp-scope.md
@@ -42,6 +42,8 @@
 - `notification_contacts` table for tenant-owned email recipients.
 - `notification_email_deliveries` table for tenant-scoped delivery status,
   retry attempts, sanitized failure codes, and sent timestamps.
+- Notification API responses expose safe aggregate delivery summaries without
+  recipient addresses, contact IDs, tenant IDs, or raw provider responses.
 - `audit_logs` table for basic traceability of critical actions.
 - `tenant_id` enforced in all tenant-owned rows.
 
@@ -65,11 +67,12 @@
 - NAT Gateway and non-essential managed services.
 - Notification creation from the browser.
 - Browser-triggered reminder scans or email delivery.
+- Recipient-level delivery details in browser responses.
 - Custom domain, CI-based frontend deployment, and production readiness.
 
 ## Planned Next Notification Phase
 
 - SES-backed email delivery internals are documented in
   `docs/notification-email-delivery-mvp.md`.
-- Remaining follow-up work is SES delivery smoke evidence, production-access
-  readiness, and future delivery operations hardening.
+- Remaining follow-up work is production-access readiness and future delivery
+  operations hardening.

--- a/docs/notification-email-delivery-mvp.md
+++ b/docs/notification-email-delivery-mvp.md
@@ -16,7 +16,8 @@ SES deliverability.
 - The internal due reminder scan creates tenant-owned `notifications` rows.
 - Notification creation is idempotent through the existing
   `tenant_id`, `lease_id`, `type`, and `due_date` uniqueness constraint.
-- The browser frontend can list notifications and mark them read.
+- The browser frontend can list notifications, mark them read, and view safe
+  aggregate email delivery status per notification.
 - The browser frontend can manage tenant-owned notification contacts.
 - The browser cannot create notifications, run the reminder scan, or trigger
   external delivery.
@@ -25,6 +26,9 @@ SES deliverability.
   and opt-in SES SMTP VPC endpoint.
 - A tenant-scoped `notification_email_deliveries` table tracks delivery status,
   attempts, sanitized failure codes, and sent timestamps.
+- `GET /notifications` includes delivery summary counts and sanitized status
+  fields, but never recipient addresses, contact IDs, tenant IDs, or raw
+  provider responses.
 - The backend has an internal `deliver_notification_emails` event handler that
   can send due reminder notifications through SES SMTP when explicitly enabled.
 - SMTP credentials are operator-created outside Terraform and referenced by SSM
@@ -95,6 +99,8 @@ Delivery must be idempotent and retry-safe:
 - failed attempts may be retried with a bounded attempt limit.
 - read acknowledgement in the browser must not be treated as proof that email
   was delivered.
+- browser-visible delivery status is read-only and must not trigger retries,
+  scans, or delivery execution.
 - exactly-once external SMTP delivery cannot be guaranteed if Lambda crashes
   after SES accepts a message but before `sent_at` is persisted.
 
@@ -142,6 +148,8 @@ The implementation should be split into separate reviewable tickets:
   Terraform foundation.
 - Implement idempotent notification email delivery. Completed as a
   disabled-by-default internal backend worker.
+- Expose safe notification email delivery status. Completed as read-only
+  aggregate status on persisted notifications.
 - Add SES delivery smoke runbook and sanitized evidence. Runbook added;
   successful evidence remains operator-run.
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -31,6 +31,7 @@ export type LeaseReminderCandidate = {
 
 export type NotificationItem = {
   created_at: string;
+  delivery_summary?: NotificationEmailDeliverySummary;
   due_date: string;
   lease_id: string;
   message: string;
@@ -38,6 +39,16 @@ export type NotificationItem = {
   read_at: string | null;
   title: string;
   type: string;
+};
+
+export type NotificationEmailDeliverySummary = {
+  failed_count: number;
+  last_error_code: string | null;
+  latest_attempt_at: string | null;
+  latest_sent_at: string | null;
+  pending_count: number;
+  sent_count: number;
+  total_count: number;
 };
 
 export type NotificationContact = {

--- a/frontend/src/pages/NotificationsPage.test.tsx
+++ b/frontend/src/pages/NotificationsPage.test.tsx
@@ -9,6 +9,29 @@ vi.mock("../features/notifications/useNotificationsPage", () => ({
   useNotificationsPageState: () => mockedUseNotificationsPageState(),
 }));
 
+function deliverySummary(
+  overrides: Partial<{
+    failed_count: number;
+    last_error_code: string | null;
+    latest_attempt_at: string | null;
+    latest_sent_at: string | null;
+    pending_count: number;
+    sent_count: number;
+    total_count: number;
+  }>
+) {
+  return {
+    failed_count: 0,
+    last_error_code: null,
+    latest_attempt_at: null,
+    latest_sent_at: null,
+    pending_count: 0,
+    sent_count: 0,
+    total_count: 1,
+    ...overrides,
+  };
+}
+
 describe("NotificationsPage", () => {
   beforeEach(() => {
     markNotificationRead.mockReset();
@@ -79,6 +102,7 @@ describe("NotificationsPage", () => {
       notifications: [
         {
           created_at: "2026-04-28T10:00:00Z",
+          delivery_summary: deliverySummary({ total_count: 0 }),
           due_date: "2026-04-30",
           lease_id: "lease-1",
           message: "Rent is due soon.",
@@ -115,6 +139,7 @@ describe("NotificationsPage", () => {
       notifications: [
         {
           created_at: "2026-04-28T10:00:00Z",
+          delivery_summary: deliverySummary({ total_count: 0 }),
           due_date: "2026-04-30",
           lease_id: "lease-1",
           message: "Rent is due soon.",
@@ -135,6 +160,131 @@ describe("NotificationsPage", () => {
     expect(screen.queryByRole("button", { name: /Mark Rent due soon read/i })).not.toBeInTheDocument();
   });
 
+  it("renders safe notification email delivery status summaries", () => {
+    mockedUseNotificationsPageState.mockReturnValue({
+      dueReminders: [],
+      error: null,
+      isLoading: false,
+      markNotificationRead,
+      notificationContacts: [],
+      notifications: [
+        {
+          created_at: "2026-04-28T10:00:00Z",
+          delivery_summary: deliverySummary({ total_count: 0 }),
+          due_date: "2026-04-30",
+          lease_id: "lease-1",
+          message: "Rent is due soon.",
+          notification_id: "notification-1",
+          read_at: null,
+          title: "Not prepared notification",
+          type: "rent_due",
+        },
+        {
+          created_at: "2026-04-28T10:00:00Z",
+          delivery_summary: deliverySummary({ pending_count: 1, total_count: 1 }),
+          due_date: "2026-04-30",
+          lease_id: "lease-2",
+          message: "Rent is due soon.",
+          notification_id: "notification-2",
+          read_at: null,
+          title: "Pending notification",
+          type: "rent_due",
+        },
+        {
+          created_at: "2026-04-28T10:00:00Z",
+          delivery_summary: deliverySummary({
+            latest_sent_at: "2026-05-04T10:00:00Z",
+            sent_count: 1,
+            total_count: 1,
+          }),
+          due_date: "2026-04-30",
+          lease_id: "lease-3",
+          message: "Rent is due soon.",
+          notification_id: "notification-3",
+          read_at: null,
+          title: "Sent notification",
+          type: "rent_due",
+        },
+        {
+          created_at: "2026-04-28T10:00:00Z",
+          delivery_summary: deliverySummary({
+            failed_count: 1,
+            last_error_code: "smtp_network_error",
+            latest_attempt_at: "2026-05-04T11:00:00Z",
+            total_count: 1,
+          }),
+          due_date: "2026-04-30",
+          lease_id: "lease-4",
+          message: "Rent is due soon.",
+          notification_id: "notification-4",
+          read_at: null,
+          title: "Failed notification",
+          type: "rent_due",
+        },
+        {
+          created_at: "2026-04-28T10:00:00Z",
+          delivery_summary: deliverySummary({
+            failed_count: 1,
+            pending_count: 1,
+            sent_count: 1,
+            total_count: 3,
+          }),
+          due_date: "2026-04-30",
+          lease_id: "lease-5",
+          message: "Rent is due soon.",
+          notification_id: "notification-5",
+          read_at: null,
+          title: "Mixed notification",
+          type: "rent_due",
+        },
+      ],
+      readingNotificationId: null,
+      updatingContactId: null,
+      updateNotificationContact: vi.fn(),
+    });
+
+    render(<NotificationsPage />);
+
+    expect(screen.getByText("Email delivery: Not prepared")).toBeInTheDocument();
+    expect(screen.getByText("Email delivery: Pending")).toBeInTheDocument();
+    expect(screen.getByText("Email delivery: Sent")).toBeInTheDocument();
+    expect(screen.getByText("Email delivery: Failed")).toBeInTheDocument();
+    expect(screen.getByText("Email delivery: Mixed")).toBeInTheDocument();
+    expect(screen.getByText("1 sent | 1 failed | 1 pending")).toBeInTheDocument();
+    expect(screen.getByText("Last failure: smtp_network_error")).toBeInTheDocument();
+    expect(screen.queryByText(/@example/)).not.toBeInTheDocument();
+  });
+
+  it("falls back when an older notification response has no delivery summary", () => {
+    mockedUseNotificationsPageState.mockReturnValue({
+      dueReminders: [],
+      error: null,
+      isLoading: false,
+      markNotificationRead,
+      notificationContacts: [],
+      notifications: [
+        {
+          created_at: "2026-04-28T10:00:00Z",
+          due_date: "2026-04-30",
+          lease_id: "lease-1",
+          message: "Rent is due soon.",
+          notification_id: "notification-1",
+          read_at: null,
+          title: "Legacy notification",
+          type: "rent_due",
+        },
+      ],
+      readingNotificationId: null,
+      updatingContactId: null,
+      updateNotificationContact: vi.fn(),
+    });
+
+    render(<NotificationsPage />);
+
+    expect(screen.getByText("Legacy notification")).toBeInTheDocument();
+    expect(screen.getByText("Email delivery: Not prepared")).toBeInTheDocument();
+  });
+
   it("preserves visible notification state when mark-read fails", async () => {
     markNotificationRead.mockRejectedValue(new Error("Mark read failed"));
     mockedUseNotificationsPageState.mockReturnValue({
@@ -146,6 +296,7 @@ describe("NotificationsPage", () => {
       notifications: [
         {
           created_at: "2026-04-28T10:00:00Z",
+          delivery_summary: deliverySummary({ total_count: 0 }),
           due_date: "2026-04-30",
           lease_id: "lease-1",
           message: "Rent is due soon.",

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
 import { useNotificationsPageState } from "../features/notifications/useNotificationsPage";
-import type { NotificationContact, NotificationItem } from "../lib/api";
+import type {
+  NotificationContact,
+  NotificationEmailDeliverySummary,
+  NotificationItem,
+} from "../lib/api";
 
 function formatDaysUntilDue(days: number) {
   if (days === 0) {
@@ -10,6 +14,50 @@ function formatDaysUntilDue(days: number) {
     return "1 day from now";
   }
   return `${days} days from now`;
+}
+
+const EMPTY_DELIVERY_SUMMARY: NotificationEmailDeliverySummary = {
+  failed_count: 0,
+  last_error_code: null,
+  latest_attempt_at: null,
+  latest_sent_at: null,
+  pending_count: 0,
+  sent_count: 0,
+  total_count: 0,
+};
+
+function notificationDeliverySummary(notification: NotificationItem) {
+  return notification.delivery_summary ?? EMPTY_DELIVERY_SUMMARY;
+}
+
+function emailDeliveryLabel(summary: NotificationEmailDeliverySummary) {
+  if (summary.total_count === 0) {
+    return "Not prepared";
+  }
+  if (summary.sent_count === summary.total_count) {
+    return "Sent";
+  }
+  if (summary.failed_count === summary.total_count) {
+    return "Failed";
+  }
+  if (summary.pending_count === summary.total_count) {
+    return "Pending";
+  }
+  return "Mixed";
+}
+
+function emailDeliveryCounts(summary: NotificationEmailDeliverySummary) {
+  const parts = [
+    summary.sent_count > 0 ? `${summary.sent_count} sent` : null,
+    summary.failed_count > 0 ? `${summary.failed_count} failed` : null,
+    summary.pending_count > 0 ? `${summary.pending_count} pending` : null,
+  ].filter(Boolean);
+
+  if (parts.length === 0) {
+    return `${summary.total_count} delivery rows`;
+  }
+
+  return parts.join(" | ");
 }
 
 export function NotificationsPage() {
@@ -170,6 +218,7 @@ export function NotificationsPage() {
           <ul className="resource-list">
             {notifications.map((notification) => {
               const isRead = notification.read_at !== null;
+              const deliverySummary = notificationDeliverySummary(notification);
 
               return (
                 <li className="resource-card notification-card" key={notification.notification_id}>
@@ -185,6 +234,17 @@ export function NotificationsPage() {
                       Due {notification.due_date} | Created{" "}
                       {new Date(notification.created_at).toLocaleDateString("en-GB")}
                     </p>
+                    <p className="resource-meta">
+                      Email delivery: {emailDeliveryLabel(deliverySummary)}
+                    </p>
+                    {deliverySummary.total_count > 0 ? (
+                      <p className="resource-meta">{emailDeliveryCounts(deliverySummary)}</p>
+                    ) : null}
+                    {deliverySummary.last_error_code ? (
+                      <p className="resource-meta">
+                        Last failure: {deliverySummary.last_error_code}
+                      </p>
+                    ) : null}
                   </div>
                   <div className="resource-actions">
                     {isRead ? (


### PR DESCRIPTION
## Summary
- Add safe aggregate email delivery summaries to notification responses.
- Render per-notification delivery status in the Notifications UI.
- Update docs for browser-visible read-only delivery status.

## Security validation
- Tenant context remains derived from validated JWT claims.
- Notification responses no longer include `tenant_id`.
- Delivery summaries exclude recipient emails, contact IDs, SMTP payloads, and raw provider responses.
- Cross-tenant delivery rows are covered by DB integration tests.

## Cost validation
- No new AWS resources.
- No SES sending, retry control, scheduler, or Terraform changes.

## Validation
- Backend unit tests, DB integration tests, frontend lint/test/build, and `git diff --check` passed locally.
