### PR TITLE
feat: add ses delivery cloudwatch dashboard

### DIFF
--- a/docs/ses-delivery-monitoring-alarms-cost-controls.md
+++ b/docs/ses-delivery-monitoring-alarms-cost-controls.md
@@ -26,8 +26,12 @@ production readiness, or cost automation.
 - SES delivery worker custom metrics now exist for normal internal delivery
   runs.
 - Terraform-managed dev alarms now cover delivery failures, retry exhaustion,
-  and a conservative attempted-send volume boundary. Delivery dashboard and AWS
-  Budgets resources do not exist yet.
+  and a conservative attempted-send volume boundary.
+- A Terraform-managed dev CloudWatch dashboard now shows aggregate delivery
+  worker health, send-volume, failure, and future feedback/suppression metric
+  panels. Dashboard widgets can show no data until delivery is enabled and the
+  relevant metrics are emitted.
+- AWS Budgets resources do not exist yet.
 
 ## Future Application Metrics
 
@@ -122,6 +126,26 @@ descriptions, dimensions, and notifications must not contain recipient data,
 tenant IDs, contact IDs, notification IDs, message bodies, raw provider
 responses, SMTP credentials, or SSM values.
 
+## Dashboard
+
+The dev CloudWatch dashboard uses the same
+`LeaseFlow/NotificationEmailDelivery` namespace and the low-cardinality
+dimensions `environment`, `service`, `operation`, and `result`.
+
+Implemented dashboard panels show:
+
+- delivery run volume for candidates, created deliveries, attempted sends, sent
+  sends, and skipped candidates
+- failure health for failed sends and retry exhaustion
+- worker result categories for completed, completed-with-failures, and disabled
+  runs
+- future feedback and suppression counts for bounces, complaints, and
+  suppressed contacts
+
+Future feedback and suppression widgets are intentionally present before those
+processors emit metrics. They should render as no-data until the future
+bounce/complaint and suppression implementations exist.
+
 ## Cost Controls
 
 Delivery must remain disabled by default until the operator intentionally
@@ -145,6 +169,11 @@ cost alert path for:
 - long-lived interface endpoint cost exposure
 - unusually high CloudWatch Logs or custom metric usage
 
+The dev CloudWatch dashboard adds the normal CloudWatch dashboard monthly cost
+exposure for one dashboard. Keep dashboard count small and aggregate-only; do
+not create tenant-, recipient-, contact-, notification-, or request-specific
+dashboards.
+
 Do not add NAT Gateway by default for email delivery. Any future proposal to
 use NAT for SES access must justify cost, security, and operational tradeoffs
 against the existing private SES SMTP endpoint direction.
@@ -166,8 +195,10 @@ browser controls, recipient-level alarm data, or production-readiness claims.
 
 ### Add SES Delivery Dashboard
 
-Add a CloudWatch dashboard for aggregate delivery health. The dashboard must not
-include recipient, tenant, contact, notification, or message-content details.
+Completed for aggregate dev delivery health. Future dashboard expansion for
+production reputation or bounce/complaint processor-specific views must remain
+aggregate-only and avoid recipient, tenant, contact, notification, or
+message-content details.
 
 ### Add SES And PrivateLink Cost Controls
 

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -172,6 +172,15 @@ module "cloudwatch_alarms" {
   tags                                                        = local.common_tags
 }
 
+module "ses_delivery_dashboard" {
+  source = "../../modules/ses_delivery_dashboard"
+
+  name_prefix = local.name_prefix
+  aws_region  = var.aws_region
+  environment = var.environment
+  tags        = local.common_tags
+}
+
 module "api_http" {
   source = "../../modules/api_http"
 

--- a/infra/environments/dev/outputs.tf
+++ b/infra/environments/dev/outputs.tf
@@ -86,6 +86,11 @@ output "baseline_alarm_email_subscription_configured" {
   value       = length(aws_sns_topic_subscription.baseline_alarm_email) > 0
 }
 
+output "notification_email_delivery_dashboard_name" {
+  description = "CloudWatch dashboard name for aggregate notification email delivery health."
+  value       = module.ses_delivery_dashboard.dashboard_name
+}
+
 output "ses_sender_identity_configured" {
   description = "Whether an optional SES sender identity is configured for future dev email delivery validation."
   value       = module.ses_email_foundation.sender_identity_configured

--- a/infra/modules/ses_delivery_dashboard/.terraform.lock.hcl
+++ b/infra/modules/ses_delivery_dashboard/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.44.0"
+  constraints = "~> 6.37"
+  hashes = [
+    "h1:lJvGaC4YNXk3TIdrd5GCIyV0gxU1WigQIao8rmcpplc=",
+    "zh:0462747d28f6dcd7b1b723bea9da1600526b7cdcf929ed4be54352d74b0746e6",
+    "zh:0c9b7e7b04050360f609ff5700d8a76227fb4ea84dac92b844d82a2013706705",
+    "zh:2877a6854edf237f9d6c66dc928294cbbcf29d3f52577fb8f232d0cfd11d5c0d",
+    "zh:3347b82e222bbfad326b79c408e53a9252b80c6c762f4dd4f4617583394f0a4e",
+    "zh:33997dbe611b5abf49c87a31f29d8f797c97421f67b71fec8aa688799511b758",
+    "zh:5d5c37375c5e776e6e8f95fb8cbd8009258618b9f51c55551a18adc09ef5814a",
+    "zh:67d6bd61c52ca5f4c37c96a76f6820c9f1902e4b83f89faddf9fd7f17ba0b160",
+    "zh:739588639fa30db7084d6939c2eb9b4dd2d7f58dbb5d5b3b2c4bda2a35dcf521",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a953797142df4245bd8f456b9e78690f501a0fff2f58552db4eb2da409cd99e9",
+    "zh:aeb8d616dd34a9f1c5048ed4cdd6d7692db93cd33a468872618d4cd38c4784aa",
+    "zh:dc8420556aca50658247b097de6734259fc3a6012ff1cf96612fca10b3982f9d",
+    "zh:f9083d6d9fb9cbdcd91e38c92f96e67223ecc7ce6d0986bd5eb8e6d52e9aa02b",
+    "zh:f9418aa1e4d29f9026aa6f521e97d085e000902ea929debbbef61135185e3ad4",
+    "zh:fb2494a6c92118055cfb2c114a4fe5c750946a1b0d6be6bf02ab3e37a091fb8b",
+  ]
+}

--- a/infra/modules/ses_delivery_dashboard/main.tf
+++ b/infra/modules/ses_delivery_dashboard/main.tf
@@ -1,0 +1,124 @@
+locals {
+  namespace = "LeaseFlow/NotificationEmailDelivery"
+
+  completed_dimensions = [
+    "environment", var.environment,
+    "service", "backend",
+    "operation", "deliver_notification_emails",
+    "result", "completed",
+  ]
+
+  failed_dimensions = [
+    "environment", var.environment,
+    "service", "backend",
+    "operation", "deliver_notification_emails",
+    "result", "completed_with_failures",
+  ]
+
+  disabled_dimensions = [
+    "environment", var.environment,
+    "service", "backend",
+    "operation", "deliver_notification_emails",
+    "result", "disabled",
+  ]
+}
+
+resource "aws_cloudwatch_dashboard" "notification_email_delivery" {
+  dashboard_name = "${var.name_prefix}-notification-email-delivery"
+
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "text"
+        x      = 0
+        y      = 0
+        width  = 24
+        height = 2
+        properties = {
+          markdown = "# Notification email delivery health\nAggregate LeaseFlow delivery metrics. Widgets can show no data until delivery is enabled and the worker emits metrics."
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 2
+        width  = 12
+        height = 6
+        properties = {
+          title   = "Delivery run volume"
+          view    = "timeSeries"
+          stacked = false
+          region  = var.aws_region
+          stat    = "Sum"
+          period  = 300
+          metrics = [
+            concat([local.namespace, "candidate_count"], local.completed_dimensions, [{ label = "candidates" }]),
+            concat([local.namespace, "created_delivery_count"], local.completed_dimensions, [{ label = "created deliveries" }]),
+            concat([local.namespace, "attempted_count"], local.completed_dimensions, [{ label = "attempted" }]),
+            concat([local.namespace, "sent_count"], local.completed_dimensions, [{ label = "sent" }]),
+            concat([local.namespace, "skipped_count"], local.completed_dimensions, [{ label = "skipped" }]),
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 2
+        width  = 12
+        height = 6
+        properties = {
+          title   = "Failure health"
+          view    = "timeSeries"
+          stacked = false
+          region  = var.aws_region
+          stat    = "Sum"
+          period  = 300
+          metrics = [
+            concat([local.namespace, "failed_count"], local.failed_dimensions, [{ label = "failed" }]),
+            concat([local.namespace, "retry_exhausted_count"], local.failed_dimensions, [{ label = "retry exhausted" }]),
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 8
+        width  = 12
+        height = 6
+        properties = {
+          title   = "Worker result categories"
+          view    = "timeSeries"
+          stacked = false
+          region  = var.aws_region
+          stat    = "SampleCount"
+          period  = 300
+          metrics = [
+            concat([local.namespace, "attempted_count"], local.completed_dimensions, [{ label = "completed runs" }]),
+            concat([local.namespace, "failed_count"], local.failed_dimensions, [{ label = "completed with failures" }]),
+            concat([local.namespace, "attempted_count"], local.disabled_dimensions, [{ label = "disabled runs" }]),
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 8
+        width  = 12
+        height = 6
+        properties = {
+          title   = "Future feedback and suppression metrics"
+          view    = "timeSeries"
+          stacked = false
+          region  = var.aws_region
+          stat    = "Sum"
+          period  = 300
+          metrics = [
+            concat([local.namespace, "bounce_count"], local.completed_dimensions, [{ label = "bounces" }]),
+            concat([local.namespace, "complaint_count"], local.completed_dimensions, [{ label = "complaints" }]),
+            concat([local.namespace, "suppressed_contact_count"], local.completed_dimensions, [{ label = "suppressed contacts" }]),
+          ]
+        }
+      },
+    ]
+  })
+}

--- a/infra/modules/ses_delivery_dashboard/outputs.tf
+++ b/infra/modules/ses_delivery_dashboard/outputs.tf
@@ -1,0 +1,4 @@
+output "dashboard_name" {
+  description = "Notification email delivery dashboard name."
+  value       = aws_cloudwatch_dashboard.notification_email_delivery.dashboard_name
+}

--- a/infra/modules/ses_delivery_dashboard/tests/defaults.tftest.hcl
+++ b/infra/modules/ses_delivery_dashboard/tests/defaults.tftest.hcl
@@ -1,0 +1,91 @@
+mock_provider "aws" {}
+
+variables {
+  name_prefix = "leaseflow-dev"
+  aws_region  = "eu-north-1"
+  environment = "dev"
+  tags = {
+    Project = "leaseflow"
+  }
+}
+
+run "creates_safe_aggregate_delivery_dashboard" {
+  command = plan
+
+  assert {
+    condition     = aws_cloudwatch_dashboard.notification_email_delivery.dashboard_name == "leaseflow-dev-notification-email-delivery"
+    error_message = "Notification email delivery dashboard should use the expected name."
+  }
+
+  assert {
+    condition     = output.dashboard_name == "leaseflow-dev-notification-email-delivery"
+    error_message = "Dashboard name output should expose the safe dashboard name."
+  }
+
+  assert {
+    condition     = strcontains(aws_cloudwatch_dashboard.notification_email_delivery.dashboard_body, "LeaseFlow/NotificationEmailDelivery")
+    error_message = "Dashboard should use the notification email delivery namespace."
+  }
+
+  assert {
+    condition     = strcontains(aws_cloudwatch_dashboard.notification_email_delivery.dashboard_body, "eu-north-1")
+    error_message = "Dashboard should use the configured AWS region for metric widgets."
+  }
+
+  assert {
+    condition = alltrue([
+      for metric_name in [
+        "candidate_count",
+        "created_delivery_count",
+        "attempted_count",
+        "sent_count",
+        "skipped_count",
+        "failed_count",
+        "retry_exhausted_count",
+        "bounce_count",
+        "complaint_count",
+        "suppressed_contact_count"
+      ] :
+      strcontains(aws_cloudwatch_dashboard.notification_email_delivery.dashboard_body, metric_name)
+    ])
+    error_message = "Dashboard should include current and future aggregate delivery metric names."
+  }
+
+  assert {
+    condition = alltrue([
+      for dimension_value in [
+        "environment",
+        "dev",
+        "service",
+        "backend",
+        "operation",
+        "deliver_notification_emails",
+        "result",
+        "completed",
+        "completed_with_failures",
+        "disabled"
+      ] :
+      strcontains(aws_cloudwatch_dashboard.notification_email_delivery.dashboard_body, dimension_value)
+    ])
+    error_message = "Dashboard should use the expected low-cardinality delivery dimensions."
+  }
+
+  assert {
+    condition = alltrue([
+      for forbidden_value in [
+        "tenant_id",
+        "recipient_email",
+        "contact_id",
+        "notification_id",
+        "request_id",
+        "message_body",
+        "credential",
+        "ssm",
+        "db_endpoint",
+        "provider_payload"
+      ] :
+      !strcontains(lower(aws_cloudwatch_dashboard.notification_email_delivery.dashboard_body), forbidden_value)
+    ])
+    error_message = "Dashboard body must not include sensitive or high-cardinality fields."
+  }
+}

--- a/infra/modules/ses_delivery_dashboard/variables.tf
+++ b/infra/modules/ses_delivery_dashboard/variables.tf
@@ -1,0 +1,20 @@
+variable "name_prefix" {
+  description = "Prefix used in dashboard names."
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region used by dashboard metric widgets."
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment dimension used by LeaseFlow custom metrics."
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags applied to dashboard resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/ses_delivery_dashboard/versions.tf
+++ b/infra/modules/ses_delivery_dashboard/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.37"
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Adds a Terraform-managed dev CloudWatch dashboard for aggregate SES notification email delivery health.

The dashboard shows:
- delivery run volume metrics
- failure and retry-exhaustion metrics
- worker result category visibility
- future bounce/complaint/suppression aggregate widgets that will show no data until those processors emit metrics

Also wires the dashboard into the dev environment and adds a safe Terraform output for the dashboard name.

## Assumptions

- Existing #188 EMF metrics are the source for current delivery-worker widgets.
- Future `bounce_count`, `complaint_count`, and `suppressed_contact_count` widgets are allowed now as no-data placeholders.
- The dashboard remains dev-focused and aggregate-only.

## Security validation

- Dashboard dimensions are limited to low-cardinality values: `environment`, `service`, `operation`, and `result`.
- No tenant IDs, recipient emails, contact IDs, notification IDs, request IDs, message bodies, credentials, SSM values, DB endpoints, or provider payload fields are included.
- No browser route, backend delivery behavior, SES behavior, NAT, or RDS change is introduced.

## Cost validation

- Adds one CloudWatch dashboard in dev.
- No new alarms, AWS Budgets, NAT Gateway, public RDS, SES resources, or production-readiness claim.

## Validation

- `terraform fmt -recursive infra`
- `cd infra/modules/ses_delivery_dashboard && terraform init -backend=false && terraform test`
- `cd infra/environments/dev && terraform init -backend=false && terraform validate`
- `git diff --check`

## Remaining risks / TODOs

- Terraform apply has not been run in AWS in this branch.
- Bounce/complaint processors, production reputation views, AWS Budgets, and monitoring evidence remain follow-up work.
