### PR TITLE
feat: add opt-in SES EventBridge event publishing foundation

### DIFF
--- a/docs/notification-email-delivery-mvp.md
+++ b/docs/notification-email-delivery-mvp.md
@@ -37,6 +37,9 @@ SES deliverability.
   credential values.
 - Outbound SES SMTP messages include a sanitized correlation message tag and may
   include an optional SES configuration-set header when configured.
+- Terraform can optionally create the matching SES configuration set and an
+  EventBridge event destination for bounce/complaint publishing. It is disabled
+  by default and does not ingest or process provider feedback by itself.
 - Dev smoke validation is documented in
   `docs/runbooks/ses-notification-email-delivery-smoke-test.md`, with sanitized
   successful evidence in
@@ -52,8 +55,8 @@ SES deliverability.
   `docs/ses-production-domain-identity-dns-authentication.md`; production
   sending remains unavailable.
 - Bounce and complaint ingestion planning is documented in
-  `docs/ses-bounce-complaint-ingestion.md`; provider feedback ingestion is not
-  implemented yet.
+  `docs/ses-bounce-complaint-ingestion.md`; the opt-in EventBridge publishing
+  foundation exists, but provider feedback ingestion is not implemented yet.
 - Notification suppression and unsubscribe/preference planning is documented in
   `docs/notification-suppression-unsubscribe-model.md`; tenant/contact-scoped
   suppression state exists, but delivery eligibility and UI visibility remain
@@ -144,6 +147,9 @@ Delivery must be idempotent and retry-safe:
   parameter ARNs.
 - Delivery remains disabled by default until SES identity, sandbox restrictions,
   SMTP credentials, endpoint connectivity, and smoke validation are ready.
+- SES configuration set EventBridge publishing remains disabled by default and
+  produces no useful application state until real SES events exist and a future
+  processor is implemented.
 
 ## Security And Tenant Isolation
 

--- a/docs/ses-bounce-complaint-ingestion.md
+++ b/docs/ses-bounce-complaint-ingestion.md
@@ -5,9 +5,11 @@
 This document defines the future production path for ingesting Amazon SES
 bounce and complaint events for LeaseFlow notification email.
 
-This is a planning artifact only. It does not create AWS resources, Terraform
-configuration, backend handlers, frontend behavior, DNS records, SES production
-access, or email-sending changes.
+This is primarily a planning artifact. Terraform now includes an
+disabled-by-default SES configuration set and EventBridge event destination
+foundation, but backend processing, EventBridge routing rules, frontend
+behavior, DNS records, SES production access, and email-sending behavior remain
+out of scope.
 
 ## Current State
 
@@ -23,6 +25,9 @@ access, or email-sending changes.
 - The browser can manage notification contacts and read safe aggregate delivery
   status, but cannot trigger scans, delivery, retries, or provider event
   processing.
+- Terraform can optionally create an SES configuration set with an EventBridge
+  event destination for `BOUNCE` and `COMPLAINT` events. This is disabled by
+  default and requires an explicit configuration set name.
 - Bounce and complaint event ingestion does not exist yet.
 - SES accepting an SMTP message is not proof that the recipient accepted or
   retained the message.
@@ -34,11 +39,11 @@ access, or email-sending changes.
 EventBridge is the chosen default for future LeaseFlow bounce and complaint
 ingestion.
 
-SES event publishing supports configuration set event destinations. A future
-SES configuration set should publish only the required `BOUNCE` and
-`COMPLAINT` events to EventBridge. An EventBridge rule can then route matching
-events to a future internal backend processor without exposing any browser
-control path.
+SES event publishing supports configuration set event destinations. LeaseFlow
+now has an opt-in Terraform foundation that can publish only the required
+`BOUNCE` and `COMPLAINT` events to EventBridge. A future EventBridge rule can
+then route matching events to a future internal backend processor without
+exposing any browser control path.
 
 This fits the current LeaseFlow direction: internal jobs use AWS events, browser
 routes remain tenant-scoped read/write flows, and production processing can be
@@ -64,11 +69,11 @@ data without storing raw provider payloads by default.
 
 ## Target Architecture
 
-Future implementation should use:
+Future implementation should build on:
 
-- SES configuration set with an EventBridge event destination.
+- SES configuration set with an opt-in EventBridge event destination.
 - Matching event types limited to `BOUNCE` and `COMPLAINT`.
-- EventBridge rule that targets an internal backend processor.
+- Future EventBridge rule that targets an internal backend processor.
 - Backend processor that maps provider events to sanitized categories and
   tenant/contact-scoped state changes.
 - Delivery-row updates for the matching notification/contact relationship when
@@ -110,9 +115,10 @@ provider-generated identifiers that are not necessary for safe debugging.
 
 ### Add SES Configuration Set EventBridge Destination
 
-Add Terraform for an SES configuration set and EventBridge event destination
-for `BOUNCE` and `COMPLAINT` only. Include least-privilege EventBridge routing.
-Out of scope: backend event processing.
+Completed as disabled-by-default Terraform foundation for an SES configuration
+set and default-bus EventBridge event destination for `BOUNCE` and `COMPLAINT`
+only. EventBridge rules, Lambda targets, IAM processor permissions, and backend
+event processing remain future work.
 
 ### Implement SES Bounce And Complaint Processor
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -10,7 +10,7 @@ Terraform code is split into reusable modules and environment composition.
 - `modules/cognito`: user pool, app client, and managed Hosted UI domain.
 - `modules/frontend_hosting`: private S3 bucket and CloudFront distribution for the SPA.
 - `modules/lambda_backend`: backend Lambda function, IAM role, log group.
-- `modules/ses_email_foundation`: optional SES sender identity and SES SMTP PrivateLink foundation.
+- `modules/ses_email_foundation`: optional SES sender identity, SES SMTP PrivateLink, and SES EventBridge publishing foundation.
 - `modules/reminder_scheduler`: EventBridge Scheduler + IAM role for daily reminder scans.
 - `modules/api_http`: HTTP API, JWT authorizer, route wiring.
 - `environments/dev`: MVP dev environment composition.
@@ -66,6 +66,16 @@ is explicitly enabled and operator-provided SES SMTP credentials are configured.
   SES from private subnets without adding a NAT Gateway.
 - The endpoint is billable while provisioned because interface VPC endpoint
   hourly and data-processing charges apply.
+- `ses_configuration_set_event_publishing_enabled` defaults to `false`. Keep it
+  disabled unless you intentionally want Terraform to create the SES
+  configuration set EventBridge publishing foundation.
+- Event publishing requires `notification_email_configuration_set` to be set.
+  The same value is used by the backend SES configuration-set header and the
+  Terraform-managed SES configuration set name.
+- The EventBridge destination publishes only SES `BOUNCE` and `COMPLAINT`
+  events to the default event bus. Terraform does not create a processor rule,
+  Lambda target, provider feedback handler, or suppression automation in this
+  slice.
 - SES sandbox and verified-identity limits still apply. In sandbox mode, test
   sending is constrained until identities and production access are handled.
 - `notification_email_delivery_enabled` defaults to `false`.
@@ -73,7 +83,8 @@ is explicitly enabled and operator-provided SES SMTP credentials are configured.
   SecureString parameters. Terraform receives only parameter names and grants
   Lambda least-privilege read/decrypt access to those configured parameters.
 - Terraform does not create SMTP credentials, IAM users, browser delivery
-  actions, automatic delivery schedules, or production email readiness.
+  actions, browser scan/retry/provider-feedback controls, automatic delivery
+  schedules, or production email readiness.
 - External SMTP delivery is not exactly-once: if Lambda crashes after SES
   accepts a message but before `sent_at` is persisted, a later retry can send
   another email for the same notification/contact pair.
@@ -105,8 +116,9 @@ cp infra/environments/dev/terraform.tfvars.example infra/environments/dev/terraf
 
 Edit `infra/environments/dev/terraform.tfvars` before applying. At minimum,
 replace `cognito_hosted_ui_domain_prefix` with a globally unique Cognito managed
-domain prefix. Leave SES and notification email delivery variables at their
-defaults unless you are explicitly validating SMTP delivery.
+domain prefix. Leave SES, SES event publishing, and notification email delivery
+variables at their defaults unless you are explicitly validating SMTP delivery
+or bounce/complaint event publishing.
 
 What it does: builds the Linux-compatible backend Lambda artifact.
 Target filename/service: `dist/leaseflow-backend.zip`.

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -121,14 +121,16 @@ module "lambda_backend" {
 module "ses_email_foundation" {
   source = "../../modules/ses_email_foundation"
 
-  name_prefix               = local.name_prefix
-  aws_region                = var.aws_region
-  sender_email              = var.ses_sender_email
-  smtp_vpc_endpoint_enabled = var.ses_smtp_vpc_endpoint_enabled
-  vpc_id                    = module.network.vpc_id
-  private_subnet_ids        = module.network.private_subnet_ids
-  lambda_security_group_id  = module.network.lambda_security_group_id
-  tags                      = local.common_tags
+  name_prefix                                = local.name_prefix
+  aws_region                                 = var.aws_region
+  sender_email                               = var.ses_sender_email
+  smtp_vpc_endpoint_enabled                  = var.ses_smtp_vpc_endpoint_enabled
+  configuration_set_event_publishing_enabled = var.ses_configuration_set_event_publishing_enabled
+  configuration_set_name                     = var.notification_email_configuration_set
+  vpc_id                                     = module.network.vpc_id
+  private_subnet_ids                         = module.network.private_subnet_ids
+  lambda_security_group_id                   = module.network.lambda_security_group_id
+  tags                                       = local.common_tags
 }
 
 module "reminder_scheduler" {

--- a/infra/environments/dev/outputs.tf
+++ b/infra/environments/dev/outputs.tf
@@ -120,3 +120,13 @@ output "ses_smtp_vpc_endpoint_security_group_id" {
   description = "SES SMTP interface VPC endpoint security group ID when enabled."
   value       = module.ses_email_foundation.smtp_vpc_endpoint_security_group_id
 }
+
+output "ses_configuration_set_event_publishing_enabled" {
+  description = "Whether SES configuration set EventBridge publishing is configured."
+  value       = module.ses_email_foundation.configuration_set_event_publishing_enabled
+}
+
+output "ses_configuration_set_name" {
+  description = "SES configuration set name when EventBridge publishing is configured."
+  value       = module.ses_email_foundation.configuration_set_name
+}

--- a/infra/environments/dev/terraform.tfvars.example
+++ b/infra/environments/dev/terraform.tfvars.example
@@ -34,6 +34,10 @@ ses_sender_email = ""
 # subnet delivery validation. Keep false until you are ready to test delivery.
 ses_smtp_vpc_endpoint_enabled = false
 
+# Optional. Creates SES configuration set EventBridge publishing for bounce and
+# complaint events. Requires notification_email_configuration_set to be set.
+ses_configuration_set_event_publishing_enabled = false
+
 # Internal notification email delivery is disabled by default. Before enabling,
 # verify the SES identity, create SES SMTP credentials manually, store them in
 # SSM SecureString parameters, and enable the SES SMTP VPC endpoint above.

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -161,6 +161,12 @@ variable "ses_smtp_vpc_endpoint_enabled" {
   default     = false
 }
 
+variable "ses_configuration_set_event_publishing_enabled" {
+  type        = bool
+  description = "Whether to create an SES configuration set with EventBridge publishing for bounce and complaint events."
+  default     = false
+}
+
 variable "notification_email_delivery_enabled" {
   type        = bool
   description = "Whether internal notification email delivery is enabled for the dev Lambda."

--- a/infra/modules/ses_email_foundation/main.tf
+++ b/infra/modules/ses_email_foundation/main.tf
@@ -1,5 +1,14 @@
 locals {
-  sender_email = trimspace(var.sender_email)
+  sender_email            = trimspace(var.sender_email)
+  configuration_set_name  = trimspace(var.configuration_set_name)
+  event_destination_name  = "${var.name_prefix}-notification-email-events"
+  event_publishing_events = ["BOUNCE", "COMPLAINT"]
+}
+
+data "aws_cloudwatch_event_bus" "default" {
+  count = var.configuration_set_event_publishing_enabled ? 1 : 0
+
+  name = "default"
 }
 
 resource "aws_sesv2_email_identity" "sender" {
@@ -8,6 +17,37 @@ resource "aws_sesv2_email_identity" "sender" {
   email_identity = local.sender_email
 
   tags = var.tags
+}
+
+resource "aws_sesv2_configuration_set" "notification_events" {
+  count = var.configuration_set_event_publishing_enabled ? 1 : 0
+
+  configuration_set_name = local.configuration_set_name
+
+  tags = var.tags
+
+  lifecycle {
+    precondition {
+      condition     = local.configuration_set_name != ""
+      error_message = "configuration_set_name must be set when configuration set event publishing is enabled."
+    }
+  }
+}
+
+resource "aws_sesv2_configuration_set_event_destination" "eventbridge" {
+  count = var.configuration_set_event_publishing_enabled ? 1 : 0
+
+  configuration_set_name = aws_sesv2_configuration_set.notification_events[0].configuration_set_name
+  event_destination_name = local.event_destination_name
+
+  event_destination {
+    event_bridge_destination {
+      event_bus_arn = data.aws_cloudwatch_event_bus.default[0].arn
+    }
+
+    enabled              = true
+    matching_event_types = local.event_publishing_events
+  }
 }
 
 resource "aws_security_group" "ses_smtp_vpce" {

--- a/infra/modules/ses_email_foundation/outputs.tf
+++ b/infra/modules/ses_email_foundation/outputs.tf
@@ -17,3 +17,13 @@ output "smtp_vpc_endpoint_security_group_id" {
   value       = try(aws_security_group.ses_smtp_vpce[0].id, null)
   description = "SES SMTP interface VPC endpoint security group ID when enabled."
 }
+
+output "configuration_set_event_publishing_enabled" {
+  value       = length(aws_sesv2_configuration_set_event_destination.eventbridge) > 0
+  description = "Whether SES configuration set EventBridge publishing is configured."
+}
+
+output "configuration_set_name" {
+  value       = try(aws_sesv2_configuration_set.notification_events[0].configuration_set_name, null)
+  description = "SES configuration set name when EventBridge publishing is configured."
+}

--- a/infra/modules/ses_email_foundation/tests/defaults.tftest.hcl
+++ b/infra/modules/ses_email_foundation/tests/defaults.tftest.hcl
@@ -1,4 +1,10 @@
-mock_provider "aws" {}
+mock_provider "aws" {
+  mock_data "aws_cloudwatch_event_bus" {
+    defaults = {
+      arn = "arn:aws:events:eu-north-1:123456789012:event-bus/default"
+    }
+  }
+}
 
 variables {
   name_prefix              = "leaseflow-dev"
@@ -30,6 +36,16 @@ run "defaults_create_no_ses_identity_or_smtp_endpoint" {
   }
 
   assert {
+    condition     = length(aws_sesv2_configuration_set.notification_events) == 0
+    error_message = "SES configuration set should not be created by default."
+  }
+
+  assert {
+    condition     = length(aws_sesv2_configuration_set_event_destination.eventbridge) == 0
+    error_message = "SES EventBridge event destination should not be created by default."
+  }
+
+  assert {
     condition     = output.sender_identity_configured == false
     error_message = "Sender identity output should be false by default."
   }
@@ -37,6 +53,11 @@ run "defaults_create_no_ses_identity_or_smtp_endpoint" {
   assert {
     condition     = output.smtp_vpc_endpoint_enabled == false
     error_message = "SMTP VPC endpoint output should be false by default."
+  }
+
+  assert {
+    condition     = output.configuration_set_event_publishing_enabled == false
+    error_message = "Configuration set event publishing output should be false by default."
   }
 }
 
@@ -124,4 +145,86 @@ run "creates_opt_in_smtp_private_endpoint" {
     condition     = output.smtp_vpc_endpoint_enabled == true
     error_message = "SMTP VPC endpoint output should be true when endpoint is enabled."
   }
+}
+
+run "creates_eventbridge_destination_for_bounce_and_complaint_events" {
+  command = plan
+
+  variables {
+    configuration_set_event_publishing_enabled = true
+    configuration_set_name                     = "leaseflow-dev-notification-email"
+  }
+
+  assert {
+    condition     = length(aws_sesv2_configuration_set.notification_events) == 1
+    error_message = "SES configuration set should be created when event publishing is enabled."
+  }
+
+  assert {
+    condition     = aws_sesv2_configuration_set.notification_events[0].configuration_set_name == "leaseflow-dev-notification-email"
+    error_message = "SES configuration set should use the configured name."
+  }
+
+  assert {
+    condition     = length(aws_sesv2_configuration_set_event_destination.eventbridge) == 1
+    error_message = "SES EventBridge event destination should be created when event publishing is enabled."
+  }
+
+  assert {
+    condition     = aws_sesv2_configuration_set_event_destination.eventbridge[0].event_destination[0].enabled == true
+    error_message = "SES EventBridge event destination should be enabled."
+  }
+
+  assert {
+    condition     = jsonencode(sort(aws_sesv2_configuration_set_event_destination.eventbridge[0].event_destination[0].matching_event_types)) == jsonencode(["BOUNCE", "COMPLAINT"])
+    error_message = "SES EventBridge event destination should publish only bounce and complaint events."
+  }
+
+  assert {
+    condition     = aws_sesv2_configuration_set_event_destination.eventbridge[0].event_destination[0].event_bridge_destination[0].event_bus_arn == "arn:aws:events:eu-north-1:123456789012:event-bus/default"
+    error_message = "SES EventBridge event destination should target the default EventBridge bus."
+  }
+
+  assert {
+    condition     = length(aws_sesv2_configuration_set_event_destination.eventbridge[0].event_destination[0].cloud_watch_destination) == 0
+    error_message = "SES EventBridge event destination should not configure CloudWatch destination."
+  }
+
+  assert {
+    condition     = length(aws_sesv2_configuration_set_event_destination.eventbridge[0].event_destination[0].kinesis_firehose_destination) == 0
+    error_message = "SES EventBridge event destination should not configure Kinesis Firehose destination."
+  }
+
+  assert {
+    condition     = length(aws_sesv2_configuration_set_event_destination.eventbridge[0].event_destination[0].pinpoint_destination) == 0
+    error_message = "SES EventBridge event destination should not configure Pinpoint destination."
+  }
+
+  assert {
+    condition     = length(aws_sesv2_configuration_set_event_destination.eventbridge[0].event_destination[0].sns_destination) == 0
+    error_message = "SES EventBridge event destination should not configure SNS destination."
+  }
+
+  assert {
+    condition     = output.configuration_set_event_publishing_enabled == true
+    error_message = "Configuration set event publishing output should be true when enabled."
+  }
+
+  assert {
+    condition     = output.configuration_set_name == "leaseflow-dev-notification-email"
+    error_message = "Configuration set output should expose only the configured set name."
+  }
+}
+
+run "enabled_event_publishing_requires_configuration_set_name" {
+  command = plan
+
+  variables {
+    configuration_set_event_publishing_enabled = true
+    configuration_set_name                     = ""
+  }
+
+  expect_failures = [
+    aws_sesv2_configuration_set.notification_events
+  ]
 }

--- a/infra/modules/ses_email_foundation/variables.tf
+++ b/infra/modules/ses_email_foundation/variables.tf
@@ -25,6 +25,18 @@ variable "smtp_vpc_endpoint_enabled" {
   default     = false
 }
 
+variable "configuration_set_event_publishing_enabled" {
+  type        = bool
+  description = "Whether to create an SES configuration set with EventBridge publishing for bounce and complaint events."
+  default     = false
+}
+
+variable "configuration_set_name" {
+  type        = string
+  description = "Optional SES configuration set name used when EventBridge event publishing is enabled."
+  default     = ""
+}
+
 variable "vpc_id" {
   type        = string
   description = "VPC ID for the optional SES SMTP interface endpoint."


### PR DESCRIPTION
## What changed and why
Adds a disabled-by-default SESv2 configuration set and EventBridge event destination foundation for future bounce/complaint ingestion. Dev uses `notification_email_configuration_set` as the shared configuration set name so backend SES headers and Terraform-managed SES config cannot silently drift.

## Assumptions
Event publishing is opt-in and targets the default EventBridge bus. The future EventBridge rule, Lambda processor, IAM processor permissions, and suppression updates remain separate tickets.

## Security validation
No browser route, backend handler, frontend flow, tenant context behavior, or provider feedback processor was added. Tenant isolation remains unchanged; no `tenant_id`, recipient email, contact ID, notification ID, raw SES payload, SSM value, or credentials are exposed in outputs or docs.

## Cost validation
Defaults create no SES configuration set or EventBridge destination. Enabling event publishing creates SES event publishing configuration only; no NAT Gateway, public RDS, scheduler, processor Lambda, or new delivery behavior is added.

## Validation
- `terraform fmt -recursive infra`
- `terraform test` in `infra/modules/ses_email_foundation`
- `terraform validate` in `infra/environments/dev`
- `git diff --check`

## Remaining risks / TODOs
Bounce/complaint events are not consumed yet. #203 should add EventBridge routing and a backend processor with sanitized parsing and tenant-scoped updates.
