### PR TITLE
feat: add ses delivery cloudwatch alarms

### DIFF
--- a/docs/ses-delivery-monitoring-alarms-cost-controls.md
+++ b/docs/ses-delivery-monitoring-alarms-cost-controls.md
@@ -5,9 +5,9 @@
 This document defines the future monitoring, alarm, and cost-control direction
 for LeaseFlow SES notification delivery.
 
-This is a planning document only. It does not add Terraform alarms, CloudWatch
-dashboards, backend metrics, AWS Budgets, SES production readiness, or cost
-automation.
+This document records the current monitoring implementation and remaining
+planning boundaries. It does not add CloudWatch dashboards, AWS Budgets, SES
+production readiness, or cost automation.
 
 ## Current State
 
@@ -24,8 +24,10 @@ automation.
 - Production rollout hardening is planned in
   `docs/ses-production-delivery-hardening.md`.
 - SES delivery worker custom metrics now exist for normal internal delivery
-  runs. Delivery alarms, delivery dashboard, and AWS Budgets resources do not
-  exist yet.
+  runs.
+- Terraform-managed dev alarms now cover delivery failures, retry exhaustion,
+  and a conservative attempted-send volume boundary. Delivery dashboard and AWS
+  Budgets resources do not exist yet.
 
 ## Future Application Metrics
 
@@ -79,15 +81,27 @@ application metrics once production access and a production sending identity are
 ready. SES native metrics are useful for account or identity reputation signals,
 but they do not replace LeaseFlow worker-specific counters.
 
-## Future Alarm Boundaries
+## Alarm Boundaries
 
-Alarm thresholds below are planning targets, not implemented resources.
+Implemented dev delivery alarms use the `LeaseFlow/NotificationEmailDelivery`
+namespace with the dimensions `environment`, `service`, `operation`, and
+`result`.
+
+Implemented delivery health alarms:
+
+- `failed_count` greater than or equal to `1` for
+  `result=completed_with_failures` over a five-minute period.
+- `retry_exhausted_count` greater than or equal to `1` for
+  `result=completed_with_failures` over a five-minute period.
+- `attempted_count` greater than `100` by default for `result=completed` over a
+  one-hour period as a dev send-volume boundary.
+
+Remaining alarm thresholds below are planning targets, not implemented
+resources.
 
 Delivery health alarms:
 
 - delivery worker invocation or processing error count greater than zero
-- sustained `failed_count` greater than zero
-- `retry_exhausted_count` greater than zero
 - sudden drop to zero sends when candidates and enabled contacts exist
 
 Provider feedback review alarms:
@@ -145,9 +159,10 @@ Terraform alarms, and dashboard resources remain out of scope.
 
 ### Add SES Delivery CloudWatch Alarms
 
-Add Terraform alarms for delivery failures, retry exhaustion, bounce/complaint
-signals, and send-volume anomaly boundaries. Out of scope: browser controls,
-recipient-level alarm data, or production-readiness claims.
+Completed for dev delivery failures, retry exhaustion, and the attempted-send
+volume boundary. Future work remains for bounce/complaint signals, production
+reputation alarms, and any production-specific volume thresholds. Out of scope:
+browser controls, recipient-level alarm data, or production-readiness claims.
 
 ### Add SES Delivery Dashboard
 

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -160,14 +160,16 @@ resource "aws_sns_topic_subscription" "baseline_alarm_email" {
 module "cloudwatch_alarms" {
   source = "../../modules/cloudwatch_alarms"
 
-  name_prefix          = local.name_prefix
-  lambda_function_name = module.lambda_backend.function_name
-  api_id               = module.api_http.api_id
-  api_stage_name       = var.environment
-  scheduler_group_name = "default"
-  scheduler_enabled    = var.reminder_scan_enabled
-  alarm_action_arns    = [aws_sns_topic.baseline_alarm_notifications.arn]
-  tags                 = local.common_tags
+  name_prefix                                                 = local.name_prefix
+  lambda_function_name                                        = module.lambda_backend.function_name
+  api_id                                                      = module.api_http.api_id
+  api_stage_name                                              = var.environment
+  environment                                                 = var.environment
+  scheduler_group_name                                        = "default"
+  scheduler_enabled                                           = var.reminder_scan_enabled
+  alarm_action_arns                                           = [aws_sns_topic.baseline_alarm_notifications.arn]
+  notification_email_delivery_attempted_count_alarm_threshold = var.notification_email_delivery_attempted_count_alarm_threshold
+  tags                                                        = local.common_tags
 }
 
 module "api_http" {

--- a/infra/environments/dev/outputs.tf
+++ b/infra/environments/dev/outputs.tf
@@ -64,7 +64,10 @@ output "baseline_alarm_names" {
     module.cloudwatch_alarms.lambda_errors_alarm_name,
     module.cloudwatch_alarms.lambda_throttles_alarm_name,
     module.cloudwatch_alarms.api_gateway_5xx_alarm_name,
-    module.cloudwatch_alarms.scheduler_target_errors_alarm_name
+    module.cloudwatch_alarms.scheduler_target_errors_alarm_name,
+    module.cloudwatch_alarms.notification_email_delivery_failures_alarm_name,
+    module.cloudwatch_alarms.notification_email_delivery_retry_exhausted_alarm_name,
+    module.cloudwatch_alarms.notification_email_delivery_send_volume_high_alarm_name
   ])
 }
 

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -214,6 +214,17 @@ variable "notification_email_max_attempts" {
   default     = 3
 }
 
+variable "notification_email_delivery_attempted_count_alarm_threshold" {
+  type        = number
+  description = "Hourly attempted_count threshold for the dev notification email delivery send-volume alarm."
+  default     = 100
+
+  validation {
+    condition     = var.notification_email_delivery_attempted_count_alarm_threshold > 0
+    error_message = "notification_email_delivery_attempted_count_alarm_threshold must be greater than zero."
+  }
+}
+
 variable "tags" {
   type        = map(string)
   description = "Extra tags."

--- a/infra/modules/cloudwatch_alarms/main.tf
+++ b/infra/modules/cloudwatch_alarms/main.tf
@@ -84,3 +84,81 @@ resource "aws_cloudwatch_metric_alarm" "scheduler_target_errors" {
 
   tags = var.tags
 }
+
+resource "aws_cloudwatch_metric_alarm" "notification_email_delivery_failures" {
+  count = var.notification_email_delivery_alarms_enabled ? 1 : 0
+
+  alarm_name          = "${var.name_prefix}-notification-email-delivery-failures"
+  alarm_description   = "Alarm for internal notification email delivery failures."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = 1
+  period              = 300
+  namespace           = "LeaseFlow/NotificationEmailDelivery"
+  metric_name         = "failed_count"
+  statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_action_arns
+
+  dimensions = {
+    environment = var.environment
+    service     = "backend"
+    operation   = "deliver_notification_emails"
+    result      = "completed_with_failures"
+  }
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "notification_email_delivery_retry_exhausted" {
+  count = var.notification_email_delivery_alarms_enabled ? 1 : 0
+
+  alarm_name          = "${var.name_prefix}-notification-email-delivery-retry-exhausted"
+  alarm_description   = "Alarm for internal notification email deliveries that exhaust retry attempts."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = 1
+  period              = 300
+  namespace           = "LeaseFlow/NotificationEmailDelivery"
+  metric_name         = "retry_exhausted_count"
+  statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_action_arns
+
+  dimensions = {
+    environment = var.environment
+    service     = "backend"
+    operation   = "deliver_notification_emails"
+    result      = "completed_with_failures"
+  }
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "notification_email_delivery_send_volume_high" {
+  count = var.notification_email_delivery_alarms_enabled ? 1 : 0
+
+  alarm_name          = "${var.name_prefix}-notification-email-delivery-send-volume-high"
+  alarm_description   = "Alarm for unexpectedly high internal notification email delivery attempts."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = var.notification_email_delivery_attempted_count_alarm_threshold
+  period              = 3600
+  namespace           = "LeaseFlow/NotificationEmailDelivery"
+  metric_name         = "attempted_count"
+  statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_action_arns
+
+  dimensions = {
+    environment = var.environment
+    service     = "backend"
+    operation   = "deliver_notification_emails"
+    result      = "completed"
+  }
+
+  tags = var.tags
+}

--- a/infra/modules/cloudwatch_alarms/outputs.tf
+++ b/infra/modules/cloudwatch_alarms/outputs.tf
@@ -37,3 +37,33 @@ output "scheduler_target_errors_alarm_arn" {
   description = "Reminder scheduler target errors alarm ARN."
   value       = try(aws_cloudwatch_metric_alarm.scheduler_target_errors[0].arn, null)
 }
+
+output "notification_email_delivery_failures_alarm_name" {
+  description = "Notification email delivery failures alarm name."
+  value       = try(aws_cloudwatch_metric_alarm.notification_email_delivery_failures[0].alarm_name, null)
+}
+
+output "notification_email_delivery_failures_alarm_arn" {
+  description = "Notification email delivery failures alarm ARN."
+  value       = try(aws_cloudwatch_metric_alarm.notification_email_delivery_failures[0].arn, null)
+}
+
+output "notification_email_delivery_retry_exhausted_alarm_name" {
+  description = "Notification email delivery retry exhausted alarm name."
+  value       = try(aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted[0].alarm_name, null)
+}
+
+output "notification_email_delivery_retry_exhausted_alarm_arn" {
+  description = "Notification email delivery retry exhausted alarm ARN."
+  value       = try(aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted[0].arn, null)
+}
+
+output "notification_email_delivery_send_volume_high_alarm_name" {
+  description = "Notification email delivery send volume high alarm name."
+  value       = try(aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].alarm_name, null)
+}
+
+output "notification_email_delivery_send_volume_high_alarm_arn" {
+  description = "Notification email delivery send volume high alarm ARN."
+  value       = try(aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].arn, null)
+}

--- a/infra/modules/cloudwatch_alarms/tests/defaults.tftest.hcl
+++ b/infra/modules/cloudwatch_alarms/tests/defaults.tftest.hcl
@@ -5,6 +5,7 @@ variables {
   lambda_function_name = "leaseflow-dev-backend"
   api_id               = "api123456"
   api_stage_name       = "dev"
+  environment          = "dev"
   scheduler_group_name = "default"
   scheduler_enabled    = true
   tags = {
@@ -104,6 +105,221 @@ run "creates_baseline_alarm_resources" {
     condition     = aws_cloudwatch_metric_alarm.scheduler_target_errors[0].period == 300
     error_message = "Scheduler alarm should use a 5-minute period."
   }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.notification_email_delivery_failures) == 1
+    error_message = "Notification email delivery failures alarm should be created by default."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_failures[0].alarm_name == "leaseflow-dev-notification-email-delivery-failures"
+    error_message = "Notification email delivery failures alarm should use the expected name."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_failures[0].namespace == "LeaseFlow/NotificationEmailDelivery"
+    error_message = "Notification email delivery failures alarm should use the delivery namespace."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_failures[0].metric_name == "failed_count"
+    error_message = "Notification email delivery failures alarm should track failed_count."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_failures[0].dimensions.environment == "dev"
+    error_message = "Notification email delivery failures alarm should scope to the environment dimension."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_failures[0].dimensions.service == "backend"
+    error_message = "Notification email delivery failures alarm should scope to the backend service dimension."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_failures[0].dimensions.operation == "deliver_notification_emails"
+    error_message = "Notification email delivery failures alarm should scope to the delivery operation dimension."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_failures[0].dimensions.result == "completed_with_failures"
+    error_message = "Notification email delivery failures alarm should scope to failed delivery runs."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_failures[0].comparison_operator == "GreaterThanOrEqualToThreshold"
+    error_message = "Notification email delivery failures alarm should trigger at or above the threshold."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_failures[0].threshold == 1
+    error_message = "Notification email delivery failures alarm should trigger on one failed delivery."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_failures[0].period == 300
+    error_message = "Notification email delivery failures alarm should use a five-minute period."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_failures[0].evaluation_periods == 1
+    error_message = "Notification email delivery failures alarm should evaluate one period."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_failures[0].datapoints_to_alarm == 1
+    error_message = "Notification email delivery failures alarm should require one breaching datapoint."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_failures[0].statistic == "Sum"
+    error_message = "Notification email delivery failures alarm should sum metric values."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_failures[0].treat_missing_data == "notBreaching"
+    error_message = "Notification email delivery failures alarm should treat missing data as not breaching."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted[0].alarm_name == "leaseflow-dev-notification-email-delivery-retry-exhausted"
+    error_message = "Notification email delivery retry exhausted alarm should use the expected name."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted[0].namespace == "LeaseFlow/NotificationEmailDelivery"
+    error_message = "Notification email delivery retry exhausted alarm should use the delivery namespace."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted[0].metric_name == "retry_exhausted_count"
+    error_message = "Notification email delivery retry exhausted alarm should track retry_exhausted_count."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted[0].dimensions.environment == "dev"
+    error_message = "Notification email delivery retry exhausted alarm should scope to the environment dimension."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted[0].dimensions.service == "backend"
+    error_message = "Notification email delivery retry exhausted alarm should scope to the backend service dimension."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted[0].dimensions.operation == "deliver_notification_emails"
+    error_message = "Notification email delivery retry exhausted alarm should scope to the delivery operation dimension."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted[0].dimensions.result == "completed_with_failures"
+    error_message = "Notification email delivery retry exhausted alarm should scope to failed delivery runs."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted[0].comparison_operator == "GreaterThanOrEqualToThreshold"
+    error_message = "Notification email delivery retry exhausted alarm should trigger at or above the threshold."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted[0].threshold == 1
+    error_message = "Notification email delivery retry exhausted alarm should trigger on one exhausted retry."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted[0].period == 300
+    error_message = "Notification email delivery retry exhausted alarm should use a five-minute period."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted[0].evaluation_periods == 1
+    error_message = "Notification email delivery retry exhausted alarm should evaluate one period."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted[0].datapoints_to_alarm == 1
+    error_message = "Notification email delivery retry exhausted alarm should require one breaching datapoint."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted[0].statistic == "Sum"
+    error_message = "Notification email delivery retry exhausted alarm should sum metric values."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted[0].treat_missing_data == "notBreaching"
+    error_message = "Notification email delivery retry exhausted alarm should treat missing data as not breaching."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].alarm_name == "leaseflow-dev-notification-email-delivery-send-volume-high"
+    error_message = "Notification email delivery send volume alarm should use the expected name."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].namespace == "LeaseFlow/NotificationEmailDelivery"
+    error_message = "Notification email delivery send volume alarm should use the delivery namespace."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].metric_name == "attempted_count"
+    error_message = "Notification email delivery send volume alarm should track attempted_count."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].dimensions.environment == "dev"
+    error_message = "Notification email delivery send volume alarm should scope to the environment dimension."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].dimensions.service == "backend"
+    error_message = "Notification email delivery send volume alarm should scope to the backend service dimension."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].dimensions.operation == "deliver_notification_emails"
+    error_message = "Notification email delivery send volume alarm should scope to the delivery operation dimension."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].dimensions.result == "completed"
+    error_message = "Notification email delivery send volume alarm should scope to completed delivery runs."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].comparison_operator == "GreaterThanThreshold"
+    error_message = "Notification email delivery send volume alarm should trigger above the threshold."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].threshold == 100
+    error_message = "Notification email delivery send volume alarm should use the default threshold."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].period == 3600
+    error_message = "Notification email delivery send volume alarm should use a one-hour period."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].evaluation_periods == 1
+    error_message = "Notification email delivery send volume alarm should evaluate one period."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].datapoints_to_alarm == 1
+    error_message = "Notification email delivery send volume alarm should require one breaching datapoint."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].statistic == "Sum"
+    error_message = "Notification email delivery send volume alarm should sum metric values."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].treat_missing_data == "notBreaching"
+    error_message = "Notification email delivery send volume alarm should treat missing data as not breaching."
+  }
 }
 
 run "attaches_alarm_actions_when_supplied" {
@@ -146,6 +362,30 @@ run "attaches_alarm_actions_when_supplied" {
     )
     error_message = "Scheduler target errors alarm should publish to the supplied action ARN."
   }
+
+  assert {
+    condition = length(aws_cloudwatch_metric_alarm.notification_email_delivery_failures[0].alarm_actions) == 1 && contains(
+      aws_cloudwatch_metric_alarm.notification_email_delivery_failures[0].alarm_actions,
+      "arn:aws:sns:eu-north-1:123456789012:leaseflow-dev-baseline-alarm-notifications"
+    )
+    error_message = "Notification email delivery failures alarm should publish to the supplied action ARN."
+  }
+
+  assert {
+    condition = length(aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted[0].alarm_actions) == 1 && contains(
+      aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted[0].alarm_actions,
+      "arn:aws:sns:eu-north-1:123456789012:leaseflow-dev-baseline-alarm-notifications"
+    )
+    error_message = "Notification email delivery retry exhausted alarm should publish to the supplied action ARN."
+  }
+
+  assert {
+    condition = length(aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].alarm_actions) == 1 && contains(
+      aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].alarm_actions,
+      "arn:aws:sns:eu-north-1:123456789012:leaseflow-dev-baseline-alarm-notifications"
+    )
+    error_message = "Notification email delivery send volume alarm should publish to the supplied action ARN."
+  }
 }
 
 run "omits_scheduler_alarm_when_disabled" {
@@ -158,5 +398,41 @@ run "omits_scheduler_alarm_when_disabled" {
   assert {
     condition     = length(aws_cloudwatch_metric_alarm.scheduler_target_errors) == 0
     error_message = "Scheduler alarm should be omitted when the scheduler is disabled."
+  }
+}
+
+run "omits_notification_email_delivery_alarms_when_disabled" {
+  command = plan
+
+  variables {
+    notification_email_delivery_alarms_enabled = false
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.notification_email_delivery_failures) == 0
+    error_message = "Notification email delivery failures alarm should be omitted when disabled."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.notification_email_delivery_retry_exhausted) == 0
+    error_message = "Notification email delivery retry exhausted alarm should be omitted when disabled."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high) == 0
+    error_message = "Notification email delivery send volume alarm should be omitted when disabled."
+  }
+}
+
+run "uses_configured_notification_email_delivery_attempt_threshold" {
+  command = plan
+
+  variables {
+    notification_email_delivery_attempted_count_alarm_threshold = 25
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.notification_email_delivery_send_volume_high[0].threshold == 25
+    error_message = "Notification email delivery send volume alarm should use the configured threshold."
   }
 }

--- a/infra/modules/cloudwatch_alarms/variables.tf
+++ b/infra/modules/cloudwatch_alarms/variables.tf
@@ -18,6 +18,11 @@ variable "api_stage_name" {
   type        = string
 }
 
+variable "environment" {
+  description = "Deployment environment dimension used by LeaseFlow custom metric alarms."
+  type        = string
+}
+
 variable "scheduler_group_name" {
   description = "EventBridge Scheduler schedule group name."
   type        = string
@@ -29,9 +34,26 @@ variable "scheduler_enabled" {
 }
 
 variable "alarm_action_arns" {
-  description = "Alarm action ARNs for baseline CloudWatch alarms."
+  description = "Alarm action ARNs for CloudWatch alarms."
   type        = list(string)
   default     = []
+}
+
+variable "notification_email_delivery_alarms_enabled" {
+  description = "Whether notification email delivery custom metric alarms should be created."
+  type        = bool
+  default     = true
+}
+
+variable "notification_email_delivery_attempted_count_alarm_threshold" {
+  description = "Hourly attempted_count threshold for the notification email delivery send-volume alarm."
+  type        = number
+  default     = 100
+
+  validation {
+    condition     = var.notification_email_delivery_attempted_count_alarm_threshold > 0
+    error_message = "notification_email_delivery_attempted_count_alarm_threshold must be greater than zero."
+  }
 }
 
 variable "tags" {


### PR DESCRIPTION
## What changed

Adds Terraform-managed dev CloudWatch alarms for SES notification email delivery metrics emitted by the internal delivery worker:
- delivery failures via `failed_count`
- retry exhaustion via `retry_exhausted_count`
- high attempted-send volume via `attempted_count`

The dev environment now wires the alarm module with the environment dimension and includes the new alarm names in the existing safe `baseline_alarm_names` output. Monitoring docs were updated to mark these dev alarms as implemented while keeping dashboards, budgets, bounce/complaint alarms, and production reputation alarms as follow-ups.

## Assumptions

- #188 EMF metrics are available before this Terraform is applied.
- `attempted_count > 100/hour` is an acceptable conservative dev safety boundary.
- Bounce/complaint metrics and production thresholds remain separate work.

## Security validation

- Alarm dimensions use only low-cardinality safe values: `environment`, `service`, `operation`, and `result`.
- No tenant IDs, recipient emails, contact IDs, notification IDs, message bodies, raw provider responses, credentials, SSM values, JWTs, or auth headers are included in Terraform, docs, outputs, or tests.
- Tenant isolation behavior is unchanged; this PR adds monitoring resources only.

## Cost validation

- Adds three CloudWatch alarms in dev using the existing SNS action path.
- No NAT Gateway, SES resource, dashboard, AWS Budgets resource, RDS change, backend change, or frontend change is added.

## Validation

- `terraform fmt -recursive infra`
- `cd infra/modules/cloudwatch_alarms && terraform init -backend=false && terraform test`
- `cd infra/environments/dev && terraform init -backend=false && terraform validate`
- `git diff --check`

## Remaining risks / TODOs

- Apply has not been run in AWS in this branch.
- Bounce/complaint alarms, production reputation alarms, dashboards, and cost controls remain follow-up work.
