### PR TITLE
docs: add ses monitoring sanitized evidence

### DIFF
--- a/docs/runbooks/evidence/ses-monitoring-sanitized-evidence-2026-05-08.md
+++ b/docs/runbooks/evidence/ses-monitoring-sanitized-evidence-2026-05-08.md
@@ -1,0 +1,171 @@
+# SES Monitoring Sanitized Evidence - 2026-05-08
+
+## Summary
+
+Result:
+
+- Repository monitoring configuration review: `pass`
+- Live CloudWatch metric visibility check: `not completed`
+- Live CloudWatch alarm state check: `not completed`
+- Live CloudWatch dashboard load check: `not completed`
+- Optional monthly cost budget runtime check: `not completed`
+- SES SMTP PrivateLink endpoint runtime review: `not completed`
+- Evidence hygiene review: `pass`
+
+This evidence does not claim production readiness. Live AWS validation was not
+completed in this session because the local AWS CLI configuration was not usable
+for the dev account.
+
+## Context
+
+- Date: `2026-05-08`
+- Branch: `192-capture-ses-monitoring-sanitized-evidence`
+- Related issue: `#192 Capture SES monitoring sanitized evidence`
+- Region intended for validation: `eu-north-1`
+- Monitoring document: `docs/ses-delivery-monitoring-alarms-cost-controls.md`
+
+## Repository Configuration Review
+
+Sanitized repository-level checks:
+
+```text
+delivery metric namespace documented:        pass
+delivery metric dimensions documented:       pass
+delivery worker aggregate metrics present:   pass
+delivery alarm Terraform wiring present:     pass
+delivery dashboard Terraform wiring present: pass
+optional monthly budget wiring present:      pass
+PrivateLink cost review wording present:     pass
+```
+
+Aggregate metric namespace checked:
+
+```text
+LeaseFlow/NotificationEmailDelivery
+```
+
+Allowed metric dimensions checked:
+
+```text
+environment
+service
+operation
+result
+```
+
+Aggregate metric names checked:
+
+```text
+candidate_count
+created_delivery_count
+attempted_count
+sent_count
+failed_count
+skipped_count
+retry_exhausted_count
+```
+
+Future aggregate metric names documented as no-data until future processors
+emit them:
+
+```text
+bounce_count
+complaint_count
+suppressed_contact_count
+```
+
+## Runtime Validation
+
+Live AWS checks were not completed in this session.
+
+Sanitized reason:
+
+```text
+local AWS CLI configuration was not usable for dev validation
+```
+
+No raw AWS CLI output, account identifiers, resource identifiers, ARNs, endpoint
+IDs, dashboard screenshots, metric datapoints, or provider payloads are captured
+in this evidence.
+
+## Alarm Checks
+
+```text
+delivery failure alarm configuration/state:       not completed
+retry exhausted alarm configuration/state:        not completed
+send-volume boundary alarm configuration/state:   not completed
+```
+
+Expected safe alarm coverage:
+
+```text
+failed_count >= 1
+retry_exhausted_count >= 1
+attempted_count > configured dev threshold
+```
+
+## Dashboard Check
+
+```text
+dashboard load check:                     not completed
+delivery run volume widget check:         not completed
+failure health widget check:              not completed
+worker result category widget check:      not completed
+future feedback/suppression widget check: not completed
+```
+
+Expected safe dashboard behavior:
+
+```text
+dashboard uses aggregate metrics only
+widgets may show no data until delivery is enabled and metrics are emitted
+future feedback widgets may show no data until future processors exist
+```
+
+## Cost-Control Check
+
+```text
+optional monthly budget runtime state:       not completed
+budget disabled-by-default behavior:         repository review pass
+budget alert subscriber runtime validation:  not completed
+SES SMTP PrivateLink endpoint runtime state: not completed
+endpoint cost ownership review:              repository review pass
+```
+
+Expected safe cost-control behavior:
+
+```text
+monthly budget is opt-in
+budget alerts require operator-provided subscribers in ignored local inputs
+no automatic destructive cost actions exist
+SES SMTP PrivateLink endpoint remains disabled by default
+operators review endpoint need after smoke or long-lived validation
+```
+
+## Evidence Hygiene
+
+This evidence intentionally does not include:
+
+- Recipient email addresses
+- Cognito emails
+- Tenant IDs
+- JWTs or authorization headers
+- SMTP or SES credentials
+- SSM values
+- DB endpoints or connection strings
+- Notification titles or message bodies
+- Contact IDs or notification IDs
+- Raw SES responses
+- Raw SMTP transcripts
+- Raw AWS provider output
+- AWS account IDs
+- Resource ARNs
+- Bucket names or distribution IDs
+- Screenshots with sensitive values
+
+## Follow-Up
+
+Run live AWS validation after the dev stack is available and the AWS CLI profile
+and region are configured correctly. Capture only sanitized pass/fail statuses
+and aggregate metric/resource checks in a new evidence file or an update to this
+one.


### PR DESCRIPTION
## What changed

Adds sanitized SES monitoring evidence for #192.

The evidence records repository-level monitoring configuration review and explicitly marks live AWS runtime validation as not completed because local AWS CLI configuration was not usable in this session.

## Security validation

The evidence avoids raw AWS output, resource identifiers, tenant data, recipient data, credentials, SSM values, DB endpoints, provider payloads, and screenshots.

## Cost validation

No AWS resources or behavior changes. Evidence-only docs change.

## Validation

- `git diff --check`

## Remaining risks / TODOs

Live CloudWatch metric, alarm, dashboard, budget, and SES SMTP PrivateLink runtime checks still need to be run with a correctly configured dev AWS profile.
