### PR TITLE
docs: plan hosted frontend deploy automation

### DIFF
--- a/docs/frontend-mvp-strategy.md
+++ b/docs/frontend-mvp-strategy.md
@@ -25,7 +25,8 @@ local portfolio/demo tool and not the production-like frontend path.
   static SPA. Asset upload remains a local operator command.
 - Hosted frontend smoke validation has passed from the CloudFront origin, but
   hosted deployment remains an operator-run path, not an implemented CI
-  deployment path.
+  deployment path. The future automation path is planned in
+  `docs/hosted-frontend-deploy-automation.md`.
 - The dashboard is the authenticated browser app entry point.
 
 ## Chosen Frontend Direction
@@ -93,7 +94,7 @@ Later frontend follow-ups:
 ## Follow-Up Tickets
 
 - Add CI-based hosted frontend deployment if deployment automation becomes a
-  release goal.
+  release goal, following `docs/hosted-frontend-deploy-automation.md`.
 
 ## Guardrails
 

--- a/docs/hosted-frontend-deploy-automation.md
+++ b/docs/hosted-frontend-deploy-automation.md
@@ -1,0 +1,201 @@
+# Hosted Frontend Deploy Automation Plan
+
+## Purpose
+
+This document plans a safe path from the current local operator upload to a
+controlled GitHub Actions deployment for the hosted LeaseFlow frontend.
+
+The current project already has a real browser frontend, private S3 +
+CloudFront hosting infrastructure, and successful hosted smoke evidence. Hosted
+asset upload still remains a local operator step through
+`scripts/dev/upload-frontend.sh`.
+
+This document does not implement a workflow, Terraform, IAM role, AWS resource,
+custom domain, or production deployment path.
+
+## Current State
+
+- Frontend CI runs on pull requests and `main` pushes.
+- CI installs with `npm ci --ignore-scripts`.
+- CI runs `npm audit --audit-level=high`, lint, tests, and build.
+- Terraform creates the private frontend S3 bucket and CloudFront distribution.
+- `scripts/dev/upload-frontend.sh` builds `frontend/`, syncs `frontend/dist/`
+  to S3, and creates a CloudFront invalidation.
+- Hosted browser smoke validation passed from the CloudFront origin with
+  sanitized evidence in
+  `docs/runbooks/evidence/hosted-frontend-smoke-test-2026-04-30.md`.
+- There is no GitHub Actions deployment workflow and no GitHub-hosted AWS
+  deploy role.
+
+## Options
+
+### Keep Manual Operator Upload
+
+This remains the current path. It is simple, explicit, and avoids adding AWS
+permissions to GitHub Actions.
+
+Tradeoffs:
+
+- Good for learning and short-lived dev validation.
+- Harder to audit than a protected workflow.
+- Depends on the operator's local AWS credentials and local environment.
+- Easy to forget the exact build, sync, invalidation, and smoke evidence steps.
+
+### Add Static AWS Access Keys To GitHub Secrets
+
+This should not be used. Long-lived AWS access keys in GitHub secrets are a
+larger credential-management risk than this project needs.
+
+Tradeoffs:
+
+- Simple to wire technically.
+- Creates rotation and exposure risk.
+- Weakens the current supply-chain and least-privilege direction.
+
+### Add GitHub OIDC Deploy Role
+
+This is the preferred future automation path. GitHub Actions obtains short-lived
+AWS credentials through OpenID Connect and assumes a narrowly scoped IAM role.
+
+Tradeoffs:
+
+- More setup than manual upload.
+- Avoids long-lived AWS keys in GitHub.
+- Can be constrained to this repository, approved refs, and the `dev`
+  deployment environment.
+- Gives repeatable logs and a safer review point through GitHub environments.
+
+## Chosen Future Direction
+
+Keep manual upload for now. When automation is needed, add a separate
+`workflow_dispatch` GitHub Actions deployment for dev only, backed by GitHub
+OIDC and a least-privilege AWS role.
+
+The first automated path should not deploy from every `main` push. Manual
+dispatch is safer for this portfolio/dev workflow because the AWS dev stack may
+be destroyed for cost control.
+
+## Future Workflow Shape
+
+The future workflow should:
+
+- Trigger only through `workflow_dispatch`.
+- Target only the dev environment.
+- Use GitHub OIDC through `aws-actions/configure-aws-credentials`.
+- Use `permissions: contents: read` and `id-token: write` only where required.
+- Install frontend dependencies with `npm ci --ignore-scripts`.
+- Run `npm audit --audit-level=high`.
+- Run `npm run lint`, `npm run test`, and `npm run build`.
+- Upload only `frontend/dist/` to the Terraform-created frontend bucket.
+- Use `aws s3 sync frontend/dist/ s3://<bucket>/ --delete`.
+- Create a CloudFront invalidation, defaulting to `/*`.
+- Print only safe deployment metadata such as branch, commit SHA, environment,
+  invalidation ID, and pass/fail statuses.
+
+The workflow must not print or store JWTs, Cognito emails, tenant IDs, SSM
+values, DB endpoints, AWS credentials, or frontend `.env.local` contents.
+
+## Future Workflow Inputs
+
+The future `workflow_dispatch` inputs should be intentionally small:
+
+- `environment`: choice, initially only `dev`.
+- `ref_to_deploy`: branch, tag, or SHA to confirm what is being deployed.
+- `invalidation_path`: optional, default `/*`.
+- `confirm_dev_deploy`: required boolean or confirmation string.
+
+The workflow should fail early if the selected environment is not `dev` or if
+the confirmation input is missing.
+
+## GitHub Environment Controls
+
+Use a GitHub deployment environment named `dev`.
+
+Recommended controls:
+
+- Restrict deploys to approved refs, preferably `main` or explicitly selected
+  release branches/tags.
+- Add required reviewer protection if the repository plan supports it.
+- Use a concurrency group such as `frontend-deploy-dev` so only one hosted
+  frontend deploy runs at a time.
+- Keep deployment history visible in GitHub.
+- Do not store static AWS access keys as environment secrets.
+
+## AWS IAM Boundaries
+
+The future deploy role should have only the permissions needed for the hosted
+frontend asset path.
+
+Trust policy requirements:
+
+- Trust GitHub's OIDC provider.
+- Restrict `aud` to `sts.amazonaws.com`.
+- Restrict `sub` to this repository and approved deployment refs or the GitHub
+  environment subject.
+
+Permission requirements:
+
+- Allow `s3:ListBucket` only on the frontend hosting bucket.
+- Allow `s3:PutObject`, `s3:DeleteObject`, and the minimum required object
+  metadata/tagging actions only under the frontend bucket objects.
+- Allow `cloudfront:CreateInvalidation` only for the configured CloudFront
+  distribution.
+- Allow read-only discovery only if required by the workflow design.
+
+Explicitly out of scope for the frontend deploy role:
+
+- Terraform state access.
+- Terraform apply or destroy.
+- RDS access.
+- SSM Parameter Store access.
+- Cognito admin access.
+- Lambda update or invoke access.
+- SES access.
+- Broad `s3:*`, `cloudfront:*`, or account-wide admin permissions.
+
+## Rollback Expectations
+
+The first workflow can deploy the current build only, but rollback must be
+defined before relying on automation for demos or releases.
+
+Acceptable future rollback paths:
+
+- Rerun the workflow for a known-good commit SHA.
+- Store a build artifact for a limited time and redeploy that artifact.
+- Keep a short runbook for restoring the previous S3 object set if artifact
+  retention is added.
+
+Rollback evidence must stay sanitized and should not include bucket names,
+distribution IDs, tenant data, tokens, or raw response bodies.
+
+## Follow-Up Tickets
+
+### Add GitHub OIDC Role For Hosted Frontend Deploy
+
+Add Terraform for the GitHub OIDC provider and a least-privilege dev frontend
+deploy role. Scope trust to this repository and approved refs/environment. Do
+not grant Terraform, RDS, SSM, Cognito, Lambda, or SES permissions.
+
+### Add Manual GitHub Actions Hosted Frontend Deploy Workflow
+
+Add a `workflow_dispatch` deploy workflow that uses OIDC, GitHub environment
+protection, npm install hardening, audit, lint, tests, build, S3 sync, and
+CloudFront invalidation.
+
+### Add Hosted Frontend Deploy Rollback Runbook
+
+Document how to redeploy a known-good commit or artifact, what evidence to
+capture, and which values must stay out of logs and committed files.
+
+### Capture Sanitized Hosted Frontend CI Deploy Evidence
+
+After the workflow exists, run it once against dev and record safe evidence:
+date, branch/ref, issue number, high-level command statuses, invalidation
+status, and browser smoke pass/fail results.
+
+## References
+
+- [GitHub Actions OpenID Connect for AWS](https://docs.github.com/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
+- [GitHub Actions deployment environments](https://docs.github.com/en/actions/reference/deployments-and-environments)
+- [GitHub Actions workflow syntax for `workflow_dispatch`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)
+- [aws-actions/configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -205,6 +205,8 @@ Then open `http://localhost:5173`.
 Terraform creates the S3 bucket and CloudFront distribution. Frontend asset
 upload remains a local operator step. If any `VITE_*` value changes, rebuild
 and upload the frontend again because the static assets contain those values.
+The future GitHub Actions deployment path is planned in
+`docs/hosted-frontend-deploy-automation.md`, but is not implemented yet.
 
 What it does: builds and uploads the hosted frontend, then invalidates
 CloudFront.

--- a/infra/README.md
+++ b/infra/README.md
@@ -38,6 +38,9 @@ the real frontend.
 - `allow_credentials = false`; browser calls use bearer tokens, not cookies.
 - Terraform creates the hosting bucket/distribution; `aws s3 sync` uploads
   built frontend assets.
+- CI-based hosted frontend deployment is planned separately in
+  `docs/hosted-frontend-deploy-automation.md`; current upload remains
+  operator-run.
 - The existing `demo-client` remains a separate local demo/operator tool.
 - Use `frontend/README.md` for browser `.env.local`, Hosted UI troubleshooting,
   and temporary Cognito demo user setup.


### PR DESCRIPTION
## Summary
- Add a docs-only plan for future hosted frontend deployment automation.
- Define the preferred future path: manual `workflow_dispatch`, GitHub OIDC, dev-only environment controls, least-privilege S3/CloudFront permissions, and existing npm supply-chain checks before deploy.
- Cross-link the plan from frontend and infrastructure docs while keeping current operator upload instructions intact.

## Assumptions
- #159 is planning only.
- Manual `scripts/dev/upload-frontend.sh` remains the active deploy path until a future workflow is implemented and smoke-tested.
- The first automated deployment target is dev only.

## Security / Tenant Isolation
- No runtime behavior changed.
- No AWS credentials or secrets were added.
- The plan explicitly rejects static AWS access keys and excludes Terraform, RDS, SSM, Cognito, Lambda, SES, and broad admin permissions from the future frontend deploy role.

## Cost Validation
- No AWS resources were added.
- Future automation is scoped to existing S3 + CloudFront hosting resources.

## Remaining Risks / TODOs
- Future tickets still need to implement the GitHub OIDC role, deploy workflow, rollback runbook, and sanitized deploy evidence.
