### PR TITLE
feat: add notification contact suppression state

### DIFF
--- a/backend/migrations/versions/20260512_0010_add_notification_contact_suppressions.py
+++ b/backend/migrations/versions/20260512_0010_add_notification_contact_suppressions.py
@@ -1,0 +1,74 @@
+"""Add tenant-scoped notification contact suppressions."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "20260512_0010"
+down_revision = "20260508_0009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notification_contact_suppressions",
+        sa.Column(
+            "suppression_id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("tenant_id", sa.Text(), nullable=False),
+        sa.Column("contact_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "reason IN ('bounce', 'complaint')",
+            name="ck_notification_contact_suppressions_reason",
+        ),
+        sa.ForeignKeyConstraint(
+            ["tenant_id", "contact_id"],
+            ["notification_contacts.tenant_id", "notification_contacts.contact_id"],
+            name="fk_notification_contact_suppressions_contact_tenant",
+        ),
+        sa.UniqueConstraint(
+            "tenant_id",
+            "contact_id",
+            "reason",
+            name="uq_notification_contact_suppressions_tenant_contact_reason",
+        ),
+    )
+    op.create_index(
+        "ix_notification_contact_suppressions_tenant_contact",
+        "notification_contact_suppressions",
+        ["tenant_id", "contact_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_notification_contact_suppressions_tenant_reason",
+        "notification_contact_suppressions",
+        ["tenant_id", "reason"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_notification_contact_suppressions_tenant_reason",
+        table_name="notification_contact_suppressions",
+    )
+    op.drop_index(
+        "ix_notification_contact_suppressions_tenant_contact",
+        table_name="notification_contact_suppressions",
+    )
+    op.drop_table("notification_contact_suppressions")

--- a/backend/src/app/db.py
+++ b/backend/src/app/db.py
@@ -17,12 +17,15 @@ from app.models import (
     LeaseReminderCandidate,
     Notification,
     NotificationContact,
+    NotificationContactSuppression,
     NotificationEmailDelivery,
     NotificationEmailDeliveryPreparationResult,
     NotificationEmailDeliverySummary,
     Property,
     ReminderScanResult,
 )
+
+_NOTIFICATION_CONTACT_SUPPRESSION_REASONS = {"bounce", "complaint"}
 
 
 class Database:
@@ -140,6 +143,118 @@ class Database:
                 )
 
         return self._row_to_notification_contact(contact_row)
+
+    def create_notification_contact_suppression(
+        self,
+        tenant_id: str,
+        actor_user_id: str,
+        contact_id: UUID,
+        reason: str,
+        audit_source: str = "leaseflow.internal",
+    ) -> NotificationContactSuppression:
+        normalized_reason = reason.strip().lower()
+        if normalized_reason not in _NOTIFICATION_CONTACT_SUPPRESSION_REASONS:
+            raise ValueError("Notification contact suppression reason must be bounce or complaint.")
+
+        contact_sql = """
+            SELECT contact_id
+            FROM notification_contacts
+            WHERE tenant_id = %s AND contact_id = %s
+        """
+        insert_sql = """
+            INSERT INTO notification_contact_suppressions (
+                tenant_id,
+                contact_id,
+                reason
+            ) VALUES (%s, %s, %s)
+            ON CONFLICT ON CONSTRAINT uq_notification_contact_suppressions_tenant_contact_reason
+            DO NOTHING
+            RETURNING suppression_id, tenant_id, contact_id, reason, created_at
+        """
+        select_existing_sql = """
+            SELECT suppression_id, tenant_id, contact_id, reason, created_at
+            FROM notification_contact_suppressions
+            WHERE tenant_id = %s AND contact_id = %s AND reason = %s
+        """
+        audit_sql = """
+            INSERT INTO audit_logs (
+                tenant_id, actor_user_id, action, entity_type, entity_id, metadata
+            ) VALUES (%s, %s, %s, %s, %s, %s::jsonb)
+        """
+
+        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+            with conn.transaction():
+                contact_row = conn.execute(contact_sql, (tenant_id, contact_id)).fetchone()
+                if contact_row is None:
+                    raise LookupError("Notification contact not found for tenant.")
+
+                suppression_row = conn.execute(
+                    insert_sql,
+                    (tenant_id, contact_id, normalized_reason),
+                ).fetchone()
+                if suppression_row is not None:
+                    conn.execute(
+                        audit_sql,
+                        (
+                            tenant_id,
+                            actor_user_id,
+                            "notification_contact_suppression.create",
+                            "notification_contact_suppression",
+                            suppression_row["suppression_id"],
+                            json.dumps(
+                                {
+                                    "source": audit_source,
+                                    "reason": normalized_reason,
+                                }
+                            ),
+                        ),
+                    )
+                else:
+                    suppression_row = conn.execute(
+                        select_existing_sql,
+                        (tenant_id, contact_id, normalized_reason),
+                    ).fetchone()
+                    if suppression_row is None:
+                        raise RuntimeError("Failed to load notification contact suppression.")
+
+        return self._row_to_notification_contact_suppression(suppression_row)
+
+    def list_notification_contact_suppressions(
+        self,
+        tenant_id: str,
+        contact_id: UUID | None = None,
+    ) -> list[NotificationContactSuppression]:
+        params: tuple[object, ...]
+        if contact_id is not None:
+            contact_sql = """
+                SELECT contact_id
+                FROM notification_contacts
+                WHERE tenant_id = %s AND contact_id = %s
+            """
+            with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+                contact_row = conn.execute(contact_sql, (tenant_id, contact_id)).fetchone()
+            if contact_row is None:
+                raise LookupError("Notification contact not found for tenant.")
+
+            sql = """
+                SELECT suppression_id, tenant_id, contact_id, reason, created_at
+                FROM notification_contact_suppressions
+                WHERE tenant_id = %s AND contact_id = %s
+                ORDER BY created_at DESC, suppression_id DESC
+            """
+            params = (tenant_id, contact_id)
+        else:
+            sql = """
+                SELECT suppression_id, tenant_id, contact_id, reason, created_at
+                FROM notification_contact_suppressions
+                WHERE tenant_id = %s
+                ORDER BY created_at DESC, suppression_id DESC
+            """
+            params = (tenant_id,)
+
+        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+            rows = conn.execute(sql, params).fetchall()
+        return [self._row_to_notification_contact_suppression(row) for row in rows]
 
     def create_missing_notification_email_deliveries(
         self,
@@ -945,6 +1060,18 @@ class Database:
             tenant_id=row["tenant_id"],
             email=row["email"],
             enabled=row["enabled"],
+            created_at=row["created_at"],
+        )
+
+    @staticmethod
+    def _row_to_notification_contact_suppression(
+        row: dict[str, Any],
+    ) -> NotificationContactSuppression:
+        return NotificationContactSuppression(
+            suppression_id=row["suppression_id"],
+            tenant_id=row["tenant_id"],
+            contact_id=row["contact_id"],
+            reason=row["reason"],
             created_at=row["created_at"],
         )
 

--- a/backend/src/app/models.py
+++ b/backend/src/app/models.py
@@ -82,6 +82,15 @@ class NotificationContact:
 
 
 @dataclass(slots=True)
+class NotificationContactSuppression:
+    suppression_id: UUID
+    tenant_id: str
+    contact_id: UUID
+    reason: str
+    created_at: datetime
+
+
+@dataclass(slots=True)
 class NotificationEmailDelivery:
     delivery_id: UUID
     tenant_id: str

--- a/backend/tests/test_db_integration.py
+++ b/backend/tests/test_db_integration.py
@@ -35,6 +35,10 @@ def _cleanup_test_tenant(settings: Settings, tenant_id: str) -> None:
                 "DELETE FROM notification_email_deliveries WHERE tenant_id = %s",
                 (tenant_id,),
             )
+            conn.execute(
+                "DELETE FROM notification_contact_suppressions WHERE tenant_id = %s",
+                (tenant_id,),
+            )
             conn.execute("DELETE FROM notifications WHERE tenant_id = %s", (tenant_id,))
             conn.execute("DELETE FROM notification_contacts WHERE tenant_id = %s", (tenant_id,))
             conn.execute("DELETE FROM audit_logs WHERE tenant_id = %s", (tenant_id,))
@@ -1704,6 +1708,261 @@ def test_set_notification_contact_enabled_rejects_cross_tenant_access(
     finally:
         _cleanup_test_tenant(integration_settings, tenant_id)
         _cleanup_test_tenant(integration_settings, other_tenant_id)
+
+
+def test_create_notification_contact_suppression_writes_tenant_scoped_row_and_safe_audit(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = "leaseflow.internal"
+
+    try:
+        contact = db.create_notification_contact(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            email=f"suppressed-{uuid4().hex[:8]}@example.com",
+        )
+
+        created = db.create_notification_contact_suppression(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            contact_id=contact.contact_id,
+            reason="bounce",
+        )
+        listed = db.list_notification_contact_suppressions(tenant_id=tenant_id)
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            audit_rows = conn.execute(
+                """
+                SELECT tenant_id, actor_user_id, action, entity_type, entity_id, metadata
+                FROM audit_logs
+                WHERE tenant_id = %s
+                  AND entity_id = %s
+                  AND action = 'notification_contact_suppression.create'
+                """,
+                (tenant_id, created.suppression_id),
+            ).fetchall()
+
+        assert created.tenant_id == tenant_id
+        assert created.contact_id == contact.contact_id
+        assert created.reason == "bounce"
+        assert [item.suppression_id for item in listed] == [created.suppression_id]
+
+        assert len(audit_rows) == 1
+        assert audit_rows[0]["tenant_id"] == tenant_id
+        assert audit_rows[0]["actor_user_id"] == actor_user_id
+        assert audit_rows[0]["entity_type"] == "notification_contact_suppression"
+        assert audit_rows[0]["entity_id"] == created.suppression_id
+        assert audit_rows[0]["metadata"] == {
+            "source": "leaseflow.internal",
+            "reason": "bounce",
+        }
+        assert "email" not in audit_rows[0]["metadata"]
+        assert "contact_id" not in audit_rows[0]["metadata"]
+        assert "tenant_id" not in audit_rows[0]["metadata"]
+        assert "message" not in audit_rows[0]["metadata"]
+        assert "body" not in audit_rows[0]["metadata"]
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+
+
+def test_notification_contact_suppression_duplicate_is_idempotent_without_duplicate_audit(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = "leaseflow.internal"
+
+    try:
+        contact = db.create_notification_contact(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            email=f"dedupe-suppression-{uuid4().hex[:8]}@example.com",
+        )
+
+        first = db.create_notification_contact_suppression(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            contact_id=contact.contact_id,
+            reason="complaint",
+        )
+        second = db.create_notification_contact_suppression(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            contact_id=contact.contact_id,
+            reason="complaint",
+        )
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            suppression_count = conn.execute(
+                """
+                SELECT count(*) AS row_count
+                FROM notification_contact_suppressions
+                WHERE tenant_id = %s AND contact_id = %s AND reason = 'complaint'
+                """,
+                (tenant_id, contact.contact_id),
+            ).fetchone()["row_count"]
+            audit_count = conn.execute(
+                """
+                SELECT count(*) AS row_count
+                FROM audit_logs
+                WHERE tenant_id = %s
+                  AND entity_id = %s
+                  AND action = 'notification_contact_suppression.create'
+                """,
+                (tenant_id, first.suppression_id),
+            ).fetchone()["row_count"]
+
+        assert second == first
+        assert suppression_count == 1
+        assert audit_count == 1
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+
+
+def test_notification_contact_suppression_is_tenant_scoped_and_filters_by_contact(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    other_tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = "leaseflow.internal"
+    shared_email = f"shared-suppression-{uuid4().hex[:8]}@example.com"
+
+    try:
+        contact = db.create_notification_contact(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            email=shared_email,
+        )
+        other_contact = db.create_notification_contact(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            email=shared_email,
+        )
+
+        bounce = db.create_notification_contact_suppression(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            contact_id=contact.contact_id,
+            reason="bounce",
+        )
+        complaint = db.create_notification_contact_suppression(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            contact_id=contact.contact_id,
+            reason="complaint",
+        )
+        other = db.create_notification_contact_suppression(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            contact_id=other_contact.contact_id,
+            reason="bounce",
+        )
+
+        tenant_items = db.list_notification_contact_suppressions(tenant_id=tenant_id)
+        contact_items = db.list_notification_contact_suppressions(
+            tenant_id=tenant_id,
+            contact_id=contact.contact_id,
+        )
+        other_items = db.list_notification_contact_suppressions(tenant_id=other_tenant_id)
+
+        assert {item.suppression_id for item in tenant_items} == {
+            bounce.suppression_id,
+            complaint.suppression_id,
+        }
+        assert {item.reason for item in contact_items} == {"bounce", "complaint"}
+        assert [item.suppression_id for item in other_items] == [other.suppression_id]
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+        _cleanup_test_tenant(integration_settings, other_tenant_id)
+
+
+def test_notification_contact_suppression_rejects_invalid_reason_and_cross_tenant_contact(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    other_tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = "leaseflow.internal"
+
+    try:
+        contact = db.create_notification_contact(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            email=f"invalid-suppression-{uuid4().hex[:8]}@example.com",
+        )
+        other_contact = db.create_notification_contact(
+            tenant_id=other_tenant_id,
+            actor_user_id=actor_user_id,
+            email=f"cross-suppression-{uuid4().hex[:8]}@example.com",
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="Notification contact suppression reason must be bounce or complaint.",
+        ):
+            db.create_notification_contact_suppression(
+                tenant_id=tenant_id,
+                actor_user_id=actor_user_id,
+                contact_id=contact.contact_id,
+                reason="delivery_delay",
+            )
+
+        with pytest.raises(LookupError, match="Notification contact not found for tenant."):
+            db.create_notification_contact_suppression(
+                tenant_id=tenant_id,
+                actor_user_id=actor_user_id,
+                contact_id=other_contact.contact_id,
+                reason="bounce",
+            )
+
+        with pytest.raises(LookupError, match="Notification contact not found for tenant."):
+            db.list_notification_contact_suppressions(
+                tenant_id=tenant_id,
+                contact_id=other_contact.contact_id,
+            )
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+        _cleanup_test_tenant(integration_settings, other_tenant_id)
+
+
+def test_reenabling_notification_contact_does_not_remove_notification_contact_suppression(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = "leaseflow.internal"
+
+    try:
+        contact = db.create_notification_contact(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            email=f"reenable-suppressed-{uuid4().hex[:8]}@example.com",
+            enabled=False,
+        )
+        suppression = db.create_notification_contact_suppression(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            contact_id=contact.contact_id,
+            reason="bounce",
+        )
+
+        db.set_notification_contact_enabled(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            contact_id=contact.contact_id,
+            enabled=True,
+        )
+        suppressions = db.list_notification_contact_suppressions(
+            tenant_id=tenant_id,
+            contact_id=contact.contact_id,
+        )
+
+        assert [item.suppression_id for item in suppressions] == [suppression.suppression_id]
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
 
 
 def test_create_due_lease_reminder_notifications_is_idempotent(

--- a/backend/tests/test_notification_contact_suppression_data_access.py
+++ b/backend/tests/test_notification_contact_suppression_data_access.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from inspect import signature
+from uuid import UUID
+
+from app.db import Database
+from app.models import NotificationContactSuppression
+
+
+def test_notification_contact_suppression_model_carries_safe_domain_fields() -> None:
+    suppression = NotificationContactSuppression(
+        suppression_id=UUID("11111111-1111-4111-8111-111111111111"),
+        tenant_id="tenant-auth",
+        contact_id=UUID("22222222-2222-4222-8222-222222222222"),
+        reason="bounce",
+        created_at=datetime(2026, 5, 12, tzinfo=UTC),
+    )
+
+    assert suppression.reason == "bounce"
+    assert suppression.contact_id == UUID("22222222-2222-4222-8222-222222222222")
+
+
+def test_database_exposes_notification_contact_suppression_methods() -> None:
+    create_params = signature(Database.create_notification_contact_suppression).parameters
+    list_params = signature(Database.list_notification_contact_suppressions).parameters
+
+    assert list(create_params) == [
+        "self",
+        "tenant_id",
+        "actor_user_id",
+        "contact_id",
+        "reason",
+        "audit_source",
+    ]
+    assert create_params["audit_source"].default == "leaseflow.internal"
+    assert list(list_params) == ["self", "tenant_id", "contact_id"]
+    assert list_params["contact_id"].default is None

--- a/docs/mvp-scope.md
+++ b/docs/mvp-scope.md
@@ -40,6 +40,8 @@
 - lease contract data includes explicit `rent_due_day_of_month` for future reminder workflows.
 - `notifications` table for tenant-owned reminder records, including nullable `read_at` for read acknowledgment.
 - `notification_contacts` table for tenant-owned email recipients.
+- `notification_contact_suppressions` table for tenant/contact-scoped bounce
+  and complaint suppression state.
 - `notification_email_deliveries` table for tenant-scoped delivery status,
   retry attempts, sanitized failure codes, and sent timestamps.
 - Notification API responses expose safe aggregate delivery summaries without

--- a/docs/notification-email-delivery-mvp.md
+++ b/docs/notification-email-delivery-mvp.md
@@ -55,8 +55,9 @@ SES deliverability.
   `docs/ses-bounce-complaint-ingestion.md`; provider feedback ingestion is not
   implemented yet.
 - Notification suppression and unsubscribe/preference planning is documented in
-  `docs/notification-suppression-unsubscribe-model.md`; suppression state is
-  not implemented yet.
+  `docs/notification-suppression-unsubscribe-model.md`; tenant/contact-scoped
+  suppression state exists, but delivery eligibility and UI visibility remain
+  future work.
 - SES delivery monitoring, alarm, and cost-control planning is documented in
   `docs/ses-delivery-monitoring-alarms-cost-controls.md`; delivery-specific
   metrics, alarms, dashboards, and budget resources are not implemented yet.

--- a/docs/notification-suppression-unsubscribe-model.md
+++ b/docs/notification-suppression-unsubscribe-model.md
@@ -5,9 +5,10 @@
 This document defines the future tenant/contact-level suppression and
 preference model for LeaseFlow notification email.
 
-This is a planning artifact only. It does not add database migrations, backend
-code, frontend UI, Terraform resources, SES integration changes, production
-access, or marketing email behavior.
+This document tracks the suppression/preference direction. Tenant-scoped
+suppression database state now exists, but frontend UI, Terraform resources, SES
+event ingestion, production access, and marketing email behavior remain future
+work.
 
 ## Current State
 
@@ -17,9 +18,13 @@ access, or marketing email behavior.
   selection.
 - `notification_email_deliveries` tracks delivery attempts, sanitized failure
   codes, and sent timestamps.
+- `notification_contact_suppressions` stores tenant/contact-scoped active
+  suppressions for `bounce` and `complaint` reasons.
 - Bounce and complaint ingestion is planned separately in
   `docs/ses-bounce-complaint-ingestion.md`.
-- No LeaseFlow-owned suppression or unsubscribe/preference state exists yet.
+- Delivery eligibility does not consume suppression state yet; that remains a
+  separate implementation step.
+- No unsubscribe/preference state exists yet.
 - The browser can manage contacts but cannot trigger reminder scans, delivery,
   retries, or provider feedback processing.
 
@@ -111,8 +116,9 @@ how SES-managed preferences sync with LeaseFlow tenant/contact state.
 
 ### Add Notification Suppression State
 
-Add DB and data-access support for tenant-scoped suppression/preference state.
-Out of scope: SES event ingestion and browser UI.
+Implemented for tenant/contact-scoped `bounce` and `complaint` suppression
+state. Out of scope remains SES event ingestion, delivery eligibility, removal
+workflow, and browser UI.
 
 ### Apply Suppression To Email Delivery Eligibility
 

--- a/docs/ses-production-delivery-hardening.md
+++ b/docs/ses-production-delivery-hardening.md
@@ -89,8 +89,9 @@ Handling requirements:
   message bodies, or raw provider responses.
 - Permanent bounces and complaints must suppress future sends to the affected
   contact.
-- Suppression behavior must be tenant-scoped in the LeaseFlow data model even
-  if SES also maintains account-level suppression.
+- Tenant/contact-scoped suppression state exists in the LeaseFlow data model,
+  but production still needs event ingestion and delivery eligibility changes
+  before provider feedback affects future sends.
 
 ### Unsubscribe And Message Classification
 
@@ -192,9 +193,11 @@ triggering, and raw provider payload storage remain out of scope.
 
 ### Add Notification Suppression And Unsubscribe Model
 
-Planned in `docs/notification-suppression-unsubscribe-model.md`. Database
-state, delivery eligibility changes, browser visibility, SES subscription
-automation, marketing mail, and Cognito user enumeration remain out of scope.
+Partially implemented as tenant/contact-scoped bounce and complaint suppression
+state, as documented in `docs/notification-suppression-unsubscribe-model.md`.
+Delivery eligibility changes, browser visibility, suppression removal workflow,
+SES subscription automation, marketing mail, and Cognito user enumeration remain
+out of scope.
 
 ### Add SES Delivery Monitoring, Alarms, And Cost Controls
 


### PR DESCRIPTION
## Summary
- Add tenant-scoped notification contact suppression persistence for `bounce` and `complaint`.
- Add backend data-access methods for creating and listing suppressions.
- Keep duplicate suppression creation idempotent.
- Update docs to distinguish implemented suppression state from future delivery eligibility and SES ingestion work.

## Security Validation
- Suppressions are scoped by `tenant_id` and existing `notification_contacts`.
- Cross-tenant contact IDs are rejected with a safe `LookupError`.
- Audit metadata contains only `source` and `reason`; no email, tenant ID, contact ID, raw SES payload, or message body is stored in metadata.
- No browser/API route, frontend UI, delivery trigger, or SES event ingestion was added.

## Cost Validation
- No AWS resources, Terraform resources, NAT Gateway, SES resources, scheduler, or dashboard changes were added.
- This is backend DB/data-access only.

## Validation
- `cd backend && python -m pytest -q`
- `cd backend && python -m pytest -q tests/test_notification_contact_suppression_data_access.py tests/test_db_integration.py -k notification_contact_suppression`
- `cd backend && python -m ruff format --check src tests migrations`
- `cd backend && python -m ruff check src tests migrations`
- `git diff --check`

## Remaining Risks / TODOs
- Local DB integration tests were skipped unless `LEASEFLOW_RUN_DB_INTEGRATION=1` is enabled.
- Delivery eligibility still ignores suppression state by design; that belongs to #204.
- SES bounce/complaint ingestion and suppression visibility remain follow-up work.
