### PR TITLE
feat: add optional dev cost controls

### DIFF
--- a/docs/ses-delivery-monitoring-alarms-cost-controls.md
+++ b/docs/ses-delivery-monitoring-alarms-cost-controls.md
@@ -6,8 +6,8 @@ This document defines the future monitoring, alarm, and cost-control direction
 for LeaseFlow SES notification delivery.
 
 This document records the current monitoring implementation and remaining
-planning boundaries. It does not add CloudWatch dashboards, AWS Budgets, SES
-production readiness, or cost automation.
+planning boundaries. It does not add SES production readiness or automatic cost
+actions.
 
 ## Current State
 
@@ -31,7 +31,8 @@ production readiness, or cost automation.
   worker health, send-volume, failure, and future feedback/suppression metric
   panels. Dashboard widgets can show no data until delivery is enabled and the
   relevant metrics are emitted.
-- AWS Budgets resources do not exist yet.
+- An optional Terraform-managed AWS monthly cost budget is available for paid
+  or long-lived dev environments. It is disabled by default.
 
 ## Future Application Metrics
 
@@ -161,8 +162,23 @@ track:
 - `NewConnections`
 - `ActiveConnections`
 
-Future paid or long-lived environments should use AWS Budgets or an equivalent
-cost alert path for:
+Paid or long-lived environments can enable the optional AWS monthly cost budget
+to alert operators when actual account spend reaches the configured percentage
+of the configured monthly USD amount.
+
+The budget is intentionally coarse-grained. It tracks AWS account cost for the
+environment account rather than tenant, recipient, contact, notification, or
+provider-payload data.
+
+The optional budget supports:
+
+- disabled-by-default cost alerting for short-lived learning stacks
+- a configurable monthly USD limit
+- a configurable actual-spend percentage threshold
+- operator email subscribers configured only in local ignored Terraform inputs
+
+Future paid or long-lived environments should also use AWS Budgets or an
+equivalent cost alert path for:
 
 - total account or environment spend
 - unexpected SES sending volume
@@ -173,6 +189,10 @@ The dev CloudWatch dashboard adds the normal CloudWatch dashboard monthly cost
 exposure for one dashboard. Keep dashboard count small and aggregate-only; do
 not create tenant-, recipient-, contact-, notification-, or request-specific
 dashboards.
+
+The optional SES SMTP interface VPC endpoint remains the primary email-specific
+cost exposure. If enabled, operators must review whether the endpoint is still
+needed after each smoke or long-lived validation window.
 
 Do not add NAT Gateway by default for email delivery. Any future proposal to
 use NAT for SES access must justify cost, security, and operational tradeoffs
@@ -202,9 +222,10 @@ message-content details.
 
 ### Add SES And PrivateLink Cost Controls
 
-Add AWS Budgets or equivalent cost-alert resources and an endpoint-cost review
-path for paid or long-lived environments. Out of scope: automatic destructive
-cost actions.
+Completed for an optional dev monthly AWS cost budget and documented SES SMTP
+PrivateLink endpoint-cost review expectations. Future work can add more
+specific budgets or reporting for paid/long-lived environments. Out of scope:
+automatic destructive cost actions.
 
 ### Capture SES Monitoring Sanitized Evidence
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -386,6 +386,11 @@ CI runs Terraform checks without AWS credentials.
   - automated backups
 - API Gateway, Lambda, Cognito, SSM Parameter Store, and CloudWatch are still real AWS resources, but for light learning use they are expected to be smaller cost contributors than RDS.
 - The optional SES SMTP interface VPC endpoint is disabled by default. If enabled, it adds PrivateLink endpoint hourly and data-processing charges.
+- The optional monthly AWS Budgets cost alert is disabled by default. Enable it
+  only for paid or long-lived dev environments, and keep subscriber addresses in
+  ignored local Terraform inputs.
+- If the SES SMTP VPC endpoint is enabled for smoke testing, review after the
+  test whether it should be disabled again to avoid idle endpoint cost.
 
 ## Apply and destroy rule
 

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -181,6 +181,17 @@ module "ses_delivery_dashboard" {
   tags        = local.common_tags
 }
 
+module "cost_controls" {
+  source = "../../modules/cost_controls"
+
+  name_prefix                               = local.name_prefix
+  monthly_budget_enabled                    = var.monthly_budget_enabled
+  monthly_budget_limit_usd                  = var.monthly_budget_limit_usd
+  monthly_budget_alert_threshold_percent    = var.monthly_budget_alert_threshold_percent
+  monthly_budget_subscriber_email_addresses = var.monthly_budget_subscriber_email_addresses
+  tags                                      = local.common_tags
+}
+
 module "api_http" {
   source = "../../modules/api_http"
 

--- a/infra/environments/dev/outputs.tf
+++ b/infra/environments/dev/outputs.tf
@@ -91,6 +91,16 @@ output "notification_email_delivery_dashboard_name" {
   value       = module.ses_delivery_dashboard.dashboard_name
 }
 
+output "monthly_budget_configured" {
+  description = "Whether the optional monthly AWS cost budget is configured."
+  value       = module.cost_controls.monthly_budget_configured
+}
+
+output "monthly_budget_name" {
+  description = "Optional monthly AWS cost budget name."
+  value       = module.cost_controls.monthly_budget_name
+}
+
 output "ses_sender_identity_configured" {
   description = "Whether an optional SES sender identity is configured for future dev email delivery validation."
   value       = module.ses_email_foundation.sender_identity_configured

--- a/infra/environments/dev/terraform.tfvars.example
+++ b/infra/environments/dev/terraform.tfvars.example
@@ -48,3 +48,10 @@ notification_email_smtp_password_ssm_param = ""
 
 notification_email_batch_size   = 25
 notification_email_max_attempts = 3
+
+# Optional. Creates an AWS Budgets monthly cost alert for paid or long-lived
+# dev environments. Keep disabled for short-lived learning stacks.
+monthly_budget_enabled                    = false
+monthly_budget_limit_usd                  = 25
+monthly_budget_alert_threshold_percent    = 80
+monthly_budget_subscriber_email_addresses = []

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -225,6 +225,40 @@ variable "notification_email_delivery_attempted_count_alarm_threshold" {
   }
 }
 
+variable "monthly_budget_enabled" {
+  type        = bool
+  description = "Whether to create the optional monthly AWS cost budget for paid or long-lived dev environments."
+  default     = false
+}
+
+variable "monthly_budget_limit_usd" {
+  type        = number
+  description = "Monthly AWS cost budget limit in USD for paid or long-lived dev environments."
+  default     = 25
+
+  validation {
+    condition     = var.monthly_budget_limit_usd > 0
+    error_message = "monthly_budget_limit_usd must be greater than zero."
+  }
+}
+
+variable "monthly_budget_alert_threshold_percent" {
+  type        = number
+  description = "Actual spend percentage that triggers the optional monthly AWS cost budget alert."
+  default     = 80
+
+  validation {
+    condition     = var.monthly_budget_alert_threshold_percent > 0 && var.monthly_budget_alert_threshold_percent <= 100
+    error_message = "monthly_budget_alert_threshold_percent must be greater than zero and less than or equal to 100."
+  }
+}
+
+variable "monthly_budget_subscriber_email_addresses" {
+  type        = set(string)
+  description = "Operator email addresses that receive optional AWS Budgets alerts. Keep empty unless monthly_budget_enabled is true."
+  default     = []
+}
+
 variable "tags" {
   type        = map(string)
   description = "Extra tags."

--- a/infra/modules/cost_controls/.terraform.lock.hcl
+++ b/infra/modules/cost_controls/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.44.0"
+  constraints = "~> 6.37"
+  hashes = [
+    "h1:lJvGaC4YNXk3TIdrd5GCIyV0gxU1WigQIao8rmcpplc=",
+    "zh:0462747d28f6dcd7b1b723bea9da1600526b7cdcf929ed4be54352d74b0746e6",
+    "zh:0c9b7e7b04050360f609ff5700d8a76227fb4ea84dac92b844d82a2013706705",
+    "zh:2877a6854edf237f9d6c66dc928294cbbcf29d3f52577fb8f232d0cfd11d5c0d",
+    "zh:3347b82e222bbfad326b79c408e53a9252b80c6c762f4dd4f4617583394f0a4e",
+    "zh:33997dbe611b5abf49c87a31f29d8f797c97421f67b71fec8aa688799511b758",
+    "zh:5d5c37375c5e776e6e8f95fb8cbd8009258618b9f51c55551a18adc09ef5814a",
+    "zh:67d6bd61c52ca5f4c37c96a76f6820c9f1902e4b83f89faddf9fd7f17ba0b160",
+    "zh:739588639fa30db7084d6939c2eb9b4dd2d7f58dbb5d5b3b2c4bda2a35dcf521",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a953797142df4245bd8f456b9e78690f501a0fff2f58552db4eb2da409cd99e9",
+    "zh:aeb8d616dd34a9f1c5048ed4cdd6d7692db93cd33a468872618d4cd38c4784aa",
+    "zh:dc8420556aca50658247b097de6734259fc3a6012ff1cf96612fca10b3982f9d",
+    "zh:f9083d6d9fb9cbdcd91e38c92f96e67223ecc7ce6d0986bd5eb8e6d52e9aa02b",
+    "zh:f9418aa1e4d29f9026aa6f521e97d085e000902ea929debbbef61135185e3ad4",
+    "zh:fb2494a6c92118055cfb2c114a4fe5c750946a1b0d6be6bf02ab3e37a091fb8b",
+  ]
+}

--- a/infra/modules/cost_controls/main.tf
+++ b/infra/modules/cost_controls/main.tf
@@ -1,0 +1,30 @@
+resource "aws_budgets_budget" "monthly_cost" {
+  count = var.monthly_budget_enabled ? 1 : 0
+
+  name         = "${var.name_prefix}-monthly-cost"
+  budget_type  = "COST"
+  limit_amount = tostring(var.monthly_budget_limit_usd)
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  dynamic "notification" {
+    for_each = length(var.monthly_budget_subscriber_email_addresses) > 0 ? [1] : []
+
+    content {
+      comparison_operator        = "GREATER_THAN"
+      notification_type          = "ACTUAL"
+      threshold                  = var.monthly_budget_alert_threshold_percent
+      threshold_type             = "PERCENTAGE"
+      subscriber_email_addresses = var.monthly_budget_subscriber_email_addresses
+    }
+  }
+
+  tags = var.tags
+
+  lifecycle {
+    precondition {
+      condition     = length(var.monthly_budget_subscriber_email_addresses) > 0
+      error_message = "monthly_budget_subscriber_email_addresses must contain at least one operator email address when monthly_budget_enabled is true."
+    }
+  }
+}

--- a/infra/modules/cost_controls/outputs.tf
+++ b/infra/modules/cost_controls/outputs.tf
@@ -1,0 +1,9 @@
+output "monthly_budget_configured" {
+  description = "Whether the optional monthly cost budget is configured."
+  value       = length(aws_budgets_budget.monthly_cost) > 0
+}
+
+output "monthly_budget_name" {
+  description = "Optional monthly cost budget name."
+  value       = try(aws_budgets_budget.monthly_cost[0].name, null)
+}

--- a/infra/modules/cost_controls/tests/defaults.tftest.hcl
+++ b/infra/modules/cost_controls/tests/defaults.tftest.hcl
@@ -1,0 +1,135 @@
+mock_provider "aws" {}
+
+variables {
+  name_prefix = "leaseflow-dev"
+  tags = {
+    Project = "leaseflow"
+  }
+}
+
+run "defaults_create_no_cost_budget" {
+  command = plan
+
+  assert {
+    condition     = length(aws_budgets_budget.monthly_cost) == 0
+    error_message = "Monthly cost budget should be disabled by default."
+  }
+
+  assert {
+    condition     = output.monthly_budget_configured == false
+    error_message = "Monthly budget configured output should be false by default."
+  }
+}
+
+run "creates_optional_monthly_cost_budget_with_email_alert" {
+  command = plan
+
+  variables {
+    monthly_budget_enabled                    = true
+    monthly_budget_limit_usd                  = 50
+    monthly_budget_alert_threshold_percent    = 75
+    monthly_budget_subscriber_email_addresses = ["operator@example.test"]
+  }
+
+  assert {
+    condition     = length(aws_budgets_budget.monthly_cost) == 1
+    error_message = "Monthly cost budget should be created when enabled."
+  }
+
+  assert {
+    condition     = aws_budgets_budget.monthly_cost[0].name == "leaseflow-dev-monthly-cost"
+    error_message = "Monthly cost budget should use the expected safe name."
+  }
+
+  assert {
+    condition     = aws_budgets_budget.monthly_cost[0].budget_type == "COST"
+    error_message = "Monthly budget should track cost."
+  }
+
+  assert {
+    condition     = aws_budgets_budget.monthly_cost[0].time_unit == "MONTHLY"
+    error_message = "Monthly budget should use a monthly time unit."
+  }
+
+  assert {
+    condition     = aws_budgets_budget.monthly_cost[0].limit_amount == "50"
+    error_message = "Monthly budget should use the configured USD amount."
+  }
+
+  assert {
+    condition     = aws_budgets_budget.monthly_cost[0].limit_unit == "USD"
+    error_message = "Monthly budget should use USD."
+  }
+
+  assert {
+    condition     = length(aws_budgets_budget.monthly_cost[0].notification) == 1
+    error_message = "Monthly budget should include a notification when subscribers are configured."
+  }
+
+  assert {
+    condition = length([
+      for notification in aws_budgets_budget.monthly_cost[0].notification : notification
+      if notification.notification_type == "ACTUAL"
+    ]) == 1
+    error_message = "Monthly budget notification should track actual spend."
+  }
+
+  assert {
+    condition = length([
+      for notification in aws_budgets_budget.monthly_cost[0].notification : notification
+      if notification.threshold == 75
+    ]) == 1
+    error_message = "Monthly budget notification should use the configured threshold."
+  }
+
+  assert {
+    condition = length([
+      for notification in aws_budgets_budget.monthly_cost[0].notification : notification
+      if notification.threshold_type == "PERCENTAGE"
+    ]) == 1
+    error_message = "Monthly budget notification should use a percentage threshold."
+  }
+
+  assert {
+    condition     = output.monthly_budget_configured == true
+    error_message = "Monthly budget configured output should be true when enabled."
+  }
+}
+
+run "budget_name_excludes_sensitive_identifiers" {
+  command = plan
+
+  variables {
+    monthly_budget_enabled                    = true
+    monthly_budget_subscriber_email_addresses = ["operator@example.test"]
+  }
+
+  assert {
+    condition = alltrue([
+      for forbidden_value in [
+        "tenant",
+        "recipient",
+        "contact",
+        "notification",
+        "smtp",
+        "ssm",
+        "db",
+        "credential"
+      ] :
+      !strcontains(lower(aws_budgets_budget.monthly_cost[0].name), forbidden_value)
+    ])
+    error_message = "Monthly budget name should not contain sensitive or tenant-specific identifiers."
+  }
+}
+
+run "enabled_budget_requires_alert_subscriber" {
+  command = plan
+
+  variables {
+    monthly_budget_enabled = true
+  }
+
+  expect_failures = [
+    aws_budgets_budget.monthly_cost
+  ]
+}

--- a/infra/modules/cost_controls/variables.tf
+++ b/infra/modules/cost_controls/variables.tf
@@ -1,0 +1,44 @@
+variable "name_prefix" {
+  description = "Prefix used in cost-control resource names."
+  type        = string
+}
+
+variable "monthly_budget_enabled" {
+  description = "Whether to create the optional monthly AWS cost budget."
+  type        = bool
+  default     = false
+}
+
+variable "monthly_budget_limit_usd" {
+  description = "Monthly AWS cost budget limit in USD for paid or long-lived environments."
+  type        = number
+  default     = 25
+
+  validation {
+    condition     = var.monthly_budget_limit_usd > 0
+    error_message = "monthly_budget_limit_usd must be greater than zero."
+  }
+}
+
+variable "monthly_budget_alert_threshold_percent" {
+  description = "Actual spend percentage that triggers the monthly cost budget alert."
+  type        = number
+  default     = 80
+
+  validation {
+    condition     = var.monthly_budget_alert_threshold_percent > 0 && var.monthly_budget_alert_threshold_percent <= 100
+    error_message = "monthly_budget_alert_threshold_percent must be greater than zero and less than or equal to 100."
+  }
+}
+
+variable "monthly_budget_subscriber_email_addresses" {
+  description = "Operator email addresses that receive AWS Budgets alerts when the optional budget is enabled."
+  type        = set(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "Tags applied to cost-control resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/cost_controls/versions.tf
+++ b/infra/modules/cost_controls/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.37"
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Adds an opt-in Terraform cost-control module for paid or long-lived dev environments.

The new module can create an AWS Budgets monthly cost budget with an actual-spend percentage alert. It is disabled by default to keep short-lived dev stacks cost-aware.

Also wires the module into the dev environment, adds safe outputs, updates `terraform.tfvars.example`, and documents SES SMTP PrivateLink endpoint cost review expectations.

## Assumptions

- Dev cost alerting should remain opt-in.
- A coarse monthly AWS account cost budget is sufficient for this slice.
- More specific service-level budgets or reporting can be future work.

## Security validation

- Budget names and outputs do not include tenant IDs, recipient data, SMTP credentials, SSM values, DB endpoints, or provider payloads.
- Subscriber emails are only local operator inputs and are not committed in example values.
- No browser, backend delivery, SES sending, NAT, or RDS behavior changed.

## Cost validation

- Default behavior creates no budget.
- When enabled, the change adds one AWS Budgets monthly cost budget.
- No automatic destructive cost actions are added.

## Validation

- `terraform fmt -recursive infra`
- `cd infra/modules/cost_controls && terraform test`
- `cd infra/environments/dev && terraform validate`
- `git diff --check`

## Remaining risks / TODOs

- Terraform apply has not been run in AWS in this branch.
- More granular budgets, cost dashboards, or production cost controls remain future work.
