### PR TITLE
feat: add github oidc role for frontend deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
           - infra/modules/cloudwatch_alarms
           - infra/modules/cognito
           - infra/modules/frontend_hosting
+          - infra/modules/github_frontend_deploy_role
           - infra/modules/lambda_backend
           - infra/modules/network
           - infra/modules/reminder_scheduler

--- a/docs/hosted-frontend-deploy-automation.md
+++ b/docs/hosted-frontend-deploy-automation.md
@@ -24,8 +24,9 @@ custom domain, or production deployment path.
 - Hosted browser smoke validation passed from the CloudFront origin with
   sanitized evidence in
   `docs/runbooks/evidence/hosted-frontend-smoke-test-2026-04-30.md`.
-- There is no GitHub Actions deployment workflow and no GitHub-hosted AWS
-  deploy role.
+- Terraform now defines a GitHub OIDC provider and a least-privilege dev
+  frontend deploy role for the future workflow.
+- There is no GitHub Actions deployment workflow yet.
 
 ## Options
 
@@ -172,8 +173,8 @@ distribution IDs, tenant data, tokens, or raw response bodies.
 
 ### Add GitHub OIDC Role For Hosted Frontend Deploy
 
-Add Terraform for the GitHub OIDC provider and a least-privilege dev frontend
-deploy role. Scope trust to this repository and approved refs/environment. Do
+Completed as a Terraform-managed OIDC provider and least-privilege dev frontend
+deploy role. The role is scoped to the `dev` GitHub Environment subject and does
 not grant Terraform, RDS, SSM, Cognito, Lambda, or SES permissions.
 
 ### Add Manual GitHub Actions Hosted Frontend Deploy Workflow

--- a/infra/README.md
+++ b/infra/README.md
@@ -38,6 +38,9 @@ the real frontend.
 - `allow_credentials = false`; browser calls use bearer tokens, not cookies.
 - Terraform creates the hosting bucket/distribution; `aws s3 sync` uploads
   built frontend assets.
+- Terraform also defines a dev-only GitHub OIDC frontend deploy role for the
+  future hosted frontend deployment workflow. This role is not for Terraform
+  apply/destroy and does not grant RDS, SSM, Cognito, Lambda, or SES access.
 - CI-based hosted frontend deployment is planned separately in
   `docs/hosted-frontend-deploy-automation.md`; current upload remains
   operator-run.

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -40,6 +40,17 @@ module "frontend_hosting" {
   tags        = local.common_tags
 }
 
+module "github_frontend_deploy_role" {
+  source = "../../modules/github_frontend_deploy_role"
+
+  name_prefix                 = local.name_prefix
+  github_repository           = var.github_frontend_deploy_repository
+  github_environment          = var.github_frontend_deploy_environment
+  frontend_bucket_arn         = module.frontend_hosting.bucket_arn
+  cloudfront_distribution_arn = module.frontend_hosting.cloudfront_distribution_arn
+  tags                        = local.common_tags
+}
+
 resource "random_password" "db_master" {
   length  = 32
   special = false

--- a/infra/environments/dev/outputs.tf
+++ b/infra/environments/dev/outputs.tf
@@ -38,6 +38,11 @@ output "frontend_cloudfront_url" {
   value       = module.frontend_hosting.cloudfront_url
 }
 
+output "frontend_deploy_role_arn" {
+  description = "IAM role ARN for future GitHub Actions hosted frontend deployment."
+  value       = module.github_frontend_deploy_role.role_arn
+}
+
 output "rds_endpoint" {
   description = "RDS endpoint."
   value       = module.rds_postgres.endpoint

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -81,6 +81,28 @@ variable "frontend_hosted_origin" {
   }
 }
 
+variable "github_frontend_deploy_repository" {
+  type        = string
+  description = "GitHub repository allowed to assume the dev hosted frontend deploy role."
+  default     = "Alpine78/leaseflow"
+
+  validation {
+    condition     = can(regex("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", var.github_frontend_deploy_repository))
+    error_message = "github_frontend_deploy_repository must use owner/name format without wildcards."
+  }
+}
+
+variable "github_frontend_deploy_environment" {
+  type        = string
+  description = "GitHub deployment environment allowed to assume the dev hosted frontend deploy role."
+  default     = "dev"
+
+  validation {
+    condition     = trimspace(var.github_frontend_deploy_environment) != "" && !strcontains(var.github_frontend_deploy_environment, "*")
+    error_message = "github_frontend_deploy_environment must be non-empty and must not contain wildcards."
+  }
+}
+
 variable "cognito_hosted_ui_domain_prefix" {
   type        = string
   description = "Globally unique Cognito managed Hosted UI domain prefix for the dev frontend auth flow."

--- a/infra/modules/frontend_hosting/outputs.tf
+++ b/infra/modules/frontend_hosting/outputs.tf
@@ -3,9 +3,19 @@ output "bucket_name" {
   value       = aws_s3_bucket.frontend.bucket
 }
 
+output "bucket_arn" {
+  description = "S3 bucket ARN for frontend assets."
+  value       = aws_s3_bucket.frontend.arn
+}
+
 output "cloudfront_distribution_id" {
   description = "CloudFront distribution ID for the hosted frontend."
   value       = aws_cloudfront_distribution.frontend.id
+}
+
+output "cloudfront_distribution_arn" {
+  description = "CloudFront distribution ARN for the hosted frontend."
+  value       = aws_cloudfront_distribution.frontend.arn
 }
 
 output "cloudfront_domain_name" {

--- a/infra/modules/github_frontend_deploy_role/.terraform.lock.hcl
+++ b/infra/modules/github_frontend_deploy_role/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.43.0"
+  constraints = "~> 6.37"
+  hashes = [
+    "h1:bS/rBRbYawLnmFqawh7iJE3qS8ErHInn6FPeepd8Xkw=",
+    "zh:0fe91026ce8c5178781de6773531dcfcf5280ee139059dc5a0c046f1532cf389",
+    "zh:114001f94c38db8702210eda643ec627fa1929a88f774e17db30bc172df6759e",
+    "zh:1fc668d57c7edd81c06f5705b03517393444fe4988a68a3fd90b5b21fed64a55",
+    "zh:2bc0b4d5b706c3bbe7824bcf410942ee631d3423c23f935a51129832d81e1e17",
+    "zh:3f27e2befae3393df2ba423abba7f64c774d8aa6e0de20d00b35d7cca6f47d65",
+    "zh:410bfc19e1f38b7caabc5e1b9cd2de196bdcaa02c840372be26734775ee0214c",
+    "zh:417181a86499386ffbf4d023b9c5219a0d322751513806e977f146f170f0aebc",
+    "zh:6764d31dbae9656b698a3b9d4a44e4267210375ff9bec3e8716bac4450a06f0d",
+    "zh:86401475746c94b12e90b065b76a77c635a84d9cbfc57eace65131c780bd34c6",
+    "zh:98388ac853abbcb18fdf578c18203f485479610d28329c21deefc573976e4b1d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:afb84c77c569e9979b8287cde33543cff992ca17e62ebe3f2b4a8e69884dbdc5",
+    "zh:c54c64dba350e6856fb8f2813b81d20286a532b02bad5f67da35135c02594407",
+    "zh:d1a46adf1c8f5bf42a1886b06fd25d86981236c933165f0fbc07e4330b77d8d1",
+    "zh:e719e227a676588cdaa5a3e7e3e6b10da26830a566730e8bce2127eec1780f40",
+  ]
+}

--- a/infra/modules/github_frontend_deploy_role/main.tf
+++ b/infra/modules/github_frontend_deploy_role/main.tf
@@ -1,0 +1,70 @@
+locals {
+  github_oidc_url = "https://token.actions.githubusercontent.com"
+  github_oidc_sub = "repo:${var.github_repository}:environment:${var.github_environment}"
+
+  deploy_policy = {
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ListFrontendBucket"
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = var.frontend_bucket_arn
+      },
+      {
+        Sid    = "WriteFrontendObjects"
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:DeleteObject",
+        ]
+        Resource = "${var.frontend_bucket_arn}/*"
+      },
+      {
+        Sid      = "InvalidateFrontendDistribution"
+        Effect   = "Allow"
+        Action   = ["cloudfront:CreateInvalidation"]
+        Resource = var.cloudfront_distribution_arn
+      },
+    ]
+  }
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = local.github_oidc_url
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = []
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-github-oidc" })
+}
+
+resource "aws_iam_role" "frontend_deploy" {
+  name = "${var.name_prefix}-github-frontend-deploy"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+            "token.actions.githubusercontent.com:sub" = local.github_oidc_sub
+          }
+        }
+      },
+    ]
+  })
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-github-frontend-deploy" })
+}
+
+resource "aws_iam_role_policy" "frontend_deploy" {
+  name   = "${var.name_prefix}-github-frontend-deploy"
+  role   = aws_iam_role.frontend_deploy.id
+  policy = jsonencode(local.deploy_policy)
+}

--- a/infra/modules/github_frontend_deploy_role/outputs.tf
+++ b/infra/modules/github_frontend_deploy_role/outputs.tf
@@ -1,0 +1,14 @@
+output "role_arn" {
+  description = "ARN of the GitHub Actions frontend deploy role."
+  value       = aws_iam_role.frontend_deploy.arn
+}
+
+output "role_name" {
+  description = "Name of the GitHub Actions frontend deploy role."
+  value       = aws_iam_role.frontend_deploy.name
+}
+
+output "oidc_provider_arn" {
+  description = "ARN of the GitHub Actions OIDC provider."
+  value       = aws_iam_openid_connect_provider.github.arn
+}

--- a/infra/modules/github_frontend_deploy_role/tests/defaults.tftest.hcl
+++ b/infra/modules/github_frontend_deploy_role/tests/defaults.tftest.hcl
@@ -1,0 +1,99 @@
+mock_provider "aws" {}
+
+variables {
+  name_prefix                 = "leaseflow-dev"
+  github_repository           = "Alpine78/leaseflow"
+  github_environment          = "dev"
+  frontend_bucket_arn         = "arn:aws:s3:::leaseflow-dev-frontend-123456789012-eu-north-1"
+  cloudfront_distribution_arn = "arn:aws:cloudfront::123456789012:distribution/E1234567890ABC"
+  tags = {
+    Project = "leaseflow"
+  }
+}
+
+run "creates_github_oidc_provider_and_scoped_deploy_role" {
+  command = apply
+
+  assert {
+    condition     = aws_iam_openid_connect_provider.github.url == "https://token.actions.githubusercontent.com"
+    error_message = "OIDC provider URL should be GitHub Actions."
+  }
+
+  assert {
+    condition     = contains(aws_iam_openid_connect_provider.github.client_id_list, "sts.amazonaws.com")
+    error_message = "OIDC provider should allow the AWS STS audience."
+  }
+
+  assert {
+    condition     = jsondecode(aws_iam_role.frontend_deploy.assume_role_policy).Statement[0].Action == "sts:AssumeRoleWithWebIdentity"
+    error_message = "Deploy role trust policy should allow web identity role assumption."
+  }
+
+  assert {
+    condition     = jsondecode(aws_iam_role.frontend_deploy.assume_role_policy).Statement[0].Principal.Federated == aws_iam_openid_connect_provider.github.arn
+    error_message = "Deploy role should trust only the Terraform-managed GitHub OIDC provider."
+  }
+
+  assert {
+    condition     = jsondecode(aws_iam_role.frontend_deploy.assume_role_policy).Statement[0].Condition.StringEquals["token.actions.githubusercontent.com:aud"] == "sts.amazonaws.com"
+    error_message = "Deploy role trust policy should require the AWS STS audience."
+  }
+
+  assert {
+    condition     = jsondecode(aws_iam_role.frontend_deploy.assume_role_policy).Statement[0].Condition.StringEquals["token.actions.githubusercontent.com:sub"] == "repo:Alpine78/leaseflow:environment:dev"
+    error_message = "Deploy role trust policy should be scoped to the repo and dev GitHub Environment."
+  }
+}
+
+run "grants_only_frontend_bucket_and_cloudfront_invalidation_permissions" {
+  command = apply
+
+  assert {
+    condition     = contains(jsondecode(aws_iam_role_policy.frontend_deploy.policy).Statement[0].Action, "s3:ListBucket")
+    error_message = "Deploy policy should allow listing only the frontend bucket."
+  }
+
+  assert {
+    condition     = jsondecode(aws_iam_role_policy.frontend_deploy.policy).Statement[0].Resource == "arn:aws:s3:::leaseflow-dev-frontend-123456789012-eu-north-1"
+    error_message = "Bucket list permission should be scoped to the frontend bucket ARN."
+  }
+
+  assert {
+    condition = alltrue([
+      for action in ["s3:PutObject", "s3:DeleteObject"] :
+      contains(jsondecode(aws_iam_role_policy.frontend_deploy.policy).Statement[1].Action, action)
+    ])
+    error_message = "Deploy policy should allow writing and deleting frontend bucket objects."
+  }
+
+  assert {
+    condition     = jsondecode(aws_iam_role_policy.frontend_deploy.policy).Statement[1].Resource == "arn:aws:s3:::leaseflow-dev-frontend-123456789012-eu-north-1/*"
+    error_message = "Object permissions should be scoped to frontend bucket objects."
+  }
+
+  assert {
+    condition     = contains(jsondecode(aws_iam_role_policy.frontend_deploy.policy).Statement[2].Action, "cloudfront:CreateInvalidation")
+    error_message = "Deploy policy should allow creating CloudFront invalidations."
+  }
+
+  assert {
+    condition     = jsondecode(aws_iam_role_policy.frontend_deploy.policy).Statement[2].Resource == "arn:aws:cloudfront::123456789012:distribution/E1234567890ABC"
+    error_message = "CloudFront invalidation permission should be scoped to the hosted frontend distribution."
+  }
+
+  assert {
+    condition = !contains(flatten([
+      for statement in jsondecode(aws_iam_role_policy.frontend_deploy.policy).Statement : statement.Action
+    ]), "*")
+    error_message = "Deploy policy must not grant wildcard actions."
+  }
+
+  assert {
+    condition = alltrue([
+      for action in flatten([
+        for statement in jsondecode(aws_iam_role_policy.frontend_deploy.policy).Statement : statement.Action
+      ]) : startswith(action, "s3:") || startswith(action, "cloudfront:")
+    ])
+    error_message = "Deploy policy should not grant Terraform, RDS, SSM, Cognito, Lambda, SES, or other service permissions."
+  }
+}

--- a/infra/modules/github_frontend_deploy_role/variables.tf
+++ b/infra/modules/github_frontend_deploy_role/variables.tf
@@ -1,0 +1,41 @@
+variable "name_prefix" {
+  type        = string
+  description = "Prefix used for GitHub frontend deploy IAM resources."
+}
+
+variable "github_repository" {
+  type        = string
+  description = "GitHub repository allowed to assume the frontend deploy role, in owner/name format."
+
+  validation {
+    condition     = can(regex("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", var.github_repository))
+    error_message = "github_repository must use owner/name format without wildcards."
+  }
+}
+
+variable "github_environment" {
+  type        = string
+  description = "GitHub deployment environment allowed to assume the frontend deploy role."
+  default     = "dev"
+
+  validation {
+    condition     = trimspace(var.github_environment) != "" && !strcontains(var.github_environment, "*")
+    error_message = "github_environment must be non-empty and must not contain wildcards."
+  }
+}
+
+variable "frontend_bucket_arn" {
+  type        = string
+  description = "S3 bucket ARN for hosted frontend assets."
+}
+
+variable "cloudfront_distribution_arn" {
+  type        = string
+  description = "CloudFront distribution ARN for the hosted frontend."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags applied to GitHub frontend deploy IAM resources."
+  default     = {}
+}

--- a/infra/modules/github_frontend_deploy_role/versions.tf
+++ b/infra/modules/github_frontend_deploy_role/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.37"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a Terraform module for GitHub Actions OIDC and a least-privilege dev frontend deploy role.
- Wire the role into the dev environment and expose `frontend_deploy_role_arn`.
- Add frontend bucket/distribution ARN outputs and CI module-test coverage.
- Update docs to clarify this is only the OIDC foundation; the deploy workflow remains follow-up work.

## Assumptions
- Future deploys use GitHub Environment `dev`.
- If the AWS account already has the GitHub OIDC provider, the operator imports it into Terraform state before apply.
- The role is dev-only and only for hosted frontend asset deployment.

## Security Validation
- Trust policy is scoped to `repo:Alpine78/leaseflow:environment:dev`.
- OIDC audience is restricted to `sts.amazonaws.com`.
- Policy grants only frontend S3 list/write/delete and CloudFront invalidation.
- No Terraform, RDS, SSM, Cognito, Lambda, SES, admin wildcard, or static AWS key access added.
- Tenant isolation is unchanged; no backend/API/runtime data path changed.

## Cost Validation
- Adds IAM/OIDC configuration only.
- No new billable runtime service, NAT Gateway, database, CloudFront distribution, or S3 bucket added.

## Validation
- `terraform fmt -recursive infra`
- `terraform test` in `infra/modules/github_frontend_deploy_role`
- `terraform test` in `infra/modules/frontend_hosting`
- `terraform validate` in `infra/environments/dev`
- `git diff --check`

## Remaining Work
- #172 should add the actual `workflow_dispatch` hosted frontend deploy workflow.
