### PR TITLE
docs: plan production SES delivery hardening

### DIFF
--- a/docs/notification-email-delivery-mvp.md
+++ b/docs/notification-email-delivery-mvp.md
@@ -35,12 +35,16 @@ SES deliverability.
   SecureString parameter names. Terraform does not create or output SMTP
   credential values.
 - Dev smoke validation is documented in
-  `docs/runbooks/ses-notification-email-delivery-smoke-test.md`, but successful
-  evidence remains operator-run and must be captured separately.
+  `docs/runbooks/ses-notification-email-delivery-smoke-test.md`, with sanitized
+  successful evidence in
+  `docs/runbooks/evidence/ses-notification-email-delivery-smoke-test-2026-05-05.md`.
+  This validates the dev SMTP path only; it is not production email readiness.
 
 ## Chosen Direction
 
 - Amazon SES is the preferred email delivery service for LeaseFlow.
+- Production delivery hardening is planned separately in
+  `docs/ses-production-delivery-hardening.md`.
 - Persisted `notifications` remain the source of delivery work; the delivery
   job must not recalculate reminder candidates independently.
 - Recipient addresses come from a LeaseFlow-owned tenant-scoped contact
@@ -151,7 +155,8 @@ The implementation should be split into separate reviewable tickets:
 - Expose safe notification email delivery status. Completed as read-only
   aggregate status on persisted notifications.
 - Add SES delivery smoke runbook and sanitized evidence. Runbook added;
-  successful evidence remains operator-run.
+- Add production-ready SES delivery hardening. Planned separately in
+  `docs/ses-production-delivery-hardening.md`.
 
 ## References
 

--- a/docs/security-baseline.md
+++ b/docs/security-baseline.md
@@ -221,8 +221,8 @@ The MVP does not require a full incident management platform, but it does requir
 - PostgreSQL Row Level Security for defense-in-depth tenant enforcement,
   following `docs/postgresql-rls-tenant-isolation-hardening.md`
 - Cognito MFA rollout for higher-risk roles
-- SES delivery smoke evidence and production-readiness guardrails for persisted
-  tenant notifications.
+- Production SES delivery hardening for persisted tenant notifications,
+  following `docs/ses-production-delivery-hardening.md`.
 - Backup retention review when recovery expectations outgrow the one-day dev window
 - Lightweight alerting for suspicious login or API abuse patterns
 - Periodic dependency and IAM permission review

--- a/docs/ses-production-delivery-hardening.md
+++ b/docs/ses-production-delivery-hardening.md
@@ -1,0 +1,230 @@
+# SES Production Delivery Hardening Plan
+
+## Purpose
+
+This document defines the gap between the current dev SES SMTP notification
+delivery MVP and a production-ready email delivery capability.
+
+The current implementation proves that persisted due reminder notifications can
+be delivered through an explicitly enabled dev SES SMTP path. It does not prove
+production readiness, sender reputation readiness, compliance readiness, or
+operational readiness.
+
+No production access request, DNS change, AWS resource change, Terraform change,
+backend code change, frontend change, or custom domain implementation is part of
+this planning document.
+
+## Current State
+
+- Persisted due reminder notifications are stored in tenant-owned
+  `notifications` rows.
+- Tenant-owned `notification_contacts` rows define recipient contacts.
+- Tenant-scoped `notification_email_deliveries` rows track delivery attempts,
+  sanitized failure codes, and sent timestamps.
+- The backend has an internal `deliver_notification_emails` event handler.
+- Email delivery is disabled by default and cannot be triggered from the
+  browser.
+- The current private delivery path uses SES SMTP over an optional interface VPC
+  endpoint.
+- SMTP credentials are operator-created outside Terraform and referenced through
+  SSM SecureString parameter names.
+- The browser can view only safe aggregate delivery status through
+  `GET /notifications`.
+- Dev SES smoke validation evidence exists in
+  `docs/runbooks/evidence/ses-notification-email-delivery-smoke-test-2026-05-05.md`.
+
+## Production Readiness Requirements
+
+### SES Account And Identity Readiness
+
+Production delivery requires an explicit SES production access decision for the
+target AWS Region. While an SES account is in sandbox mode, sending is limited
+to verified recipients or the SES mailbox simulator, with low daily and
+per-second quotas.
+
+The production sender should use a verified domain identity rather than relying
+only on one verified email address. Domain verification is the better long-term
+fit because it supports sending from addresses under the domain without
+verifying each address separately.
+
+Required future decisions:
+
+- Which domain or subdomain is the production sender identity.
+- Whether LeaseFlow uses a custom MAIL FROM domain.
+- Which AWS Region owns the production SES identity.
+- Whether dev and production identities are isolated by account, region, or
+  configuration.
+
+### Email Authentication
+
+Production sending needs DNS-based authentication before broad delivery:
+
+- DKIM must be enabled for the sending domain.
+- SPF alignment must be reviewed, especially if a custom MAIL FROM domain is
+  used.
+- DMARC must exist for the sending domain and start with a safe monitoring
+  posture before any stricter policy is considered.
+
+The first rollout should avoid claiming strong deliverability until DNS
+authentication has been verified and monitored.
+
+### Bounce, Complaint, And Suppression Handling
+
+Production delivery cannot rely only on SMTP success. SES accepting a message is
+not proof that the recipient received or accepted it.
+
+Future production work must ingest bounce and complaint signals through SES
+configuration sets and an AWS event destination such as SNS, EventBridge, or
+another explicitly reviewed path.
+
+Handling requirements:
+
+- Persist only sanitized event categories and aggregate-safe status fields.
+- Do not store raw SES provider payloads unless a separate privacy and retention
+  review justifies it.
+- Do not log recipient emails, tenant IDs, SMTP transcripts, notification
+  message bodies, or raw provider responses.
+- Permanent bounces and complaints must suppress future sends to the affected
+  contact.
+- Suppression behavior must be tenant-scoped in the LeaseFlow data model even
+  if SES also maintains account-level suppression.
+
+### Unsubscribe And Message Classification
+
+Due reminder emails are closer to transactional operational mail than marketing
+mail, but production rollout still needs an explicit classification decision.
+
+If any future notification type is promotional, digest-style, or optional, it
+must include unsubscribe/list-management behavior before broad sending. Amazon
+SES supports subscription management for supported sending flows, but the
+LeaseFlow model must still define tenant/contact-level preferences and safe
+browser visibility.
+
+Production requirements:
+
+- Classify each email type before enabling production sending.
+- Keep browser delivery controls read-only; users may manage contacts but must
+  not trigger scans or delivery runs.
+- Define how disabled contacts, suppressed contacts, and unsubscribed contacts
+  interact.
+
+### Retry And Idempotency
+
+The current delivery table prevents duplicate sends after `sent_at` is
+persisted. This remains required in production.
+
+Future production retry behavior must add:
+
+- Clear distinction between transient and permanent failures.
+- Bounded retry attempts.
+- Backoff or scheduled retry cadence.
+- No automatic infinite retries.
+- No retry of already sent delivery rows.
+- Explicit documentation that exactly-once external SMTP delivery cannot be
+  guaranteed if Lambda crashes after SES accepts a message but before the DB
+  status update commits.
+
+### Monitoring And Alarms
+
+Production delivery needs CloudWatch-visible health signals before enabling
+real recipients at scale.
+
+Minimum monitoring topics:
+
+- Delivery worker invocation success/failure.
+- Candidate, attempted, sent, failed, and skipped counts.
+- Bounce and complaint counts.
+- Failure categories.
+- Retry exhaustion.
+- SES sending quota pressure.
+- Unusual spikes in send volume.
+- Optional SES SMTP VPC endpoint cost exposure when enabled.
+
+Alarms must use aggregate counts and sanitized categories. They must not include
+recipient addresses, tenant IDs, message bodies, raw SES responses, SMTP
+credentials, or SSM values.
+
+### Cost Controls
+
+Delivery must stay disabled by default until production readiness is explicit.
+
+Production hardening should include:
+
+- Environment-level enablement flag.
+- Batch size limits.
+- Max attempt limits.
+- Optional per-tenant or per-run send caps.
+- Explicit review before enabling a billable interface endpoint for long-lived
+  environments.
+- CloudWatch alarms for unexpected send volume and endpoint cost exposure.
+
+## Integration Path Decision
+
+The near-term default remains SES SMTP over PrivateLink because the backend
+Lambda runs in private subnets and the project avoids NAT Gateway by default.
+This is consistent with the current cost-aware private networking direction.
+
+SES API integration may be evaluated later, but it must be a separate ticket
+with an explicit network, security, cost, and operational tradeoff. Do not add a
+NAT Gateway only to reach SES APIs unless the PR proves that the cost and
+security tradeoff is justified.
+
+## Follow-Up Tickets
+
+### Add SES Production Domain Identity And DNS Authentication Plan
+
+Define the production sender domain, SES identity ownership, DKIM records, SPF
+alignment approach, DMARC monitoring policy, and production access request
+preconditions. Out of scope: sending code and production access submission.
+
+### Add SES Bounce And Complaint Ingestion
+
+Add the AWS event path and backend processing for bounce and complaint events.
+Persist only sanitized categories and tenant/contact-scoped state. Out of scope:
+browser-triggered delivery and raw provider payload storage.
+
+### Add Notification Suppression And Unsubscribe Model
+
+Extend contact preferences so permanent bounces, complaints, disabled contacts,
+and future unsubscribe decisions are represented explicitly. Out of scope:
+marketing mail and Cognito user enumeration.
+
+### Add SES Delivery Monitoring, Alarms, And Cost Controls
+
+Add aggregate metrics and alarms for send volume, failures, retries, bounces,
+complaints, and cost-sensitive endpoint enablement. Out of scope: exposing
+recipient-level details or raw SES responses.
+
+### Add Production SES Rollout Runbook And Sanitized Evidence Template
+
+Document the controlled production-readiness validation path with safe evidence
+rules. Out of scope: actual production access request or real customer data.
+
+### Evaluate SES API Integration Path For Production Delivery
+
+Compare the current SMTP PrivateLink path with SES API options. The decision
+must cover private networking, IAM, idempotency, error mapping, cost, and
+operational complexity. Out of scope: changing the implementation inside the
+planning ticket.
+
+## Security Boundaries
+
+- Tenant context remains backend-derived from validated Cognito JWT claims.
+- Browser request bodies and query parameters must never define delivery tenant
+  context.
+- Browser UI may manage contacts and read safe aggregate status, but must not
+  trigger scan, retry, or delivery jobs.
+- Production hardening must not make RDS public.
+- Production hardening must not introduce NAT Gateway by default.
+- Production hardening must not log or commit real emails, tenant IDs, JWTs,
+  SMTP credentials, SES credentials, SSM values, DB endpoints, notification
+  bodies, raw SES responses, or raw SMTP transcripts.
+
+## References
+
+- [Amazon SES verified identities](https://docs.aws.amazon.com/ses/latest/dg/verify-addresses-and-domains.html)
+- [Amazon SES production access](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html)
+- [Amazon SES VPC endpoints](https://docs.aws.amazon.com/ses/latest/dg/send-email-set-up-vpc-endpoints.html)
+- [Amazon SES configuration sets](https://docs.aws.amazon.com/ses/latest/dg/using-configuration-sets.html)
+- [Amazon SES subscription management](https://docs.aws.amazon.com/ses/latest/dg/sending-email-subscription-management.html)
+- [Amazon SES DMARC](https://docs.aws.amazon.com/ses/latest/dg/send-email-authentication-dmarc.html)


### PR DESCRIPTION
## Summary
- Add a production SES delivery hardening plan for the gap between the dev SMTP MVP and production-ready notification email delivery.
- Document SES production access, domain identity, DKIM/SPF/DMARC, bounce/complaint handling, suppression, unsubscribe, monitoring, retry, and cost-control requirements.
- Cross-link current notification delivery and security docs without claiming production readiness.

## Assumptions
- #158 is docs-only.
- SES remains the intended production-like email provider.
- Current SMTP over PrivateLink remains the near-term default for the private-subnet/no-NAT architecture.

## Security / Tenant Isolation
- No runtime behavior changed.
- Tenant context remains backend-derived from validated Cognito JWT claims.
- The plan explicitly keeps browser scan/delivery triggering out of scope and preserves tenant-safe logging/evidence rules.

## Cost Validation
- No AWS resources were added.
- The plan keeps NAT Gateway out of the default path and calls out endpoint cost controls for future production work.

## Remaining Risks / TODOs
- Production SES access, DNS authentication, bounce/complaint ingestion, suppression/unsubscribe modeling, monitoring, and rollout evidence remain follow-up tickets.
