### PR TITLE
docs: plan SES production sender DNS authentication

### DIFF
--- a/docs/notification-email-delivery-mvp.md
+++ b/docs/notification-email-delivery-mvp.md
@@ -45,6 +45,9 @@ SES deliverability.
 - Amazon SES is the preferred email delivery service for LeaseFlow.
 - Production delivery hardening is planned separately in
   `docs/ses-production-delivery-hardening.md`.
+- Production sender identity and DNS authentication planning is documented in
+  `docs/ses-production-domain-identity-dns-authentication.md`; production
+  sending remains unavailable.
 - Persisted `notifications` remain the source of delivery work; the delivery
   job must not recalculate reminder candidates independently.
 - Recipient addresses come from a LeaseFlow-owned tenant-scoped contact

--- a/docs/ses-production-delivery-hardening.md
+++ b/docs/ses-production-delivery-hardening.md
@@ -49,8 +49,9 @@ verifying each address separately.
 
 Required future decisions:
 
-- Which domain or subdomain is the production sender identity.
-- Whether LeaseFlow uses a custom MAIL FROM domain.
+- The production sender identity direction is documented in
+  `docs/ses-production-domain-identity-dns-authentication.md`.
+- Whether LeaseFlow later adopts a custom MAIL FROM domain.
 - Which AWS Region owns the production SES identity.
 - Whether dev and production identities are isolated by account, region, or
   configuration.
@@ -173,9 +174,10 @@ security tradeoff is justified.
 
 ### Add SES Production Domain Identity And DNS Authentication Plan
 
-Define the production sender domain, SES identity ownership, DKIM records, SPF
-alignment approach, DMARC monitoring policy, and production access request
-preconditions. Out of scope: sending code and production access submission.
+Completed as a focused planning document in
+`docs/ses-production-domain-identity-dns-authentication.md`. Implementation,
+DNS changes, sending code, and production access submission remain out of
+scope.
 
 ### Add SES Bounce And Complaint Ingestion
 
@@ -227,4 +229,7 @@ planning ticket.
 - [Amazon SES VPC endpoints](https://docs.aws.amazon.com/ses/latest/dg/send-email-set-up-vpc-endpoints.html)
 - [Amazon SES configuration sets](https://docs.aws.amazon.com/ses/latest/dg/using-configuration-sets.html)
 - [Amazon SES subscription management](https://docs.aws.amazon.com/ses/latest/dg/sending-email-subscription-management.html)
+- [Amazon SES Easy DKIM](https://docs.aws.amazon.com/ses/latest/dg/send-email-authentication-dkim-easy.html)
+- [Amazon SES SPF authentication](https://docs.aws.amazon.com/ses/latest/dg/send-email-authentication-spf.html)
+- [Amazon SES custom MAIL FROM](https://docs.aws.amazon.com/ses/latest/dg/mail-from.html)
 - [Amazon SES DMARC](https://docs.aws.amazon.com/ses/latest/dg/send-email-authentication-dmarc.html)

--- a/docs/ses-production-domain-identity-dns-authentication.md
+++ b/docs/ses-production-domain-identity-dns-authentication.md
@@ -1,0 +1,136 @@
+# SES Production Domain Identity And DNS Authentication Plan
+
+## Purpose
+
+This document defines the production sender identity and DNS authentication
+direction for LeaseFlow notification email.
+
+This is a planning artifact only. It does not create SES identities, DNS
+records, Terraform resources, production access requests, backend behavior,
+frontend behavior, or email-sending changes.
+
+## Current State
+
+- Dev SES SMTP delivery exists as an internal backend worker and is disabled by
+  default.
+- Dev SES delivery smoke evidence exists for the controlled development path.
+- Production sender identity does not exist.
+- Production DNS authentication records have not been created.
+- SES production access and production deliverability readiness are not in
+  place.
+- Bounce, complaint, suppression, unsubscribe, monitoring, and cost-control
+  hardening remain separate production-readiness work.
+
+## Sender Identity Direction
+
+The production sender identity should be a dedicated sender subdomain, written
+generically as `<notification-sender-subdomain>`.
+
+Use an SES domain identity for `<notification-sender-subdomain>` rather than a
+single email-address identity. A domain identity is the better production fit
+because it supports operational sender addresses under the same controlled
+subdomain without verifying each individual address.
+
+Repository docs, evidence, and PRs must not include real production domains,
+email addresses, hosted zone names, DNS record values, AWS account IDs, SES
+provider responses, tenant IDs, or credentials.
+
+## DNS Authentication Plan
+
+### SES Domain Identity
+
+The future implementation should create or register an SES domain identity for
+`<notification-sender-subdomain>` in the selected production SES Region.
+
+The identity must be verified before any production access request or broad
+sending rollout is treated as ready.
+
+### DKIM
+
+Easy DKIM is the default DKIM approach.
+
+The future implementation should use SES-generated DKIM records for the domain
+identity and publish the required CNAME records through the DNS provider. The
+rollout must wait until SES reports the identity and DKIM signing status as
+verified before claiming sender authentication is complete.
+
+BYODKIM is out of scope unless a later compliance requirement justifies the
+extra key-management responsibility.
+
+### SPF
+
+The first DNS plan should review SPF through SES default MAIL FROM behavior.
+With default MAIL FROM, SES uses an Amazon-owned MAIL FROM domain and SPF is
+handled by SES for that envelope sender path.
+
+Do not claim strict SPF alignment for the production sender until the project
+explicitly decides whether to use a custom MAIL FROM domain.
+
+### DMARC
+
+DMARC should start in monitoring mode.
+
+The initial posture should use monitoring-only policy language such as
+`p=none`, with reporting destinations decided outside this repository. Do not
+commit real report mailbox addresses or provider-generated DNS values.
+
+Move to stricter DMARC policies only after DKIM alignment, bounce/complaint
+handling, suppression behavior, and production monitoring have been validated.
+
+### Custom MAIL FROM
+
+Custom MAIL FROM is deferred to a follow-up decision.
+
+If adopted later, it must use a dedicated MAIL FROM subdomain that is not reused
+for normal sending or receiving. The follow-up plan must include the required
+MX record, SPF TXT record, behavior on MX failure, operational ownership, and
+rollback path.
+
+## Production Access Prerequisites
+
+Before requesting SES production access for LeaseFlow notification email, the
+project should have:
+
+- Verified domain identity for `<notification-sender-subdomain>`.
+- Easy DKIM verification and signing confirmed.
+- Sending use case documented as tenant notification and due reminder
+  operational mail.
+- Recipient source confirmed as tenant-scoped notification contacts.
+- Bounce and complaint handling plan in place.
+- Suppression and unsubscribe/preference model planned for applicable message
+  types.
+- Monitoring, alarms, batch limits, retry limits, and cost controls planned.
+- Sanitized runbook/evidence rules for production rollout.
+
+Production access should not be treated as production readiness by itself.
+
+## Security And Cost Boundaries
+
+- Browser routes must not trigger reminder scans, email delivery, or production
+  rollout actions.
+- Tenant context must continue to come from validated Cognito JWT claims, not
+  browser request bodies or query parameters.
+- Production identity planning must not make RDS public.
+- Production identity planning must not introduce NAT Gateway by default.
+- Production identity planning must not commit or log real domains, email
+  addresses, DNS values, tenant IDs, JWTs, SMTP credentials, SES credentials,
+  SSM values, DB endpoints, notification content, raw SES responses, or raw
+  SMTP transcripts.
+
+## Follow-Up Work
+
+- Add SES production domain identity and DNS implementation plan.
+- Add SES production access request runbook.
+- Add SES bounce and complaint ingestion.
+- Add notification suppression and unsubscribe/preference model.
+- Add SES delivery monitoring, alarms, and cost controls.
+- Add production SES rollout runbook and sanitized evidence template.
+
+## References
+
+- [Amazon SES verified identities](https://docs.aws.amazon.com/ses/latest/dg/verify-addresses-and-domains.html)
+- [Amazon SES Easy DKIM](https://docs.aws.amazon.com/ses/latest/dg/send-email-authentication-dkim-easy.html)
+- [Amazon SES SPF authentication](https://docs.aws.amazon.com/ses/latest/dg/send-email-authentication-spf.html)
+- [Amazon SES custom MAIL FROM](https://docs.aws.amazon.com/ses/latest/dg/mail-from.html)
+- [Amazon SES DMARC](https://docs.aws.amazon.com/ses/latest/dg/send-email-authentication-dmarc.html)
+- [Amazon SES production access](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html)


### PR DESCRIPTION
## Summary
- Add a docs-only SES production domain identity and DNS authentication plan.
- Choose a dedicated sender subdomain strategy using a generic placeholder.
- Document Easy DKIM as the default, DMARC monitoring-first posture, SPF review through default MAIL FROM, and custom MAIL FROM as a deferred decision.
- Cross-link the new plan from SES production hardening and notification delivery MVP docs.

## Security validation
- No real domains, email addresses, DNS values, AWS account IDs, tenant IDs, credentials, SSM values, DB endpoints, or provider responses are included.
- Tenant context wording remains backend/JWT-derived.
- No browser-triggered scan or delivery path is introduced.

## Cost validation
- No AWS resources or Terraform changes.
- No NAT Gateway, DNS, SES identity, or production access request added.

## Validation
- `git diff --check`
