### PR TITLE
docs: clarify local wsl postgres workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ npm ci --ignore-scripts
 npm run dev
 ```
 
+## Local Development Modes
+
+Use the mode that matches what you are validating:
+
+| Mode | What runs locally | What it uses | Use for |
+| --- | --- | --- | --- |
+| Backend + WSL PostgreSQL | Backend tests, Alembic migrations, DB integration tests, and local Lambda handler invokes | PostgreSQL running in WSL through `backend/.env.local` | Everyday backend and database development |
+| Frontend local dev | Vite dev server at `http://localhost:5173` | The AWS API Gateway and Cognito Hosted UI configured in `frontend/.env.local` | Browser UI work against the deployed dev stack |
+| Full local browser stack | Not implemented | Not applicable | Would require a separate local HTTP API/auth path |
+
+The browser frontend does not automatically use the WSL PostgreSQL database.
+`VITE_API_BASE_URL` controls which API the browser calls. Today that is the
+deployed dev API for the real frontend slice.
+
 ## Current MVP Status
 
 Implemented now:
@@ -102,11 +116,18 @@ For everyday backend and database development in WSL, use the local PostgreSQL
 workflow in `backend/README.md` instead of keeping the AWS dev RDS instance
 running.
 
-Migration command:
+Useful WSL PostgreSQL targets from the repo root:
 
 ```bash
-make migrate
+make migrate-local
+make db-check-local
+make test-local
+make test-integration-local
+make invoke-local-health
 ```
+
+Use `make invoke-local-*` targets for lightweight local Lambda handler checks.
+These commands do not start a local HTTP API server for the browser frontend.
 
 ## Infrastructure Layout
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -42,7 +42,11 @@ python -m pip install -e ".[dev]"
 
 ## Local PostgreSQL in WSL
 
-For everyday backend development, prefer a local PostgreSQL instance in WSL instead of keeping the AWS dev RDS instance running.
+For everyday backend and database development, prefer a local PostgreSQL
+instance in WSL instead of keeping the AWS dev RDS instance running.
+
+This mode is for backend tests, Alembic migrations, DB integration tests, and
+local Lambda handler invokes. It is not a full local browser stack.
 
 Why:
 
@@ -120,9 +124,13 @@ Important:
   `.venv/Scripts/activate`.
 - If `.env.local` was created from Windows tools, normalize line endings with
   `sed -i 's/\r$//' .env.local` before sourcing it.
-- This local PostgreSQL path is for backend and DB development only. It does
-  not replace Cognito Hosted UI, API Gateway, or browser CORS validation in
-  AWS.
+- This local PostgreSQL path is for backend and DB development only. It powers
+  local tests, migrations, integration tests, and `scripts/invoke_local.py`.
+- It does not replace Cognito Hosted UI, API Gateway, browser CORS validation,
+  hosted frontend smoke, or deployed AWS API validation.
+- The real React/Vite frontend calls whatever `VITE_API_BASE_URL` points to.
+  It does not use this WSL database unless a separate local HTTP API/auth path
+  is implemented later.
 
 If you are working from the repo root in WSL with the backend virtual
 environment already activated, you can also use:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,6 +6,10 @@ It is local-first and targets the deployed dev API directly from the browser.
 It is separate from `demo-client`, which remains a local portfolio/operator
 tool.
 
+Local frontend development starts only the Vite browser app. It still uses the
+API and Cognito Hosted UI values from `frontend/.env.local`; it does not
+automatically use a PostgreSQL database running in WSL.
+
 ## What it includes
 
 - Cognito Hosted UI sign in and sign out
@@ -199,6 +203,21 @@ npm run dev
 ```
 
 Then open `http://localhost:5173`.
+
+## Local frontend API boundary
+
+`npm run dev` starts the browser frontend only. The browser calls the API from
+`VITE_API_BASE_URL` and signs in through `VITE_COGNITO_HOSTED_UI_BASE_URL` with
+`VITE_COGNITO_CLIENT_ID`.
+
+For the current MVP, local Vite development is expected to target the deployed
+dev API Gateway and Cognito Hosted UI. Backend and database development can use
+WSL PostgreSQL through `backend/README.md`, but that path is exercised through
+backend tests, Alembic, and local Lambda handler invokes, not through the
+browser frontend.
+
+A full local browser stack would require a separate local HTTP API and local
+auth strategy. That is not implemented in this repository.
 
 ## Hosted dev deploy
 


### PR DESCRIPTION
## What changed and why

Clarifies the local development modes so WSL PostgreSQL backend work is not confused with the AWS-backed browser frontend flow.

## Assumptions

- WSL PostgreSQL remains the preferred everyday backend/DB development path.
- Local Vite frontend development still targets configured AWS Cognito/API values.
- A full local browser stack is not implemented.

## Security validation

- Docs do not suggest trusting browser-provided tenant context.
- Docs do not suggest making RDS public.
- No secrets, JWTs, tenant IDs, SSM values, DB endpoints, or `.env.local` contents were added.

## Cost validation

- No AWS, Terraform, or runtime changes.
- Docs reinforce using local PostgreSQL to avoid keeping AWS dev RDS running unnecessarily.

## Validation

- `git diff --check`
