### PR TITLE
ci: add manual dev frontend deploy workflow

### DIFF
--- a/.github/workflows/deploy-frontend-dev.yml
+++ b/.github/workflows/deploy-frontend-dev.yml
@@ -1,0 +1,145 @@
+name: Deploy hosted frontend (dev)
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deployment environment"
+        required: true
+        type: choice
+        default: dev
+        options:
+          - dev
+      confirm_dev_deploy:
+        description: "Confirm deployment to the dev hosted frontend"
+        required: true
+        type: boolean
+        default: false
+      invalidation_path:
+        description: "CloudFront invalidation path"
+        required: true
+        type: string
+        default: "/*"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: frontend-deploy-dev
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy hosted frontend to dev
+    runs-on: ubuntu-latest
+    environment: dev
+
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
+      FRONTEND_BUCKET_NAME: ${{ vars.FRONTEND_BUCKET_NAME }}
+      FRONTEND_CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.FRONTEND_CLOUDFRONT_DISTRIBUTION_ID }}
+      FRONTEND_CLOUDFRONT_URL: ${{ vars.FRONTEND_CLOUDFRONT_URL }}
+      CONFIRM_DEV_DEPLOY: ${{ inputs.confirm_dev_deploy }}
+      INVALIDATION_PATH: ${{ inputs.invalidation_path }}
+
+    steps:
+      - name: Validate deployment inputs
+        env:
+          FRONTEND_DEPLOY_ROLE_ARN: ${{ vars.FRONTEND_DEPLOY_ROLE_ARN }}
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
+          VITE_COGNITO_HOSTED_UI_BASE_URL: ${{ vars.VITE_COGNITO_HOSTED_UI_BASE_URL }}
+          VITE_COGNITO_CLIENT_ID: ${{ vars.VITE_COGNITO_CLIENT_ID }}
+        run: |
+          set -euo pipefail
+          if [[ "${DEPLOY_ENVIRONMENT}" != "dev" ]]; then
+            echo "Only the dev environment is supported." >&2
+            exit 1
+          fi
+          if [[ "${CONFIRM_DEV_DEPLOY}" != "true" ]]; then
+            echo "confirm_dev_deploy must be true." >&2
+            exit 1
+          fi
+          if [[ "${INVALIDATION_PATH}" != /* ]]; then
+            echo "invalidation_path must start with /." >&2
+            exit 1
+          fi
+          for name in \
+            AWS_REGION \
+            FRONTEND_DEPLOY_ROLE_ARN \
+            FRONTEND_BUCKET_NAME \
+            FRONTEND_CLOUDFRONT_DISTRIBUTION_ID \
+            FRONTEND_CLOUDFRONT_URL \
+            VITE_API_BASE_URL \
+            VITE_COGNITO_HOSTED_UI_BASE_URL \
+            VITE_COGNITO_CLIENT_ID; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "Required GitHub Environment variable is missing: ${name}" >&2
+              exit 1
+            fi
+          done
+
+      - name: Check out selected ref
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci --ignore-scripts
+
+      - name: Audit frontend dependencies
+        working-directory: frontend
+        run: npm audit --audit-level=high
+
+      - name: Lint frontend
+        working-directory: frontend
+        run: npm run lint
+
+      - name: Test frontend
+        working-directory: frontend
+        run: npm run test
+
+      - name: Build frontend
+        working-directory: frontend
+        env:
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
+          VITE_COGNITO_HOSTED_UI_BASE_URL: ${{ vars.VITE_COGNITO_HOSTED_UI_BASE_URL }}
+          VITE_COGNITO_CLIENT_ID: ${{ vars.VITE_COGNITO_CLIENT_ID }}
+        run: npm run build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.1.0
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: ${{ vars.FRONTEND_DEPLOY_ROLE_ARN }}
+
+      - name: Upload frontend assets
+        run: |
+          set -euo pipefail
+          aws s3 sync frontend/dist/ "s3://${FRONTEND_BUCKET_NAME}/" \
+            --delete \
+            --only-show-errors
+
+      - name: Invalidate CloudFront
+        run: |
+          set -euo pipefail
+          aws cloudfront create-invalidation \
+            --distribution-id "${FRONTEND_CLOUDFRONT_DISTRIBUTION_ID}" \
+            --paths "${INVALIDATION_PATH}" \
+            --query 'Invalidation.{Id:Id,Status:Status}' \
+            --output json
+
+      - name: Print safe deployment summary
+        run: |
+          set -euo pipefail
+          printf 'DEPLOY_ENVIRONMENT=%s\n' "${DEPLOY_ENVIRONMENT}"
+          printf 'DEPLOY_REF=%s\n' "${GITHUB_REF_NAME}"
+          printf 'DEPLOY_SHA=%s\n' "${GITHUB_SHA}"
+          printf 'FRONTEND_URL_CONFIGURED=%s\n' "$([[ -n "${FRONTEND_CLOUDFRONT_URL}" ]] && echo true || echo false)"

--- a/docs/hosted-frontend-deploy-automation.md
+++ b/docs/hosted-frontend-deploy-automation.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document plans a safe path from the current local operator upload to a
+This document records the safe path from the current local operator upload to a
 controlled GitHub Actions deployment for the hosted LeaseFlow frontend.
 
 The current project already has a real browser frontend, private S3 +
@@ -10,8 +10,7 @@ CloudFront hosting infrastructure, and successful hosted smoke evidence. Hosted
 asset upload still remains a local operator step through
 `scripts/dev/upload-frontend.sh`.
 
-This document does not implement a workflow, Terraform, IAM role, AWS resource,
-custom domain, or production deployment path.
+This document does not define a custom domain or production deployment path.
 
 ## Current State
 
@@ -26,7 +25,8 @@ custom domain, or production deployment path.
   `docs/runbooks/evidence/hosted-frontend-smoke-test-2026-04-30.md`.
 - Terraform now defines a GitHub OIDC provider and a least-privilege dev
   frontend deploy role for the future workflow.
-- There is no GitHub Actions deployment workflow yet.
+- `.github/workflows/deploy-frontend-dev.yml` now defines a manual dev-only
+  hosted frontend deploy workflow.
 
 ## Options
 
@@ -66,19 +66,19 @@ Tradeoffs:
   deployment environment.
 - Gives repeatable logs and a safer review point through GitHub environments.
 
-## Chosen Future Direction
+## Chosen Direction
 
-Keep manual upload for now. When automation is needed, add a separate
-`workflow_dispatch` GitHub Actions deployment for dev only, backed by GitHub
-OIDC and a least-privilege AWS role.
+Keep manual upload supported. Use a separate `workflow_dispatch` GitHub Actions
+deployment for dev only when repeatable hosted deploy logs are useful. The
+workflow is backed by GitHub OIDC and a least-privilege AWS role.
 
 The first automated path should not deploy from every `main` push. Manual
 dispatch is safer for this portfolio/dev workflow because the AWS dev stack may
 be destroyed for cost control.
 
-## Future Workflow Shape
+## Workflow Shape
 
-The future workflow should:
+The workflow:
 
 - Trigger only through `workflow_dispatch`.
 - Target only the dev environment.
@@ -88,7 +88,7 @@ The future workflow should:
 - Run `npm audit --audit-level=high`.
 - Run `npm run lint`, `npm run test`, and `npm run build`.
 - Upload only `frontend/dist/` to the Terraform-created frontend bucket.
-- Use `aws s3 sync frontend/dist/ s3://<bucket>/ --delete`.
+- Use `aws s3 sync frontend/dist/ s3://<bucket>/ --delete --only-show-errors`.
 - Create a CloudFront invalidation, defaulting to `/*`.
 - Print only safe deployment metadata such as branch, commit SHA, environment,
   invalidation ID, and pass/fail statuses.
@@ -96,14 +96,13 @@ The future workflow should:
 The workflow must not print or store JWTs, Cognito emails, tenant IDs, SSM
 values, DB endpoints, AWS credentials, or frontend `.env.local` contents.
 
-## Future Workflow Inputs
+## Workflow Inputs
 
-The future `workflow_dispatch` inputs should be intentionally small:
+The `workflow_dispatch` inputs are intentionally small:
 
 - `environment`: choice, initially only `dev`.
-- `ref_to_deploy`: branch, tag, or SHA to confirm what is being deployed.
-- `invalidation_path`: optional, default `/*`.
-- `confirm_dev_deploy`: required boolean or confirmation string.
+- `invalidation_path`: string, default `/*`.
+- `confirm_dev_deploy`: required boolean.
 
 The workflow should fail early if the selected environment is not `dev` or if
 the confirmation input is missing.
@@ -179,9 +178,9 @@ not grant Terraform, RDS, SSM, Cognito, Lambda, or SES permissions.
 
 ### Add Manual GitHub Actions Hosted Frontend Deploy Workflow
 
-Add a `workflow_dispatch` deploy workflow that uses OIDC, GitHub environment
-protection, npm install hardening, audit, lint, tests, build, S3 sync, and
-CloudFront invalidation.
+Completed as a `workflow_dispatch` deploy workflow that uses OIDC, GitHub
+environment protection, npm install hardening, audit, lint, tests, build, S3
+sync, and CloudFront invalidation.
 
 ### Add Hosted Frontend Deploy Rollback Runbook
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -17,8 +17,8 @@ tool.
 - due-soon reminder candidate list
 - persisted notifications list and mark-read action
 
-This slice does not include notification creation, email delivery, or hosted CI
-deploy automation.
+This slice does not include notification creation, email delivery, custom
+domains, or production-ready deploy automation.
 
 ## Prerequisites
 
@@ -203,10 +203,29 @@ Then open `http://localhost:5173`.
 ## Hosted dev deploy
 
 Terraform creates the S3 bucket and CloudFront distribution. Frontend asset
-upload remains a local operator step. If any `VITE_*` value changes, rebuild
-and upload the frontend again because the static assets contain those values.
-The future GitHub Actions deployment path is planned in
-`docs/hosted-frontend-deploy-automation.md`, but is not implemented yet.
+upload can be done either with the local operator script or the manual GitHub
+Actions workflow. If any `VITE_*` value changes, rebuild and upload the
+frontend again because the static assets contain those values.
+
+The manual GitHub Actions workflow is `.github/workflows/deploy-frontend-dev.yml`.
+It uses GitHub OIDC, the `dev` GitHub Environment, and non-secret environment
+variables copied from Terraform outputs. It does not use static AWS access
+keys and does not run Terraform.
+
+Required GitHub Environment `dev` variables:
+
+- `AWS_REGION`
+- `FRONTEND_DEPLOY_ROLE_ARN`
+- `FRONTEND_BUCKET_NAME`
+- `FRONTEND_CLOUDFRONT_DISTRIBUTION_ID`
+- `FRONTEND_CLOUDFRONT_URL`
+- `VITE_API_BASE_URL`
+- `VITE_COGNITO_HOSTED_UI_BASE_URL`
+- `VITE_COGNITO_CLIENT_ID`
+
+Run the workflow manually with `environment=dev`, `confirm_dev_deploy=true`,
+and `invalidation_path=/*`. The local upload path below remains supported for
+operator testing and troubleshooting.
 
 What it does: builds and uploads the hosted frontend, then invalidates
 CloudFront.


### PR DESCRIPTION
## Summary
- Add a dev-only manual hosted frontend deploy workflow using GitHub OIDC.
- Preserve frontend install hardening, audit, lint, test, and build before deploy.
- Upload only `frontend/dist/` to S3 and create a CloudFront invalidation.
- Document required GitHub Environment `dev` variables.

## Security Validation
- No static AWS access keys or GitHub AWS secrets.
- OIDC uses the #171 deploy role via `FRONTEND_DEPLOY_ROLE_ARN`.
- Workflow does not run Terraform and has no RDS, SSM, Cognito, Lambda, SES, or tenant-data path.
- Browser tenant isolation is unchanged.

## Cost Validation
- No new AWS resources.
- Workflow only uploads existing frontend assets and invalidates existing CloudFront distribution.

## Validation
- `git diff --check`
- `npm audit --audit-level=high`
- Frontend install/lint/test/build require local `node_modules` lock cleanup before rerun.
