### PR TITLE
docs: plan notification suppression preferences

### DIFF
--- a/docs/notification-email-delivery-mvp.md
+++ b/docs/notification-email-delivery-mvp.md
@@ -51,6 +51,9 @@ SES deliverability.
 - Bounce and complaint ingestion planning is documented in
   `docs/ses-bounce-complaint-ingestion.md`; provider feedback ingestion is not
   implemented yet.
+- Notification suppression and unsubscribe/preference planning is documented in
+  `docs/notification-suppression-unsubscribe-model.md`; suppression state is
+  not implemented yet.
 - Persisted `notifications` remain the source of delivery work; the delivery
   job must not recalculate reminder candidates independently.
 - Recipient addresses come from a LeaseFlow-owned tenant-scoped contact

--- a/docs/notification-suppression-unsubscribe-model.md
+++ b/docs/notification-suppression-unsubscribe-model.md
@@ -1,0 +1,149 @@
+# Notification Suppression And Unsubscribe Model Plan
+
+## Purpose
+
+This document defines the future tenant/contact-level suppression and
+preference model for LeaseFlow notification email.
+
+This is a planning artifact only. It does not add database migrations, backend
+code, frontend UI, Terraform resources, SES integration changes, production
+access, or marketing email behavior.
+
+## Current State
+
+- `notification_contacts.enabled` is the current tenant-managed recipient
+  on/off state.
+- Disabled contacts remain stored and are excluded from delivery candidate
+  selection.
+- `notification_email_deliveries` tracks delivery attempts, sanitized failure
+  codes, and sent timestamps.
+- Bounce and complaint ingestion is planned separately in
+  `docs/ses-bounce-complaint-ingestion.md`.
+- No LeaseFlow-owned suppression or unsubscribe/preference state exists yet.
+- The browser can manage contacts but cannot trigger reminder scans, delivery,
+  retries, or provider feedback processing.
+
+## Message Classification
+
+Due reminder email is classified as operational tenant notification mail for
+the first production-ready delivery path.
+
+Due reminder delivery should be controlled by the LeaseFlow tenant-owned contact
+model:
+
+- tenant users can enable or disable a contact.
+- provider feedback can suppress a contact after permanent bounce or complaint.
+- optional unsubscribe/list-topic behavior is not required for the first due
+  reminder path.
+
+Marketing mail, digest mail, optional newsletters, and broad promotional
+messages are out of scope. If those message types are added later, they need an
+explicit preference/unsubscribe design before delivery is enabled.
+
+## Future Contact State Model
+
+The future model should distinguish these states:
+
+- `enabled`: tenant-managed contact is eligible if no suppression/preference
+  block applies.
+- `disabled`: tenant-managed contact opt-out; delivery must not select the
+  contact.
+- `suppressed_bounce`: system-managed block after permanent bounce or
+  provider suppression bounce.
+- `suppressed_complaint`: system-managed block after complaint feedback.
+- future `unsubscribed`: reserved for optional, digest, or marketing-like
+  notification types; not required for the first due reminder path.
+
+Delivery eligibility requires both:
+
+- the contact is enabled.
+- no suppression or preference state blocks the message type.
+
+Suppression must be tenant-scoped in LeaseFlow even if SES account-level
+suppression is also enabled later. SES account-level suppression can protect
+sender reputation, but it is not a replacement for application-owned
+tenant/contact state.
+
+## State Priority
+
+When multiple states apply, delivery must choose the safest outcome:
+
+- `disabled`, `suppressed_bounce`, `suppressed_complaint`, or future
+  `unsubscribed` blocks delivery.
+- Re-enabling a contact should not automatically remove provider-derived
+  suppression.
+- Removing provider-derived suppression must be an explicit future operator or
+  tenant-safe workflow with auditability.
+- Complaint suppression should be treated as stronger than ordinary disabled
+  state because it represents recipient/provider feedback.
+
+## SES Subscription Management
+
+Amazon SES subscription management is not the first source of truth for
+LeaseFlow due reminder delivery.
+
+The first source of truth remains the LeaseFlow-owned tenant contact model
+because:
+
+- current delivery uses the SES SMTP path.
+- due reminders are operational tenant notifications.
+- tenant isolation and browser visibility must remain LeaseFlow-controlled.
+- optional/digest/marketing message types do not exist yet.
+
+SES contact list/topic subscription management may be evaluated later for
+optional email types. That evaluation must be a separate ticket and must decide
+how SES-managed preferences sync with LeaseFlow tenant/contact state.
+
+## Browser And Tenant Boundaries
+
+- Browser users may manage notification contacts.
+- Browser users must not trigger delivery, retries, reminder scans, or
+  provider feedback ingestion.
+- Browser UI may later show safe contact status such as enabled, disabled, or
+  suppressed.
+- Browser UI must not show raw SES payloads, raw provider identifiers, SMTP
+  transcripts, notification message bodies, tenant IDs, or recipient-level
+  provider diagnostics.
+- Tenant context must remain backend-derived from validated Cognito JWT claims
+  or internal processing context, never browser request bodies.
+
+## Follow-Up Tickets
+
+### Add Notification Suppression State
+
+Add DB and data-access support for tenant-scoped suppression/preference state.
+Out of scope: SES event ingestion and browser UI.
+
+### Apply Suppression To Email Delivery Eligibility
+
+Update delivery preparation and sending selection so disabled or suppressed
+contacts are excluded before delivery rows are created or sent.
+
+### Add Suppression Visibility In Notifications UI
+
+Expose safe contact status in the existing notifications/contact UI. Do not
+show provider payloads, raw event data, tenant IDs, or recipient-level provider
+diagnostics.
+
+### Evaluate SES Subscription Management For Optional Email Types
+
+Evaluate SES contact list/topic subscription management only if LeaseFlow adds
+optional, digest, or marketing-like message types.
+
+## Security And Cost Boundaries
+
+- No Cognito user enumeration.
+- No NAT Gateway is part of this plan.
+- RDS must remain private.
+- No browser-triggered delivery, scan, retry, or provider event processing.
+- No production readiness claim is made.
+- No raw SES event payloads, real email addresses, tenant IDs, message bodies,
+  SMTP credentials, SES credentials, SSM values, DB endpoints, or provider
+  responses should be stored in docs, logs, evidence, or audit metadata.
+
+## References
+
+- [Amazon SES subscription management](https://docs.aws.amazon.com/ses/latest/dg/sending-email-subscription-management.html)
+- [Amazon SES global suppression list](https://docs.aws.amazon.com/ses/latest/dg/sending-email-global-suppression-list.html)
+- [Amazon SES account-level suppression list](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-email-suppression-list.html)
+- [Amazon SES event publishing](https://docs.aws.amazon.com/ses/latest/dg/monitor-using-event-publishing.html)

--- a/docs/ses-production-delivery-hardening.md
+++ b/docs/ses-production-delivery-hardening.md
@@ -96,10 +96,9 @@ Due reminder emails are closer to transactional operational mail than marketing
 mail, but production rollout still needs an explicit classification decision.
 
 If any future notification type is promotional, digest-style, or optional, it
-must include unsubscribe/list-management behavior before broad sending. Amazon
-SES supports subscription management for supported sending flows, but the
-LeaseFlow model must still define tenant/contact-level preferences and safe
-browser visibility.
+must include unsubscribe/list-management behavior before broad sending. The
+LeaseFlow suppression and preference direction is documented in
+`docs/notification-suppression-unsubscribe-model.md`.
 
 Production requirements:
 
@@ -187,9 +186,9 @@ triggering, and raw provider payload storage remain out of scope.
 
 ### Add Notification Suppression And Unsubscribe Model
 
-Extend contact preferences so permanent bounces, complaints, disabled contacts,
-and future unsubscribe decisions are represented explicitly. Out of scope:
-marketing mail and Cognito user enumeration.
+Planned in `docs/notification-suppression-unsubscribe-model.md`. Database
+state, delivery eligibility changes, browser visibility, SES subscription
+automation, marketing mail, and Cognito user enumeration remain out of scope.
 
 ### Add SES Delivery Monitoring, Alarms, And Cost Controls
 
@@ -230,6 +229,7 @@ planning ticket.
 - [Amazon SES event publishing](https://docs.aws.amazon.com/ses/latest/dg/monitor-using-event-publishing.html)
 - [Amazon SES configuration sets](https://docs.aws.amazon.com/ses/latest/dg/using-configuration-sets.html)
 - [Amazon SES subscription management](https://docs.aws.amazon.com/ses/latest/dg/sending-email-subscription-management.html)
+- [Amazon SES global suppression list](https://docs.aws.amazon.com/ses/latest/dg/sending-email-global-suppression-list.html)
 - [Amazon SES Easy DKIM](https://docs.aws.amazon.com/ses/latest/dg/send-email-authentication-dkim-easy.html)
 - [Amazon SES SPF authentication](https://docs.aws.amazon.com/ses/latest/dg/send-email-authentication-spf.html)
 - [Amazon SES custom MAIL FROM](https://docs.aws.amazon.com/ses/latest/dg/mail-from.html)


### PR DESCRIPTION
## Summary
- Add a docs-only notification suppression and unsubscribe/preference model plan.
- Classify due reminder email as operational tenant notification mail.
- Keep LeaseFlow tenant contact enabled/disabled state as the first preference source of truth.
- Reserve SES subscription management for possible future optional/digest/marketing email types.

## Security validation
- No browser-triggered delivery, scan, retry, or provider event processing is introduced.
- Tenant context remains backend-derived.
- No Cognito user enumeration is proposed.
- No raw SES payloads, real emails, tenant IDs, message bodies, credentials, SSM values, DB endpoints, or provider responses are included.

## Cost validation
- No AWS resources, Terraform changes, NAT Gateway, or public RDS change.
- SES subscription management and account-level suppression remain future planning topics only.

## Validation
- `git diff --check`
- Manual sensitive-data review
