### PR TITLE
feat: add SES provider feedback processor

### DIFF
--- a/backend/src/app/db.py
+++ b/backend/src/app/db.py
@@ -23,6 +23,7 @@ from app.models import (
     NotificationEmailDeliverySummary,
     Property,
     ReminderScanResult,
+    SesProviderFeedbackResult,
 )
 
 _NOTIFICATION_CONTACT_SUPPRESSION_REASONS = {"bounce", "complaint"}
@@ -451,6 +452,122 @@ class Database:
                         ),
                     ),
                 )
+
+    def process_ses_provider_feedback(
+        self,
+        *,
+        event_correlation_token: UUID,
+        feedback_type: str,
+    ) -> SesProviderFeedbackResult:
+        normalized_feedback_type = feedback_type.strip().lower()
+        if normalized_feedback_type not in _NOTIFICATION_CONTACT_SUPPRESSION_REASONS:
+            raise ValueError("SES provider feedback type must be bounce or complaint.")
+
+        error_code = f"ses_{normalized_feedback_type}"
+        select_delivery_sql = """
+            SELECT tenant_id, delivery_id, contact_id, status, last_error_code
+            FROM notification_email_deliveries
+            WHERE event_correlation_token = %s
+            FOR UPDATE
+        """
+        update_delivery_sql = """
+            UPDATE notification_email_deliveries
+            SET status = 'failed',
+                last_error_code = %s,
+                updated_at = now()
+            WHERE tenant_id = %s AND delivery_id = %s
+        """
+        insert_suppression_sql = """
+            INSERT INTO notification_contact_suppressions (
+                tenant_id,
+                contact_id,
+                reason
+            ) VALUES (%s, %s, %s)
+            ON CONFLICT ON CONSTRAINT uq_notification_contact_suppressions_tenant_contact_reason
+            DO NOTHING
+            RETURNING suppression_id
+        """
+        audit_sql = """
+            INSERT INTO audit_logs (
+                tenant_id, actor_user_id, action, entity_type, entity_id, metadata
+            ) VALUES (%s, %s, %s, %s, %s, %s::jsonb)
+        """
+
+        suppressed_contact_count = 0
+        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+            with conn.transaction():
+                delivery_row = conn.execute(
+                    select_delivery_sql,
+                    (event_correlation_token,),
+                ).fetchone()
+                if delivery_row is None:
+                    return SesProviderFeedbackResult(
+                        processed=False,
+                        feedback_type=normalized_feedback_type,
+                        bounce_count=0,
+                        complaint_count=0,
+                        suppressed_contact_count=0,
+                        unknown_correlation_count=1,
+                    )
+
+                tenant_id = delivery_row["tenant_id"]
+                delivery_id = delivery_row["delivery_id"]
+                contact_id = delivery_row["contact_id"]
+                delivery_changed = (
+                    delivery_row["status"] != "failed"
+                    or delivery_row["last_error_code"] != error_code
+                )
+                if delivery_changed:
+                    conn.execute(update_delivery_sql, (error_code, tenant_id, delivery_id))
+                    conn.execute(
+                        audit_sql,
+                        (
+                            tenant_id,
+                            "leaseflow.internal",
+                            "notification_email_delivery.provider_feedback",
+                            "notification_email_delivery",
+                            delivery_id,
+                            json.dumps(
+                                {
+                                    "source": "aws.ses",
+                                    "feedback_type": normalized_feedback_type,
+                                    "error_code": error_code,
+                                }
+                            ),
+                        ),
+                    )
+
+                suppression_row = conn.execute(
+                    insert_suppression_sql,
+                    (tenant_id, contact_id, normalized_feedback_type),
+                ).fetchone()
+                if suppression_row is not None:
+                    suppressed_contact_count = 1
+                    conn.execute(
+                        audit_sql,
+                        (
+                            tenant_id,
+                            "leaseflow.internal",
+                            "notification_contact_suppression.create",
+                            "notification_contact_suppression",
+                            suppression_row["suppression_id"],
+                            json.dumps(
+                                {
+                                    "source": "aws.ses",
+                                    "reason": normalized_feedback_type,
+                                }
+                            ),
+                        ),
+                    )
+
+        return SesProviderFeedbackResult(
+            processed=True,
+            feedback_type=normalized_feedback_type,
+            bounce_count=1 if normalized_feedback_type == "bounce" else 0,
+            complaint_count=1 if normalized_feedback_type == "complaint" else 0,
+            suppressed_contact_count=suppressed_contact_count,
+            unknown_correlation_count=0,
+        )
 
     def create_due_lease_reminder_notifications(
         self,

--- a/backend/src/app/handler.py
+++ b/backend/src/app/handler.py
@@ -24,6 +24,7 @@ from app.routes.notification_email_delivery import deliver_notification_emails
 from app.routes.notifications import list_notifications, mark_notification_read
 from app.routes.properties import create_property, list_properties, update_property
 from app.routes.reminder_scans import scan_due_lease_reminders
+from app.routes.ses_provider_feedback import process_ses_provider_feedback
 
 setup_logging()
 LOGGER = get_logger(__name__)
@@ -149,6 +150,11 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             and event.get("detail-type") == "configure_notification_contact"
         ):
             return _response(HTTPStatus.OK, configure_notification_contact(event, db))
+        if event.get("source") == "aws.ses" and event.get("detail-type") in {
+            "Email Bounced",
+            "Email Complaint Received",
+        }:
+            return _response(HTTPStatus.OK, process_ses_provider_feedback(event, db, settings))
         if method == "PATCH" and notification_contact_id is not None:
             return _response(
                 HTTPStatus.OK,

--- a/backend/src/app/models.py
+++ b/backend/src/app/models.py
@@ -119,6 +119,16 @@ class NotificationEmailDeliveryPreparationResult:
 
 
 @dataclass(slots=True)
+class SesProviderFeedbackResult:
+    processed: bool
+    feedback_type: str
+    bounce_count: int
+    complaint_count: int
+    suppressed_contact_count: int
+    unknown_correlation_count: int
+
+
+@dataclass(slots=True)
 class ReminderScanResult:
     tenant_id: str | None
     as_of_date: date

--- a/backend/src/app/routes/ses_provider_feedback.py
+++ b/backend/src/app/routes/ses_provider_feedback.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from app.config import Settings
+from app.db import Database
+from app.metrics import emit_emf_metrics
+
+_METRIC_NAMESPACE = "LeaseFlow/NotificationEmailDelivery"
+_METRIC_SERVICE = "backend"
+_METRIC_OPERATION = "process_ses_provider_feedback"
+_CORRELATION_TAG = "leaseflow_delivery_correlation"
+_FEEDBACK_TYPES = {
+    "Email Bounced": "bounce",
+    "Email Complaint Received": "complaint",
+}
+
+
+def process_ses_provider_feedback(
+    event: dict[str, Any],
+    db: Database,
+    settings: Settings,
+) -> dict[str, Any]:
+    feedback_type = _FEEDBACK_TYPES.get(str(event.get("detail-type", "")))
+    if feedback_type is None:
+        payload = _payload(
+            processed=False,
+            feedback_type="ignored",
+            bounce_count=0,
+            complaint_count=0,
+            suppressed_contact_count=0,
+            unknown_correlation_count=0,
+        )
+        _emit_feedback_metrics(settings=settings, result="ignored", payload=payload)
+        return payload
+
+    correlation_token = _parse_correlation_token(event)
+    result = db.process_ses_provider_feedback(
+        event_correlation_token=correlation_token,
+        feedback_type=feedback_type,
+    )
+    payload = _payload(
+        processed=result.processed,
+        feedback_type=result.feedback_type,
+        bounce_count=result.bounce_count,
+        complaint_count=result.complaint_count,
+        suppressed_contact_count=result.suppressed_contact_count,
+        unknown_correlation_count=result.unknown_correlation_count,
+    )
+    _emit_feedback_metrics(
+        settings=settings,
+        result="unknown" if result.unknown_correlation_count else "processed",
+        payload=payload,
+    )
+    return payload
+
+
+def _parse_correlation_token(event: dict[str, Any]) -> UUID:
+    tags = ((event.get("detail") or {}).get("mail") or {}).get("tags") or {}
+    raw_token = tags.get(_CORRELATION_TAG)
+    if isinstance(raw_token, list):
+        raw_token = raw_token[0] if raw_token else None
+    if not isinstance(raw_token, str) or not raw_token.strip():
+        raise ValueError("SES event is missing delivery correlation token.")
+
+    try:
+        return UUID(raw_token.strip())
+    except ValueError as exc:
+        raise ValueError("SES delivery correlation token is invalid.") from exc
+
+
+def _payload(
+    *,
+    processed: bool,
+    feedback_type: str,
+    bounce_count: int,
+    complaint_count: int,
+    suppressed_contact_count: int,
+    unknown_correlation_count: int,
+) -> dict[str, Any]:
+    return {
+        "processed": processed,
+        "feedback_type": feedback_type,
+        "bounce_count": bounce_count,
+        "complaint_count": complaint_count,
+        "suppressed_contact_count": suppressed_contact_count,
+        "unknown_correlation_count": unknown_correlation_count,
+    }
+
+
+def _emit_feedback_metrics(
+    *,
+    settings: Settings,
+    result: str,
+    payload: dict[str, Any],
+) -> None:
+    emit_emf_metrics(
+        namespace=_METRIC_NAMESPACE,
+        environment=settings.app_env,
+        service=_METRIC_SERVICE,
+        operation=_METRIC_OPERATION,
+        result=result,
+        metrics={
+            "bounce_count": payload["bounce_count"],
+            "complaint_count": payload["complaint_count"],
+            "suppressed_contact_count": payload["suppressed_contact_count"],
+        },
+    )

--- a/backend/tests/test_db_integration.py
+++ b/backend/tests/test_db_integration.py
@@ -2382,6 +2382,146 @@ def test_notification_email_delivery_rejects_cross_tenant_status_update(
         _cleanup_test_tenant(integration_settings, other_tenant_id)
 
 
+def test_process_ses_provider_feedback_updates_delivery_and_suppression_idempotently(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+    tenant_id = f"test-local-{uuid4().hex}"
+    actor_user_id = f"user-{uuid4().hex[:12]}"
+
+    try:
+        property_record = db.create_property(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            name=f"SES Feedback HQ {uuid4().hex[:8]}",
+            address=f"SES Feedback Street {uuid4().hex[:8]}",
+        )
+        db.create_lease(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            property_id=property_record.property_id,
+            resident_name=f"SES Feedback User {uuid4().hex[:8]}",
+            rent_due_day_of_month=5,
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+        )
+        contact = db.create_notification_contact(
+            tenant_id=tenant_id,
+            actor_user_id=actor_user_id,
+            email=f"feedback-{uuid4().hex[:8]}@example.com",
+        )
+        db.create_due_lease_reminder_notifications(
+            tenant_id=tenant_id,
+            as_of_date=date(2026, 4, 3),
+            days=7,
+        )
+        db.create_missing_notification_email_deliveries(tenant_id=tenant_id)
+        pending = db.list_pending_notification_email_deliveries(
+            tenant_id=tenant_id,
+            max_attempts=3,
+            limit=10,
+        )[0]
+        db.mark_notification_email_delivery_sent(
+            tenant_id=tenant_id,
+            delivery_id=pending.delivery_id,
+        )
+
+        first = db.process_ses_provider_feedback(
+            event_correlation_token=pending.event_correlation_token,
+            feedback_type="bounce",
+        )
+        second = db.process_ses_provider_feedback(
+            event_correlation_token=pending.event_correlation_token,
+            feedback_type="bounce",
+        )
+
+        with psycopg.connect(integration_settings.db_dsn(), row_factory=dict_row) as conn:
+            delivery_rows = conn.execute(
+                """
+                SELECT tenant_id, status, attempt_count, last_error_code
+                FROM notification_email_deliveries
+                WHERE delivery_id = %s
+                """,
+                (pending.delivery_id,),
+            ).fetchall()
+            suppression_rows = conn.execute(
+                """
+                SELECT tenant_id, contact_id, reason
+                FROM notification_contact_suppressions
+                WHERE tenant_id = %s AND contact_id = %s
+                """,
+                (tenant_id, contact.contact_id),
+            ).fetchall()
+            audit_rows = conn.execute(
+                """
+                SELECT action, entity_id, metadata
+                FROM audit_logs
+                WHERE tenant_id = %s
+                  AND action IN (
+                    'notification_email_delivery.provider_feedback',
+                    'notification_contact_suppression.create'
+                  )
+                ORDER BY action, created_at
+                """,
+                (tenant_id,),
+            ).fetchall()
+
+        assert first.processed is True
+        assert first.feedback_type == "bounce"
+        assert first.bounce_count == 1
+        assert first.complaint_count == 0
+        assert first.suppressed_contact_count == 1
+        assert first.unknown_correlation_count == 0
+        assert second.processed is True
+        assert second.suppressed_contact_count == 0
+        assert delivery_rows == [
+            {
+                "tenant_id": tenant_id,
+                "status": "failed",
+                "attempt_count": 1,
+                "last_error_code": "ses_bounce",
+            }
+        ]
+        assert suppression_rows == [
+            {
+                "tenant_id": tenant_id,
+                "contact_id": contact.contact_id,
+                "reason": "bounce",
+            }
+        ]
+        assert len(audit_rows) == 2
+        for row in audit_rows:
+            metadata = row["metadata"]
+            assert "email" not in metadata
+            assert "tenant_id" not in metadata
+            assert "contact_id" not in metadata
+            assert "notification_id" not in metadata
+            assert "event_correlation_token" not in metadata
+            assert "message" not in metadata
+            assert "body" not in metadata
+            assert "provider_payload" not in metadata
+    finally:
+        _cleanup_test_tenant(integration_settings, tenant_id)
+
+
+def test_process_ses_provider_feedback_unknown_correlation_is_safe_noop(
+    integration_settings: Settings,
+) -> None:
+    db = Database(integration_settings)
+
+    result = db.process_ses_provider_feedback(
+        event_correlation_token=uuid4(),
+        feedback_type="complaint",
+    )
+
+    assert result.processed is False
+    assert result.feedback_type == "complaint"
+    assert result.bounce_count == 0
+    assert result.complaint_count == 0
+    assert result.suppressed_contact_count == 0
+    assert result.unknown_correlation_count == 1
+
+
 def test_list_notifications_includes_tenant_scoped_email_delivery_summary(
     integration_settings: Settings,
 ) -> None:

--- a/backend/tests/test_handler.py
+++ b/backend/tests/test_handler.py
@@ -740,6 +740,48 @@ def test_configure_notification_contact_accepts_internal_event(monkeypatch) -> N
     }
 
 
+def test_ses_provider_feedback_accepts_eventbridge_bounce_event(monkeypatch) -> None:
+    settings = SimpleNamespace(log_level="INFO", app_env="test")
+    db = object()
+    monkeypatch.setattr(handler, "load_settings", lambda: settings)
+    monkeypatch.setattr(handler, "Database", lambda loaded_settings: db)
+    monkeypatch.setattr(
+        handler,
+        "process_ses_provider_feedback",
+        lambda event, database, loaded_settings: {
+            "processed": True,
+            "feedback_type": "bounce",
+            "bounce_count": 1,
+            "complaint_count": 0,
+            "suppressed_contact_count": 1,
+            "unknown_correlation_count": 0,
+        },
+        raising=False,
+    )
+
+    event = {
+        "source": "aws.ses",
+        "detail-type": "Email Bounced",
+        "detail": {
+            "mail": {
+                "tags": {"leaseflow_delivery_correlation": ["11111111-1111-4111-8111-111111111111"]}
+            }
+        },
+    }
+
+    response = handler.lambda_handler(event, SimpleNamespace(aws_request_id="test-id"))
+
+    assert response["statusCode"] == 200
+    assert json.loads(response["body"]) == {
+        "processed": True,
+        "feedback_type": "bounce",
+        "bounce_count": 1,
+        "complaint_count": 0,
+        "suppressed_contact_count": 1,
+        "unknown_correlation_count": 0,
+    }
+
+
 def test_list_notification_contacts_accepts_protected_route(monkeypatch) -> None:
     settings = SimpleNamespace(log_level="INFO")
     db = object()

--- a/backend/tests/test_ses_provider_feedback_route.py
+++ b/backend/tests/test_ses_provider_feedback_route.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+
+def _feedback_module():
+    return importlib.import_module("app.routes.ses_provider_feedback")
+
+
+class _FakeDb:
+    def __init__(self, *, processed: bool = True) -> None:
+        self.processed = processed
+        self.calls: list[tuple[UUID, str]] = []
+
+    def process_ses_provider_feedback(
+        self,
+        *,
+        event_correlation_token: UUID,
+        feedback_type: str,
+    ) -> SimpleNamespace:
+        self.calls.append((event_correlation_token, feedback_type))
+        if not self.processed:
+            return SimpleNamespace(
+                processed=False,
+                feedback_type=feedback_type,
+                bounce_count=0,
+                complaint_count=0,
+                suppressed_contact_count=0,
+                unknown_correlation_count=1,
+            )
+        return SimpleNamespace(
+            processed=True,
+            feedback_type=feedback_type,
+            bounce_count=1 if feedback_type == "bounce" else 0,
+            complaint_count=1 if feedback_type == "complaint" else 0,
+            suppressed_contact_count=1,
+            unknown_correlation_count=0,
+        )
+
+
+def _event(detail_type: str = "Email Bounced", token: object | None = None) -> dict[str, Any]:
+    if token is None:
+        token = "11111111-1111-4111-8111-111111111111"
+    return {
+        "version": "0",
+        "id": "event-id-that-must-not-be-a-metric-dimension",
+        "source": "aws.ses",
+        "detail-type": detail_type,
+        "detail": {
+            "mail": {
+                "destination": ["recipient@example.test"],
+                "tags": {
+                    "leaseflow_delivery_correlation": [token],
+                    "raw_provider_tag": ["not-used"],
+                },
+            },
+            "bounce": {
+                "bounceType": "Permanent",
+                "bouncedRecipients": [{"emailAddress": "recipient@example.test"}],
+            },
+            "complaint": {
+                "complainedRecipients": [{"emailAddress": "recipient@example.test"}],
+            },
+        },
+    }
+
+
+def _capture_metrics(monkeypatch) -> list[dict[str, Any]]:
+    feedback = _feedback_module()
+    emitted: list[dict[str, Any]] = []
+
+    def _emit(**kwargs: Any) -> None:
+        emitted.append(kwargs)
+
+    monkeypatch.setattr(feedback, "emit_emf_metrics", _emit, raising=False)
+    return emitted
+
+
+def test_processes_bounce_event_by_correlation_token(monkeypatch) -> None:
+    feedback = _feedback_module()
+    db = _FakeDb()
+    emitted = _capture_metrics(monkeypatch)
+
+    payload = feedback.process_ses_provider_feedback(
+        _event("Email Bounced"),
+        db,
+        SimpleNamespace(app_env="test"),
+    )
+
+    token = UUID("11111111-1111-4111-8111-111111111111")
+    assert db.calls == [(token, "bounce")]
+    assert payload == {
+        "processed": True,
+        "feedback_type": "bounce",
+        "bounce_count": 1,
+        "complaint_count": 0,
+        "suppressed_contact_count": 1,
+        "unknown_correlation_count": 0,
+    }
+    assert emitted == [
+        {
+            "namespace": "LeaseFlow/NotificationEmailDelivery",
+            "environment": "test",
+            "service": "backend",
+            "operation": "process_ses_provider_feedback",
+            "result": "processed",
+            "metrics": {
+                "bounce_count": 1,
+                "complaint_count": 0,
+                "suppressed_contact_count": 1,
+            },
+        }
+    ]
+
+
+def test_processes_complaint_event_by_correlation_token(monkeypatch) -> None:
+    feedback = _feedback_module()
+    db = _FakeDb()
+    _capture_metrics(monkeypatch)
+
+    payload = feedback.process_ses_provider_feedback(
+        _event("Email Complaint Received"),
+        db,
+        SimpleNamespace(app_env="test"),
+    )
+
+    assert db.calls == [(UUID("11111111-1111-4111-8111-111111111111"), "complaint")]
+    assert payload["feedback_type"] == "complaint"
+    assert payload["bounce_count"] == 0
+    assert payload["complaint_count"] == 1
+    assert payload["suppressed_contact_count"] == 1
+
+
+def test_unknown_correlation_token_is_safe_noop(monkeypatch) -> None:
+    feedback = _feedback_module()
+    db = _FakeDb(processed=False)
+    emitted = _capture_metrics(monkeypatch)
+
+    payload = feedback.process_ses_provider_feedback(
+        _event("Email Bounced"),
+        db,
+        SimpleNamespace(app_env="test"),
+    )
+
+    assert payload == {
+        "processed": False,
+        "feedback_type": "bounce",
+        "bounce_count": 0,
+        "complaint_count": 0,
+        "suppressed_contact_count": 0,
+        "unknown_correlation_count": 1,
+    }
+    assert emitted[0]["result"] == "unknown"
+
+
+def test_rejects_missing_correlation_token_without_leaking_raw_payload(monkeypatch) -> None:
+    feedback = _feedback_module()
+    event = _event("Email Bounced")
+    event["detail"]["mail"]["tags"] = {}
+    _capture_metrics(monkeypatch)
+
+    with pytest.raises(ValueError, match="SES event is missing delivery correlation token."):
+        feedback.process_ses_provider_feedback(event, _FakeDb(), SimpleNamespace(app_env="test"))
+
+
+def test_rejects_malformed_correlation_token_without_leaking_raw_payload(monkeypatch) -> None:
+    feedback = _feedback_module()
+    _capture_metrics(monkeypatch)
+
+    with pytest.raises(ValueError, match="SES delivery correlation token is invalid."):
+        feedback.process_ses_provider_feedback(
+            _event("Email Bounced", token="not-a-uuid"),
+            _FakeDb(),
+            SimpleNamespace(app_env="test"),
+        )
+
+
+def test_metrics_do_not_include_sensitive_payload_values(monkeypatch) -> None:
+    feedback = _feedback_module()
+    emitted = _capture_metrics(monkeypatch)
+
+    feedback.process_ses_provider_feedback(
+        _event("Email Bounced"),
+        _FakeDb(),
+        SimpleNamespace(app_env="test"),
+    )
+
+    emitted_text = str(emitted)
+    assert "recipient@example.test" not in emitted_text
+    assert "11111111-1111-4111-8111-111111111111" not in emitted_text
+    assert "event-id-that-must-not-be-a-metric-dimension" not in emitted_text
+    assert "raw_provider_tag" not in emitted_text
+    assert "tenant" not in emitted_text.lower()
+    assert "contact_id" not in emitted_text
+    assert "notification_id" not in emitted_text

--- a/docs/notification-email-delivery-mvp.md
+++ b/docs/notification-email-delivery-mvp.md
@@ -40,6 +40,10 @@ SES deliverability.
 - Terraform can optionally create the matching SES configuration set and an
   EventBridge event destination for bounce/complaint publishing. It is disabled
   by default and does not ingest or process provider feedback by itself.
+- Terraform can optionally route SES bounce/complaint EventBridge events to the
+  backend processor. This is disabled by default.
+- The backend can process SES bounce/complaint feedback through the opaque
+  delivery correlation token and persist sanitized delivery/suppression state.
 - Dev smoke validation is documented in
   `docs/runbooks/ses-notification-email-delivery-smoke-test.md`, with sanitized
   successful evidence in
@@ -55,15 +59,16 @@ SES deliverability.
   `docs/ses-production-domain-identity-dns-authentication.md`; production
   sending remains unavailable.
 - Bounce and complaint ingestion planning is documented in
-  `docs/ses-bounce-complaint-ingestion.md`; the opt-in EventBridge publishing
-  foundation exists, but provider feedback ingestion is not implemented yet.
+  `docs/ses-bounce-complaint-ingestion.md`; the opt-in EventBridge publishing,
+  routing, and backend processor foundation exists.
 - Notification suppression and unsubscribe/preference planning is documented in
   `docs/notification-suppression-unsubscribe-model.md`; tenant/contact-scoped
   suppression state exists, but delivery eligibility and UI visibility remain
   future work.
 - SES delivery monitoring, alarm, and cost-control planning is documented in
-  `docs/ses-delivery-monitoring-alarms-cost-controls.md`; delivery-specific
-  metrics, alarms, dashboards, and budget resources are not implemented yet.
+  `docs/ses-delivery-monitoring-alarms-cost-controls.md`; delivery and
+  provider-feedback metrics exist, while production feedback alarms/evidence
+  remain future work.
 - Persisted `notifications` remain the source of delivery work; the delivery
   job must not recalculate reminder candidates independently.
 - Recipient addresses come from a LeaseFlow-owned tenant-scoped contact
@@ -97,7 +102,7 @@ Delivery tracking is stored in `notification_email_deliveries` and supports:
 - last attempt timestamp
 - sent timestamp
 - non-sensitive failure category or code
-- opaque event correlation token for future provider feedback matching
+- opaque event correlation token for provider feedback matching
 
 Do not store SES raw responses, SMTP transcripts, recipient email addresses,
 message bodies, or secrets in delivery rows.
@@ -148,8 +153,8 @@ Delivery must be idempotent and retry-safe:
 - Delivery remains disabled by default until SES identity, sandbox restrictions,
   SMTP credentials, endpoint connectivity, and smoke validation are ready.
 - SES configuration set EventBridge publishing remains disabled by default and
-  produces no useful application state until real SES events exist and a future
-  processor is implemented.
+  produces no useful application state until real SES events exist and processor
+  routing is enabled.
 
 ## Security And Tenant Isolation
 
@@ -178,6 +183,8 @@ The implementation should be split into separate reviewable tickets:
 - Expose safe notification email delivery status. Completed as read-only
   aggregate status on persisted notifications.
 - Add SES delivery smoke runbook and sanitized evidence. Runbook added;
+- Implement SES bounce and complaint processor. Completed as disabled-by-default
+  EventBridge routing plus internal backend processing.
 - Add production-ready SES delivery hardening. Planned separately in
   `docs/ses-production-delivery-hardening.md`.
 

--- a/docs/notification-suppression-unsubscribe-model.md
+++ b/docs/notification-suppression-unsubscribe-model.md
@@ -20,7 +20,8 @@ work.
   codes, and sent timestamps.
 - `notification_contact_suppressions` stores tenant/contact-scoped active
   suppressions for `bounce` and `complaint` reasons.
-- Bounce and complaint ingestion is planned separately in
+- Bounce and complaint ingestion exists as disabled-by-default internal
+  processing and opt-in EventBridge routing, documented in
   `docs/ses-bounce-complaint-ingestion.md`.
 - Delivery eligibility does not consume suppression state yet; that remains a
   separate implementation step.

--- a/docs/ses-bounce-complaint-ingestion.md
+++ b/docs/ses-bounce-complaint-ingestion.md
@@ -5,11 +5,11 @@
 This document defines the future production path for ingesting Amazon SES
 bounce and complaint events for LeaseFlow notification email.
 
-This is primarily a planning artifact. Terraform now includes an
-disabled-by-default SES configuration set and EventBridge event destination
-foundation, but backend processing, EventBridge routing rules, frontend
-behavior, DNS records, SES production access, and email-sending behavior remain
-out of scope.
+This document records the current implementation and remaining production
+boundaries. Terraform now includes disabled-by-default SES event publishing and
+processor routing, and the backend can process sanitized bounce/complaint
+events. Frontend behavior, DNS records, SES production access, and production
+email-sending readiness remain out of scope.
 
 ## Current State
 
@@ -28,7 +28,12 @@ out of scope.
 - Terraform can optionally create an SES configuration set with an EventBridge
   event destination for `BOUNCE` and `COMPLAINT` events. This is disabled by
   default and requires an explicit configuration set name.
-- Bounce and complaint event ingestion does not exist yet.
+- Terraform can optionally route SES `Email Bounced` and
+  `Email Complaint Received` events from the default EventBridge bus to the
+  backend Lambda. This is disabled by default.
+- The backend resolves SES provider feedback through the opaque
+  `leaseflow_delivery_correlation` message tag and stores only sanitized
+  delivery/suppression state.
 - SES accepting an SMTP message is not proof that the recipient accepted or
   retained the message.
 
@@ -40,9 +45,9 @@ EventBridge is the chosen default for future LeaseFlow bounce and complaint
 ingestion.
 
 SES event publishing supports configuration set event destinations. LeaseFlow
-now has an opt-in Terraform foundation that can publish only the required
-`BOUNCE` and `COMPLAINT` events to EventBridge. A future EventBridge rule can
-then route matching events to a future internal backend processor without
+has an opt-in Terraform foundation that can publish only the required `BOUNCE`
+and `COMPLAINT` events to EventBridge. A separate opt-in EventBridge rule routes
+SES bounce and complaint events to the internal backend processor without
 exposing any browser control path.
 
 This fits the current LeaseFlow direction: internal jobs use AWS events, browser
@@ -69,16 +74,16 @@ data without storing raw provider payloads by default.
 
 ## Target Architecture
 
-Future implementation should build on:
+The implemented ingestion path uses:
 
 - SES configuration set with an opt-in EventBridge event destination.
 - Matching event types limited to `BOUNCE` and `COMPLAINT`.
-- Future EventBridge rule that targets an internal backend processor.
+- Opt-in EventBridge rule that targets the internal backend processor.
 - Backend processor that maps provider events to sanitized categories and
   tenant/contact-scoped state changes.
-- Delivery-row updates for the matching notification/contact relationship when
-  that relationship can be safely resolved.
-- Suppression/preference state updates for permanent bounces and complaints.
+- Delivery-row updates for the matching notification/contact relationship
+  resolved by opaque correlation token.
+- Suppression state updates for bounces and complaints.
 
 `DELIVERY_DELAY`, `REJECT`, or other SES event types should be added only by a
 separate decision because they have different operational meaning and retry
@@ -122,9 +127,9 @@ event processing remain future work.
 
 ### Implement SES Bounce And Complaint Processor
 
-Add an internal backend event handler that parses SES events into sanitized
-categories and updates tenant/contact-scoped state. Include unit and integration
-tests for tenant isolation and no raw payload persistence.
+Completed as an internal backend event handler plus opt-in EventBridge routing.
+It parses SES bounce/complaint events into sanitized categories and updates
+tenant/contact-scoped state through the opaque delivery correlation token.
 
 ### Add Notification Suppression State
 
@@ -134,8 +139,9 @@ Cognito user enumeration and marketing email.
 
 ### Add Bounce Complaint Monitoring And Evidence
 
-Add aggregate metrics, alarms, runbook steps, and sanitized evidence templates
-for bounce/complaint ingestion validation.
+Add alarms, runbook steps, and sanitized evidence templates for
+bounce/complaint ingestion validation. Aggregate processor metrics now exist,
+but alarms/evidence remain future work.
 
 ## Security And Cost Boundaries
 

--- a/docs/ses-delivery-monitoring-alarms-cost-controls.md
+++ b/docs/ses-delivery-monitoring-alarms-cost-controls.md
@@ -17,8 +17,8 @@ actions.
   by default.
 - Dev SES SMTP delivery has sanitized smoke evidence, but this does not prove
   production monitoring or production email readiness.
-- SES bounce/complaint ingestion is planned in
-  `docs/ses-bounce-complaint-ingestion.md`, not implemented.
+- SES bounce/complaint ingestion exists as a disabled-by-default internal
+  backend processor and opt-in EventBridge routing.
 - Notification suppression and unsubscribe/preference handling is planned in
   `docs/notification-suppression-unsubscribe-model.md`, not implemented.
 - Production rollout hardening is planned in
@@ -72,7 +72,7 @@ The delivery worker emits these aggregate counters:
 - `skipped_count`
 - `retry_exhausted_count`
 
-The future bounce/complaint processor should emit these aggregate counters:
+The bounce/complaint processor emits these aggregate counters:
 
 - `bounce_count`
 - `complaint_count`
@@ -144,8 +144,8 @@ Implemented dashboard panels show:
   suppressed contacts
 
 Future feedback and suppression widgets are intentionally present before those
-processors emit metrics. They should render as no-data until the future
-bounce/complaint and suppression implementations exist.
+metrics are emitted. They can render as no-data until EventBridge routing is
+enabled and real SES feedback events are processed.
 
 ## Cost Controls
 
@@ -202,9 +202,10 @@ against the existing private SES SMTP endpoint direction.
 
 ### Emit SES Delivery CloudWatch Custom Metrics
 
-Completed for the internal delivery worker. Future bounce/complaint processor
-metrics remain out of scope. Recipient-level dimensions, tenant dimensions,
-Terraform alarms, and dashboard resources remain out of scope.
+Completed for the internal delivery worker. Bounce/complaint processor
+metrics are also implemented as aggregate EMF-style counters. Recipient-level
+dimensions, tenant dimensions, Terraform alarms, and dashboard resources remain
+out of scope for metric emission.
 
 ### Add SES Delivery CloudWatch Alarms
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -11,6 +11,7 @@ Terraform code is split into reusable modules and environment composition.
 - `modules/frontend_hosting`: private S3 bucket and CloudFront distribution for the SPA.
 - `modules/lambda_backend`: backend Lambda function, IAM role, log group.
 - `modules/ses_email_foundation`: optional SES sender identity, SES SMTP PrivateLink, and SES EventBridge publishing foundation.
+- `modules/ses_feedback_eventbridge_processor`: optional EventBridge routing from SES provider feedback events to the backend Lambda.
 - `modules/reminder_scheduler`: EventBridge Scheduler + IAM role for daily reminder scans.
 - `modules/api_http`: HTTP API, JWT authorizer, route wiring.
 - `environments/dev`: MVP dev environment composition.
@@ -73,9 +74,15 @@ is explicitly enabled and operator-provided SES SMTP credentials are configured.
   The same value is used by the backend SES configuration-set header and the
   Terraform-managed SES configuration set name.
 - The EventBridge destination publishes only SES `BOUNCE` and `COMPLAINT`
-  events to the default event bus. Terraform does not create a processor rule,
-  Lambda target, provider feedback handler, or suppression automation in this
-  slice.
+  events to the default event bus.
+- `ses_feedback_processor_eventbridge_enabled` defaults to `false`. When
+  enabled, Terraform creates a default-bus EventBridge rule, backend Lambda
+  target, and scoped Lambda permission for SES `Email Bounced` and
+  `Email Complaint Received` events.
+- The backend provider feedback processor stores only sanitized delivery and
+  suppression state resolved through the opaque delivery correlation token.
+  Terraform does not create browser delivery actions, browser scan/retry/provider
+  feedback controls, or production email readiness.
 - SES sandbox and verified-identity limits still apply. In sandbox mode, test
   sending is constrained until identities and production access are handled.
 - `notification_email_delivery_enabled` defaults to `false`.
@@ -84,7 +91,7 @@ is explicitly enabled and operator-provided SES SMTP credentials are configured.
   Lambda least-privilege read/decrypt access to those configured parameters.
 - Terraform does not create SMTP credentials, IAM users, browser delivery
   actions, browser scan/retry/provider-feedback controls, automatic delivery
-  schedules, or production email readiness.
+  schedules, raw provider payload storage, or production email readiness.
 - External SMTP delivery is not exactly-once: if Lambda crashes after SES
   accepts a message but before `sent_at` is persisted, a later retry can send
   another email for the same notification/contact pair.

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -146,6 +146,16 @@ module "reminder_scheduler" {
   tags                 = local.common_tags
 }
 
+module "ses_feedback_eventbridge_processor" {
+  source = "../../modules/ses_feedback_eventbridge_processor"
+
+  name_prefix          = local.name_prefix
+  lambda_function_name = module.lambda_backend.function_name
+  lambda_function_arn  = module.lambda_backend.function_arn
+  enabled              = var.ses_feedback_processor_eventbridge_enabled
+  tags                 = local.common_tags
+}
+
 resource "aws_sns_topic" "baseline_alarm_notifications" {
   name = "${local.name_prefix}-baseline-alarm-notifications"
 

--- a/infra/environments/dev/outputs.tf
+++ b/infra/environments/dev/outputs.tf
@@ -130,3 +130,13 @@ output "ses_configuration_set_name" {
   description = "SES configuration set name when EventBridge publishing is configured."
   value       = module.ses_email_foundation.configuration_set_name
 }
+
+output "ses_feedback_processor_eventbridge_enabled" {
+  description = "Whether SES feedback EventBridge routing is configured."
+  value       = module.ses_feedback_eventbridge_processor.enabled
+}
+
+output "ses_feedback_processor_eventbridge_rule_name" {
+  description = "SES feedback EventBridge rule name when enabled."
+  value       = module.ses_feedback_eventbridge_processor.rule_name
+}

--- a/infra/environments/dev/terraform.tfvars.example
+++ b/infra/environments/dev/terraform.tfvars.example
@@ -38,6 +38,10 @@ ses_smtp_vpc_endpoint_enabled = false
 # complaint events. Requires notification_email_configuration_set to be set.
 ses_configuration_set_event_publishing_enabled = false
 
+# Optional. Routes SES bounce and complaint EventBridge events to the backend
+# processor. Keep false until event publishing is enabled and ready to test.
+ses_feedback_processor_eventbridge_enabled = false
+
 # Internal notification email delivery is disabled by default. Before enabling,
 # verify the SES identity, create SES SMTP credentials manually, store them in
 # SSM SecureString parameters, and enable the SES SMTP VPC endpoint above.

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -167,6 +167,12 @@ variable "ses_configuration_set_event_publishing_enabled" {
   default     = false
 }
 
+variable "ses_feedback_processor_eventbridge_enabled" {
+  type        = bool
+  description = "Whether to route SES bounce and complaint EventBridge events to the backend processor."
+  default     = false
+}
+
 variable "notification_email_delivery_enabled" {
   type        = bool
   description = "Whether internal notification email delivery is enabled for the dev Lambda."

--- a/infra/modules/ses_delivery_dashboard/main.tf
+++ b/infra/modules/ses_delivery_dashboard/main.tf
@@ -21,6 +21,13 @@ locals {
     "operation", "deliver_notification_emails",
     "result", "disabled",
   ]
+
+  feedback_processed_dimensions = [
+    "environment", var.environment,
+    "service", "backend",
+    "operation", "process_ses_provider_feedback",
+    "result", "processed",
+  ]
 }
 
 resource "aws_cloudwatch_dashboard" "notification_email_delivery" {
@@ -113,9 +120,9 @@ resource "aws_cloudwatch_dashboard" "notification_email_delivery" {
           stat    = "Sum"
           period  = 300
           metrics = [
-            concat([local.namespace, "bounce_count"], local.completed_dimensions, [{ label = "bounces" }]),
-            concat([local.namespace, "complaint_count"], local.completed_dimensions, [{ label = "complaints" }]),
-            concat([local.namespace, "suppressed_contact_count"], local.completed_dimensions, [{ label = "suppressed contacts" }]),
+            concat([local.namespace, "bounce_count"], local.feedback_processed_dimensions, [{ label = "bounces" }]),
+            concat([local.namespace, "complaint_count"], local.feedback_processed_dimensions, [{ label = "complaints" }]),
+            concat([local.namespace, "suppressed_contact_count"], local.feedback_processed_dimensions, [{ label = "suppressed contacts" }]),
           ]
         }
       },

--- a/infra/modules/ses_delivery_dashboard/tests/defaults.tftest.hcl
+++ b/infra/modules/ses_delivery_dashboard/tests/defaults.tftest.hcl
@@ -60,6 +60,7 @@ run "creates_safe_aggregate_delivery_dashboard" {
         "backend",
         "operation",
         "deliver_notification_emails",
+        "process_ses_provider_feedback",
         "result",
         "completed",
         "completed_with_failures",

--- a/infra/modules/ses_feedback_eventbridge_processor/.terraform.lock.hcl
+++ b/infra/modules/ses_feedback_eventbridge_processor/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.44.0"
+  constraints = "~> 6.37"
+  hashes = [
+    "h1:lJvGaC4YNXk3TIdrd5GCIyV0gxU1WigQIao8rmcpplc=",
+    "zh:0462747d28f6dcd7b1b723bea9da1600526b7cdcf929ed4be54352d74b0746e6",
+    "zh:0c9b7e7b04050360f609ff5700d8a76227fb4ea84dac92b844d82a2013706705",
+    "zh:2877a6854edf237f9d6c66dc928294cbbcf29d3f52577fb8f232d0cfd11d5c0d",
+    "zh:3347b82e222bbfad326b79c408e53a9252b80c6c762f4dd4f4617583394f0a4e",
+    "zh:33997dbe611b5abf49c87a31f29d8f797c97421f67b71fec8aa688799511b758",
+    "zh:5d5c37375c5e776e6e8f95fb8cbd8009258618b9f51c55551a18adc09ef5814a",
+    "zh:67d6bd61c52ca5f4c37c96a76f6820c9f1902e4b83f89faddf9fd7f17ba0b160",
+    "zh:739588639fa30db7084d6939c2eb9b4dd2d7f58dbb5d5b3b2c4bda2a35dcf521",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a953797142df4245bd8f456b9e78690f501a0fff2f58552db4eb2da409cd99e9",
+    "zh:aeb8d616dd34a9f1c5048ed4cdd6d7692db93cd33a468872618d4cd38c4784aa",
+    "zh:dc8420556aca50658247b097de6734259fc3a6012ff1cf96612fca10b3982f9d",
+    "zh:f9083d6d9fb9cbdcd91e38c92f96e67223ecc7ce6d0986bd5eb8e6d52e9aa02b",
+    "zh:f9418aa1e4d29f9026aa6f521e97d085e000902ea929debbbef61135185e3ad4",
+    "zh:fb2494a6c92118055cfb2c114a4fe5c750946a1b0d6be6bf02ab3e37a091fb8b",
+  ]
+}

--- a/infra/modules/ses_feedback_eventbridge_processor/main.tf
+++ b/infra/modules/ses_feedback_eventbridge_processor/main.tf
@@ -1,0 +1,30 @@
+resource "aws_cloudwatch_event_rule" "ses_feedback" {
+  count = var.enabled ? 1 : 0
+
+  name        = "${var.name_prefix}-ses-feedback"
+  description = "Routes SES bounce and complaint feedback events to the LeaseFlow backend."
+
+  event_pattern = jsonencode({
+    source        = ["aws.ses"]
+    "detail-type" = ["Email Bounced", "Email Complaint Received"]
+  })
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-ses-feedback" })
+}
+
+resource "aws_cloudwatch_event_target" "lambda" {
+  count = var.enabled ? 1 : 0
+
+  rule = aws_cloudwatch_event_rule.ses_feedback[0].name
+  arn  = var.lambda_function_arn
+}
+
+resource "aws_lambda_permission" "eventbridge" {
+  count = var.enabled ? 1 : 0
+
+  statement_id  = "AllowExecutionFromSesFeedbackEventBridge"
+  action        = "lambda:InvokeFunction"
+  function_name = var.lambda_function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.ses_feedback[0].arn
+}

--- a/infra/modules/ses_feedback_eventbridge_processor/outputs.tf
+++ b/infra/modules/ses_feedback_eventbridge_processor/outputs.tf
@@ -1,0 +1,9 @@
+output "rule_name" {
+  value       = try(aws_cloudwatch_event_rule.ses_feedback[0].name, null)
+  description = "SES feedback EventBridge rule name when enabled."
+}
+
+output "enabled" {
+  value       = length(aws_cloudwatch_event_rule.ses_feedback) > 0
+  description = "Whether SES feedback EventBridge routing is configured."
+}

--- a/infra/modules/ses_feedback_eventbridge_processor/tests/defaults.tftest.hcl
+++ b/infra/modules/ses_feedback_eventbridge_processor/tests/defaults.tftest.hcl
@@ -1,0 +1,79 @@
+mock_provider "aws" {
+  mock_resource "aws_cloudwatch_event_rule" {
+    defaults = {
+      arn = "arn:aws:events:eu-north-1:123456789012:rule/leaseflow-dev-ses-feedback"
+    }
+  }
+}
+
+variables {
+  name_prefix          = "leaseflow-dev"
+  lambda_function_name = "leaseflow-dev-backend"
+  lambda_function_arn  = "arn:aws:lambda:eu-north-1:123456789012:function:leaseflow-dev-backend"
+  enabled              = false
+  tags = {
+    Project = "leaseflow"
+  }
+}
+
+run "defaults_create_no_eventbridge_processor_resources" {
+  command = plan
+
+  assert {
+    condition     = length(aws_cloudwatch_event_rule.ses_feedback) == 0
+    error_message = "SES feedback EventBridge rule should not be created by default."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_event_target.lambda) == 0
+    error_message = "SES feedback Lambda target should not be created by default."
+  }
+
+  assert {
+    condition     = length(aws_lambda_permission.eventbridge) == 0
+    error_message = "SES feedback Lambda permission should not be created by default."
+  }
+}
+
+run "enabled_rule_routes_ses_bounce_and_complaint_events_to_lambda" {
+  command = apply
+
+  variables {
+    enabled = true
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_event_rule.ses_feedback) == 1
+    error_message = "SES feedback EventBridge rule should be created when enabled."
+  }
+
+  assert {
+    condition     = jsondecode(aws_cloudwatch_event_rule.ses_feedback[0].event_pattern).source == ["aws.ses"]
+    error_message = "SES feedback rule should match only SES events."
+  }
+
+  assert {
+    condition     = jsonencode(sort(jsondecode(aws_cloudwatch_event_rule.ses_feedback[0].event_pattern)["detail-type"])) == jsonencode(["Email Bounced", "Email Complaint Received"])
+    error_message = "SES feedback rule should match only bounce and complaint detail types."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_event_target.lambda[0].arn == var.lambda_function_arn
+    error_message = "SES feedback rule target should invoke the backend Lambda ARN."
+  }
+
+  assert {
+    condition     = aws_lambda_permission.eventbridge[0].principal == "events.amazonaws.com"
+    error_message = "SES feedback Lambda permission should allow EventBridge service principal."
+  }
+
+  assert {
+    condition     = aws_lambda_permission.eventbridge[0].function_name == var.lambda_function_name
+    error_message = "SES feedback Lambda permission should target the configured Lambda function name."
+  }
+
+  assert {
+    condition     = aws_lambda_permission.eventbridge[0].source_arn == aws_cloudwatch_event_rule.ses_feedback[0].arn
+    error_message = "SES feedback Lambda permission should be scoped to the EventBridge rule ARN."
+  }
+}

--- a/infra/modules/ses_feedback_eventbridge_processor/variables.tf
+++ b/infra/modules/ses_feedback_eventbridge_processor/variables.tf
@@ -1,0 +1,26 @@
+variable "name_prefix" {
+  type        = string
+  description = "Prefix for SES feedback EventBridge processor resources."
+}
+
+variable "lambda_function_name" {
+  type        = string
+  description = "Backend Lambda function name targeted by SES feedback events."
+}
+
+variable "lambda_function_arn" {
+  type        = string
+  description = "Backend Lambda function ARN targeted by SES feedback events."
+}
+
+variable "enabled" {
+  type        = bool
+  description = "Whether to create EventBridge routing for SES bounce and complaint processor events."
+  default     = false
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Common tags."
+  default     = {}
+}

--- a/infra/modules/ses_feedback_eventbridge_processor/versions.tf
+++ b/infra/modules/ses_feedback_eventbridge_processor/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.37"
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Implements internal SES bounce/complaint provider feedback handling.

- Added backend processor for SES EventBridge bounce and complaint events.
- Resolves feedback only through the opaque `leaseflow_delivery_correlation` token.
- Updates matched delivery rows with sanitized `ses_bounce` / `ses_complaint` failure codes.
- Creates tenant-scoped contact suppressions idempotently.
- Emits aggregate EMF metrics for provider feedback processing.
- Adds disabled-by-default Terraform EventBridge routing to the backend Lambda.
- Updates monitoring/dashboard dimensions and SES delivery docs.

## Assumptions

- SES EventBridge events provide the outbound message tag at `detail.mail.tags.leaseflow_delivery_correlation`.
- EventBridge routing stays disabled by default until SES event publishing and processor routing are intentionally enabled.
- Unknown correlation tokens are safe no-ops.

## Security validation

- Tenant/contact context is derived only from the matched delivery row, never from SES event payload tenant input.
- No browser route or API Gateway route was added.
- Audit metadata excludes recipient email, tenant ID, contact ID, notification ID, correlation token, raw SES payload, and message body.
- Metrics use only low-cardinality aggregate dimensions.

## Cost validation

- Adds Terraform for an EventBridge rule/target/permission, disabled by default in dev.
- No NAT Gateway, public RDS, SES production resources, scheduler, DLQ, or new always-on processing path was added.

## Validation

- `cd backend && python -m pytest -q`
- `cd backend && python -m ruff check src tests migrations`
- `terraform fmt -recursive infra`
- `cd infra/modules/ses_feedback_eventbridge_processor && terraform test`
- `cd infra/modules/ses_delivery_dashboard && terraform test`
- `cd infra/environments/dev && terraform validate`
- `git diff --check`

## Remaining risks / TODOs

- Real AWS SES feedback evidence is still a follow-up.
- Bounce/complaint alarms and suppression UI remain separate tickets.
- DB integration tests require local PostgreSQL / `LEASEFLOW_RUN_DB_INTEGRATION=1`.
