### PR TITLE
feat: emit ses delivery emf metrics

### DIFF
--- a/backend/src/app/metrics.py
+++ b/backend/src/app/metrics.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable, Mapping
+
+
+def build_emf_payload(
+    *,
+    namespace: str,
+    environment: str,
+    service: str,
+    operation: str,
+    result: str,
+    metrics: Mapping[str, int | float],
+    timestamp_ms: int | None = None,
+) -> dict[str, object]:
+    if any(not isinstance(value, int | float) for value in metrics.values()):
+        raise TypeError("EMF metric values must be numeric.")
+
+    dimensions = ["environment", "service", "operation", "result"]
+    return {
+        "_aws": {
+            "Timestamp": timestamp_ms if timestamp_ms is not None else int(time.time() * 1000),
+            "CloudWatchMetrics": [
+                {
+                    "Namespace": namespace,
+                    "Dimensions": [dimensions],
+                    "Metrics": [{"Name": name, "Unit": "Count"} for name in metrics],
+                }
+            ],
+        },
+        "environment": environment,
+        "service": service,
+        "operation": operation,
+        "result": result,
+        **dict(metrics),
+    }
+
+
+def emit_emf_metrics(
+    *,
+    namespace: str,
+    environment: str,
+    service: str,
+    operation: str,
+    result: str,
+    metrics: Mapping[str, int | float],
+    writer: Callable[[str], object] = print,
+) -> None:
+    writer(
+        json.dumps(
+            build_emf_payload(
+                namespace=namespace,
+                environment=environment,
+                service=service,
+                operation=operation,
+                result=result,
+                metrics=metrics,
+            ),
+            ensure_ascii=True,
+            separators=(",", ":"),
+        )
+    )

--- a/backend/src/app/routes/notification_email_delivery.py
+++ b/backend/src/app/routes/notification_email_delivery.py
@@ -5,6 +5,11 @@ from typing import Any, Protocol
 from app.config import ConfigError, Settings
 from app.db import Database
 from app.email_delivery import NotificationEmailSendError, SmtpNotificationEmailSender
+from app.metrics import emit_emf_metrics
+
+_METRIC_NAMESPACE = "LeaseFlow/NotificationEmailDelivery"
+_METRIC_SERVICE = "backend"
+_METRIC_OPERATION = "deliver_notification_emails"
 
 
 class NotificationEmailSender(Protocol):
@@ -28,7 +33,7 @@ def deliver_notification_emails(
     tenant_id = _parse_tenant_id(detail)
 
     if not settings.notification_email_delivery_enabled:
-        return _payload(
+        payload = _payload(
             enabled=False,
             tenant_id=tenant_id,
             candidate_count=0,
@@ -37,7 +42,11 @@ def deliver_notification_emails(
             attempted_count=0,
             sent_count=0,
             failed_count=0,
+            skipped_count=0,
+            retry_exhausted_count=0,
         )
+        _emit_delivery_metrics(settings=settings, result="disabled", payload=payload)
+        return payload
 
     if not settings.notification_email_sender.strip():
         raise ConfigError("Set NOTIFICATION_EMAIL_SENDER before enabling email delivery.")
@@ -60,6 +69,7 @@ def deliver_notification_emails(
 
     sent_count = 0
     failed_count = 0
+    retry_exhausted_count = 0
     for item in pending:
         try:
             sender.send(
@@ -70,6 +80,8 @@ def deliver_notification_emails(
             )
         except NotificationEmailSendError as exc:
             failed_count += 1
+            if item.attempt_count + 1 >= settings.notification_email_max_attempts:
+                retry_exhausted_count += 1
             db.mark_notification_email_delivery_failed(
                 tenant_id=item.tenant_id,
                 delivery_id=item.delivery_id,
@@ -82,7 +94,7 @@ def deliver_notification_emails(
                 delivery_id=item.delivery_id,
             )
 
-    return _payload(
+    payload = _payload(
         enabled=True,
         tenant_id=tenant_id,
         candidate_count=preparation.candidate_count,
@@ -91,7 +103,15 @@ def deliver_notification_emails(
         attempted_count=len(pending),
         sent_count=sent_count,
         failed_count=failed_count,
+        skipped_count=max(preparation.candidate_count - len(pending), 0),
+        retry_exhausted_count=retry_exhausted_count,
     )
+    _emit_delivery_metrics(
+        settings=settings,
+        result="completed_with_failures" if failed_count else "completed",
+        payload=payload,
+    )
+    return payload
 
 
 def _parse_tenant_id(detail: dict[str, Any]) -> str | None:
@@ -109,6 +129,8 @@ def _payload(
     attempted_count: int,
     sent_count: int,
     failed_count: int,
+    skipped_count: int,
+    retry_exhausted_count: int,
 ) -> dict[str, Any]:
     return {
         "enabled": enabled,
@@ -119,4 +141,30 @@ def _payload(
         "attempted_count": attempted_count,
         "sent_count": sent_count,
         "failed_count": failed_count,
+        "skipped_count": skipped_count,
+        "retry_exhausted_count": retry_exhausted_count,
     }
+
+
+def _emit_delivery_metrics(
+    *,
+    settings: Settings,
+    result: str,
+    payload: dict[str, Any],
+) -> None:
+    emit_emf_metrics(
+        namespace=_METRIC_NAMESPACE,
+        environment=settings.app_env,
+        service=_METRIC_SERVICE,
+        operation=_METRIC_OPERATION,
+        result=result,
+        metrics={
+            "candidate_count": payload["candidate_count"],
+            "created_delivery_count": payload["created_count"],
+            "attempted_count": payload["attempted_count"],
+            "sent_count": payload["sent_count"],
+            "failed_count": payload["failed_count"],
+            "skipped_count": payload["skipped_count"],
+            "retry_exhausted_count": payload["retry_exhausted_count"],
+        },
+    )

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+
+from app.metrics import build_emf_payload
+
+
+def test_build_emf_payload_uses_safe_dimensions_and_count_metrics() -> None:
+    payload = build_emf_payload(
+        namespace="LeaseFlow/NotificationEmailDelivery",
+        environment="test",
+        service="backend",
+        operation="deliver_notification_emails",
+        result="completed",
+        metrics={
+            "candidate_count": 2,
+            "created_delivery_count": 1,
+            "attempted_count": 1,
+        },
+        timestamp_ms=1_779_000_000_000,
+    )
+
+    assert payload == {
+        "_aws": {
+            "Timestamp": 1_779_000_000_000,
+            "CloudWatchMetrics": [
+                {
+                    "Namespace": "LeaseFlow/NotificationEmailDelivery",
+                    "Dimensions": [["environment", "service", "operation", "result"]],
+                    "Metrics": [
+                        {"Name": "candidate_count", "Unit": "Count"},
+                        {"Name": "created_delivery_count", "Unit": "Count"},
+                        {"Name": "attempted_count", "Unit": "Count"},
+                    ],
+                }
+            ],
+        },
+        "environment": "test",
+        "service": "backend",
+        "operation": "deliver_notification_emails",
+        "result": "completed",
+        "candidate_count": 2,
+        "created_delivery_count": 1,
+        "attempted_count": 1,
+    }
+    assert "tenant" not in json.dumps(payload).lower()
+    assert "recipient" not in json.dumps(payload).lower()
+
+
+def test_build_emf_payload_rejects_non_numeric_metric_values() -> None:
+    try:
+        build_emf_payload(
+            namespace="LeaseFlow/NotificationEmailDelivery",
+            environment="test",
+            service="backend",
+            operation="deliver_notification_emails",
+            result="completed",
+            metrics={"candidate_count": "1"},
+            timestamp_ms=1_779_000_000_000,
+        )
+    except TypeError as exc:
+        assert str(exc) == "EMF metric values must be numeric."
+    else:
+        raise AssertionError("Expected TypeError for non-numeric EMF metric value.")

--- a/backend/tests/test_notification_email_delivery_route.py
+++ b/backend/tests/test_notification_email_delivery_route.py
@@ -4,6 +4,7 @@ import importlib
 from dataclasses import dataclass
 from datetime import date
 from types import SimpleNamespace
+from typing import Any
 from uuid import UUID
 
 
@@ -99,6 +100,7 @@ class _FakeSender:
 
 def _settings(**overrides: object) -> SimpleNamespace:
     values = {
+        "app_env": "test",
         "notification_email_delivery_enabled": True,
         "notification_email_sender": "sender@example.test",
         "notification_email_batch_size": 25,
@@ -134,10 +136,22 @@ def _delivery_record() -> _DeliveryRecord:
     )
 
 
-def test_deliver_notification_emails_disabled_does_not_prepare_or_send() -> None:
+def _capture_metrics(monkeypatch) -> list[dict[str, Any]]:
+    delivery = _delivery_module()
+    emitted: list[dict[str, Any]] = []
+
+    def _emit(**kwargs: Any) -> None:
+        emitted.append(kwargs)
+
+    monkeypatch.setattr(delivery, "emit_emf_metrics", _emit, raising=False)
+    return emitted
+
+
+def test_deliver_notification_emails_disabled_does_not_prepare_or_send(monkeypatch) -> None:
     delivery = _delivery_module()
     db = _FakeDb([_delivery_record()])
     sender = _FakeSender()
+    emitted = _capture_metrics(monkeypatch)
 
     payload = delivery.deliver_notification_emails(
         _event(),
@@ -155,26 +169,47 @@ def test_deliver_notification_emails_disabled_does_not_prepare_or_send() -> None
         "attempted_count": 0,
         "sent_count": 0,
         "failed_count": 0,
+        "skipped_count": 0,
+        "retry_exhausted_count": 0,
     }
+    assert emitted == [
+        {
+            "namespace": "LeaseFlow/NotificationEmailDelivery",
+            "environment": "test",
+            "service": "backend",
+            "operation": "deliver_notification_emails",
+            "result": "disabled",
+            "metrics": {
+                "candidate_count": 0,
+                "created_delivery_count": 0,
+                "attempted_count": 0,
+                "sent_count": 0,
+                "failed_count": 0,
+                "skipped_count": 0,
+                "retry_exhausted_count": 0,
+            },
+        }
+    ]
     assert db.prepare_calls == []
     assert sender.sent == []
 
 
-def test_deliver_notification_emails_sends_pending_delivery_and_marks_success() -> None:
+def test_deliver_notification_emails_sends_pending_delivery_and_marks_success(monkeypatch) -> None:
     delivery = _delivery_module()
     record = _delivery_record()
-    db = _FakeDb([record])
+    db = _FakeDb([record, _delivery_record()])
     sender = _FakeSender()
+    emitted = _capture_metrics(monkeypatch)
 
     payload = delivery.deliver_notification_emails(
         _event(),
         db,
-        _settings(),
+        _settings(notification_email_batch_size=1),
         sender=sender,
     )
 
     assert db.prepare_calls == ["tenant-auth"]
-    assert db.list_calls == [("tenant-auth", 3, 25)]
+    assert db.list_calls == [("tenant-auth", 3, 1)]
     assert sender.sent == [
         (
             "sender@example.test",
@@ -188,20 +223,44 @@ def test_deliver_notification_emails_sends_pending_delivery_and_marks_success() 
     assert payload == {
         "enabled": True,
         "tenant_id": "tenant-auth",
-        "candidate_count": 1,
-        "created_count": 1,
+        "candidate_count": 2,
+        "created_count": 2,
         "duplicate_count": 0,
         "attempted_count": 1,
         "sent_count": 1,
         "failed_count": 0,
+        "skipped_count": 1,
+        "retry_exhausted_count": 0,
     }
+    assert emitted == [
+        {
+            "namespace": "LeaseFlow/NotificationEmailDelivery",
+            "environment": "test",
+            "service": "backend",
+            "operation": "deliver_notification_emails",
+            "result": "completed",
+            "metrics": {
+                "candidate_count": 2,
+                "created_delivery_count": 2,
+                "attempted_count": 1,
+                "sent_count": 1,
+                "failed_count": 0,
+                "skipped_count": 1,
+                "retry_exhausted_count": 0,
+            },
+        }
+    ]
 
 
-def test_deliver_notification_emails_marks_sanitized_failure_without_leaking_payload() -> None:
+def test_deliver_notification_emails_marks_sanitized_failure_without_leaking_payload(
+    monkeypatch,
+) -> None:
     delivery = _delivery_module()
     record = _delivery_record()
+    record.attempt_count = 2
     db = _FakeDb([record])
     sender = _FakeSender(fail_code="smtp_auth_failed")
+    emitted = _capture_metrics(monkeypatch)
 
     payload = delivery.deliver_notification_emails(
         _event(),
@@ -221,14 +280,43 @@ def test_deliver_notification_emails_marks_sanitized_failure_without_leaking_pay
         "attempted_count": 1,
         "sent_count": 0,
         "failed_count": 1,
+        "skipped_count": 0,
+        "retry_exhausted_count": 1,
     }
-    assert "recipient@example.test" not in str(payload)
+    assert emitted == [
+        {
+            "namespace": "LeaseFlow/NotificationEmailDelivery",
+            "environment": "test",
+            "service": "backend",
+            "operation": "deliver_notification_emails",
+            "result": "completed_with_failures",
+            "metrics": {
+                "candidate_count": 1,
+                "created_delivery_count": 1,
+                "attempted_count": 1,
+                "sent_count": 0,
+                "failed_count": 1,
+                "skipped_count": 0,
+                "retry_exhausted_count": 1,
+            },
+        }
+    ]
+    emitted_text = str(emitted)
+    assert "tenant-auth" not in emitted_text
+    assert "recipient@example.test" not in emitted_text
+    assert "cccccccc-cccc-cccc-cccc-cccccccccccc" not in emitted_text
+    assert "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" not in emitted_text
+    assert "Rent due soon" not in emitted_text
+    assert "Rent is due in 2 days." not in emitted_text
 
 
-def test_deliver_notification_emails_defaults_to_all_tenants_when_tenant_missing() -> None:
+def test_deliver_notification_emails_defaults_to_all_tenants_when_tenant_missing(
+    monkeypatch,
+) -> None:
     delivery = _delivery_module()
     record = _delivery_record()
     db = _FakeDb([record])
+    _capture_metrics(monkeypatch)
 
     payload = delivery.deliver_notification_emails(
         _event(tenant_id=None),

--- a/docs/ses-delivery-monitoring-alarms-cost-controls.md
+++ b/docs/ses-delivery-monitoring-alarms-cost-controls.md
@@ -23,8 +23,9 @@ automation.
   `docs/notification-suppression-unsubscribe-model.md`, not implemented.
 - Production rollout hardening is planned in
   `docs/ses-production-delivery-hardening.md`.
-- No SES delivery-specific custom metrics, delivery alarms, delivery dashboard,
-  or AWS Budgets resources exist yet.
+- SES delivery worker custom metrics now exist for normal internal delivery
+  runs. Delivery alarms, delivery dashboard, and AWS Budgets resources do not
+  exist yet.
 
 ## Future Application Metrics
 
@@ -32,6 +33,10 @@ LeaseFlow-specific delivery visibility should use CloudWatch custom metrics
 emitted from backend logs in an Embedded Metric Format style. These metrics
 should be aggregate operational counters, not recipient- or tenant-identifying
 records.
+
+Implemented delivery worker metrics use the namespace
+`LeaseFlow/NotificationEmailDelivery` and the dimension set `environment`,
+`service`, `operation`, and `result`.
 
 Allowed low-cardinality dimensions:
 
@@ -50,7 +55,7 @@ Forbidden metric dimensions:
 - message body or notification content
 - request ID or other high-cardinality per-run identifiers
 
-The delivery worker should eventually emit these aggregate counters:
+The delivery worker emits these aggregate counters:
 
 - `candidate_count`
 - `created_delivery_count`
@@ -134,9 +139,9 @@ against the existing private SES SMTP endpoint direction.
 
 ### Emit SES Delivery CloudWatch Custom Metrics
 
-Add backend aggregate EMF-style metrics for the delivery worker and future
-bounce/complaint processor. Out of scope: recipient-level dimensions, tenant
-dimensions, Terraform alarms, or dashboard resources.
+Completed for the internal delivery worker. Future bounce/complaint processor
+metrics remain out of scope. Recipient-level dimensions, tenant dimensions,
+Terraform alarms, and dashboard resources remain out of scope.
 
 ### Add SES Delivery CloudWatch Alarms
 


### PR DESCRIPTION
## What changed and why

Adds backend-only CloudWatch Embedded Metric Format style metrics for the internal SES notification email delivery worker. The worker now emits aggregate delivery counters for normal runs and exposes `skipped_count` and `retry_exhausted_count` in its safe internal response payload.

## Assumptions

- Metric emission uses stdout log events, not `cloudwatch:PutMetricData`.
- This ticket does not add Terraform alarms, dashboards, budgets, AWS resources, frontend behavior, or SES behavior changes.
- Bounce/complaint processor metrics remain future work.

## Security validation

- EMF dimensions are limited to `environment`, `service`, `operation`, and `result`.
- Metrics exclude tenant IDs, recipient emails, contact IDs, notification IDs, message content, JWTs, SMTP credentials, SSM values, DB endpoints, and raw provider responses.
- Delivery remains internal-only; no browser-triggered scan, retry, or delivery path was added.

## Cost validation

- No AWS resources were added.
- Metric design avoids high-cardinality dimensions to reduce custom metric cost risk.

## Validation

- `python -m ruff format --check src tests migrations --no-cache`
- `python -m ruff check src tests migrations --no-cache`
- `python -m pytest -q`
- `git diff --check`
