### PR TITLE
feat: add suppression visibility in notifications UI (#205)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ build/
 
 docs/reference/raw/
 .tmp-edge-profile/
+.claude/settings.json
+.claude/settings.local.json

--- a/backend/src/app/routes/notification_contacts.py
+++ b/backend/src/app/routes/notification_contacts.py
@@ -6,15 +6,22 @@ from uuid import UUID
 
 from app.auth import extract_auth_context
 from app.db import Database
-from app.models import NotificationContact
+from app.models import NotificationContact, NotificationContactSuppression
 
 _DUPLICATE_MESSAGE = "Notification contact already exists for tenant."
 
 
 def list_notification_contacts(event: dict[str, Any], db: Database) -> dict[str, Any]:
     auth = extract_auth_context(event)
-    items = db.list_notification_contacts(tenant_id=auth.tenant_id)
-    return {"items": notification_contacts_to_dict(items)}
+    contacts = db.list_notification_contacts(tenant_id=auth.tenant_id)
+    suppressions = db.list_notification_contact_suppressions(tenant_id=auth.tenant_id)
+    reasons_by_contact = _group_suppression_reasons(suppressions)
+    return {
+        "items": [
+            notification_contact_to_dict(contact, reasons_by_contact.get(contact.contact_id, []))
+            for contact in contacts
+        ]
+    }
 
 
 def create_notification_contact(
@@ -35,16 +42,19 @@ def create_notification_contact(
     except ValueError as exc:
         if str(exc) != _DUPLICATE_MESSAGE:
             raise
-        return notification_contact_to_dict(
-            _reenable_disabled_duplicate(
-                db,
-                tenant_id=auth.tenant_id,
-                actor_user_id=auth.user_id,
-                email=email,
-            )
+        reenabled = _reenable_disabled_duplicate(
+            db,
+            tenant_id=auth.tenant_id,
+            actor_user_id=auth.user_id,
+            email=email,
         )
+        suppressions = db.list_notification_contact_suppressions(
+            tenant_id=auth.tenant_id,
+            contact_id=reenabled.contact_id,
+        )
+        return notification_contact_to_dict(reenabled, [s.reason for s in suppressions])
 
-    return notification_contact_to_dict(created)
+    return notification_contact_to_dict(created, [])
 
 
 def update_notification_contact(
@@ -60,22 +70,30 @@ def update_notification_contact(
         contact_id=contact_id,
         enabled=enabled,
     )
-    return notification_contact_to_dict(updated)
+    suppressions = db.list_notification_contact_suppressions(
+        tenant_id=auth.tenant_id,
+        contact_id=updated.contact_id,
+    )
+    return notification_contact_to_dict(updated, [s.reason for s in suppressions])
 
 
-def notification_contact_to_dict(item: NotificationContact) -> dict[str, Any]:
+def notification_contact_to_dict(item: NotificationContact, suppression_reasons: list[str]) -> dict[str, Any]:
     return {
         "contact_id": str(item.contact_id),
         "email": item.email,
         "enabled": item.enabled,
         "created_at": item.created_at.isoformat(),
+        "suppression_reasons": sorted(suppression_reasons),
     }
 
 
-def notification_contacts_to_dict(
-    items: list[NotificationContact],
-) -> list[dict[str, Any]]:
-    return [notification_contact_to_dict(item) for item in items]
+def _group_suppression_reasons(
+    suppressions: list[NotificationContactSuppression],
+) -> dict[UUID, list[str]]:
+    result: dict[UUID, list[str]] = {}
+    for suppression in suppressions:
+        result.setdefault(suppression.contact_id, []).append(suppression.reason)
+    return result
 
 
 def _create_body_email(body: dict[str, Any]) -> str:

--- a/backend/src/app/routes/notification_contacts.py
+++ b/backend/src/app/routes/notification_contacts.py
@@ -77,7 +77,9 @@ def update_notification_contact(
     return notification_contact_to_dict(updated, [s.reason for s in suppressions])
 
 
-def notification_contact_to_dict(item: NotificationContact, suppression_reasons: list[str]) -> dict[str, Any]:
+def notification_contact_to_dict(
+    item: NotificationContact, suppression_reasons: list[str]
+) -> dict[str, Any]:
     return {
         "contact_id": str(item.contact_id),
         "email": item.email,

--- a/backend/tests/test_notification_contacts_route.py
+++ b/backend/tests/test_notification_contacts_route.py
@@ -23,6 +23,15 @@ class _ContactRecord:
     created_at: datetime
 
 
+@dataclass(slots=True)
+class _SuppressionRecord:
+    suppression_id: UUID
+    tenant_id: str
+    contact_id: UUID
+    reason: str
+    created_at: datetime
+
+
 class _FakeDb:
     def __init__(self) -> None:
         self.contacts: list[_ContactRecord] = [
@@ -39,6 +48,7 @@ class _FakeDb:
                 enabled=False,
             ),
         ]
+        self.suppressions: list[_SuppressionRecord] = []
         self.create_calls: list[dict[str, object]] = []
         self.list_calls: list[str] = []
         self.update_calls: list[dict[str, object]] = []
@@ -46,6 +56,17 @@ class _FakeDb:
     def list_notification_contacts(self, tenant_id: str) -> list[_ContactRecord]:
         self.list_calls.append(tenant_id)
         return [contact for contact in self.contacts if contact.tenant_id == tenant_id]
+
+    def list_notification_contact_suppressions(
+        self,
+        tenant_id: str,
+        contact_id: UUID | None = None,
+    ) -> list[_SuppressionRecord]:
+        return [
+            s for s in self.suppressions
+            if s.tenant_id == tenant_id
+            and (contact_id is None or s.contact_id == contact_id)
+        ]
 
     def create_notification_contact(
         self,
@@ -121,6 +142,21 @@ def _contact(
     )
 
 
+def _suppression(
+    *,
+    contact_id: UUID,
+    tenant_id: str,
+    reason: str,
+) -> _SuppressionRecord:
+    return _SuppressionRecord(
+        suppression_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        tenant_id=tenant_id,
+        contact_id=contact_id,
+        reason=reason,
+        created_at=datetime(2026, 5, 12, tzinfo=UTC),
+    )
+
+
 def _event_with_auth(*, tenant_id: str = "tenant-auth", user_id: str = "user-auth") -> dict:
     return {
         "requestContext": {
@@ -152,12 +188,14 @@ def test_list_notification_contacts_uses_auth_tenant_and_excludes_tenant_id() ->
                 "email": "enabled@example.test",
                 "enabled": True,
                 "created_at": "2026-05-05T00:00:00+00:00",
+                "suppression_reasons": [],
             },
             {
                 "contact_id": "22222222-2222-2222-2222-222222222222",
                 "email": "disabled@example.test",
                 "enabled": False,
                 "created_at": "2026-05-05T00:00:00+00:00",
+                "suppression_reasons": [],
             },
         ]
     }
@@ -183,6 +221,7 @@ def test_create_notification_contact_uses_auth_context_and_excludes_tenant_id() 
         "email": "new@example.test",
         "enabled": True,
         "created_at": "2026-05-05T00:00:00+00:00",
+        "suppression_reasons": [],
     }
 
 
@@ -254,6 +293,7 @@ def test_update_notification_contact_enabled_uses_auth_context_and_excludes_tena
         "email": "enabled@example.test",
         "enabled": False,
         "created_at": "2026-05-05T00:00:00+00:00",
+        "suppression_reasons": [],
     }
 
 
@@ -294,3 +334,56 @@ def test_notification_contact_routes_require_jwt_claims() -> None:
 
     with pytest.raises(AuthError, match="Missing JWT claims."):
         contacts.create_notification_contact({}, db, {"email": "contact@example.test"})
+
+
+def test_list_notification_contacts_includes_suppression_reasons() -> None:
+    contacts = _contacts_module()
+    db = _FakeDb()
+    db.suppressions = [
+        _suppression(
+            contact_id=UUID("11111111-1111-1111-1111-111111111111"),
+            tenant_id="tenant-auth",
+            reason="bounce",
+        ),
+        _suppression(
+            contact_id=UUID("11111111-1111-1111-1111-111111111111"),
+            tenant_id="tenant-auth",
+            reason="complaint",
+        ),
+    ]
+    event = _event_with_auth()
+
+    payload = contacts.list_notification_contacts(event, db)
+
+    suppressed_item = next(
+        item for item in payload["items"]
+        if item["contact_id"] == "11111111-1111-1111-1111-111111111111"
+    )
+    unsuppressed_item = next(
+        item for item in payload["items"]
+        if item["contact_id"] == "22222222-2222-2222-2222-222222222222"
+    )
+    assert suppressed_item["suppression_reasons"] == ["bounce", "complaint"]
+    assert unsuppressed_item["suppression_reasons"] == []
+
+
+def test_update_notification_contact_includes_suppression_reasons() -> None:
+    contacts = _contacts_module()
+    db = _FakeDb()
+    db.suppressions = [
+        _suppression(
+            contact_id=UUID("11111111-1111-1111-1111-111111111111"),
+            tenant_id="tenant-auth",
+            reason="bounce",
+        ),
+    ]
+    event = _event_with_auth()
+    event["body"] = '{"enabled": false}'
+
+    payload = contacts.update_notification_contact(
+        event,
+        db,
+        UUID("11111111-1111-1111-1111-111111111111"),
+    )
+
+    assert payload["suppression_reasons"] == ["bounce"]

--- a/backend/tests/test_notification_contacts_route.py
+++ b/backend/tests/test_notification_contacts_route.py
@@ -63,9 +63,9 @@ class _FakeDb:
         contact_id: UUID | None = None,
     ) -> list[_SuppressionRecord]:
         return [
-            s for s in self.suppressions
-            if s.tenant_id == tenant_id
-            and (contact_id is None or s.contact_id == contact_id)
+            s
+            for s in self.suppressions
+            if s.tenant_id == tenant_id and (contact_id is None or s.contact_id == contact_id)
         ]
 
     def create_notification_contact(
@@ -356,11 +356,13 @@ def test_list_notification_contacts_includes_suppression_reasons() -> None:
     payload = contacts.list_notification_contacts(event, db)
 
     suppressed_item = next(
-        item for item in payload["items"]
+        item
+        for item in payload["items"]
         if item["contact_id"] == "11111111-1111-1111-1111-111111111111"
     )
     unsuppressed_item = next(
-        item for item in payload["items"]
+        item
+        for item in payload["items"]
         if item["contact_id"] == "22222222-2222-2222-2222-222222222222"
     )
     assert suppressed_item["suppression_reasons"] == ["bounce", "complaint"]

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -56,6 +56,7 @@ export type NotificationContact = {
   created_at: string;
   email: string;
   enabled: boolean;
+  suppression_reasons: string[];
 };
 
 export type CreatePropertyInput = {

--- a/frontend/src/pages/NotificationsPage.test.tsx
+++ b/frontend/src/pages/NotificationsPage.test.tsx
@@ -342,12 +342,14 @@ describe("NotificationsPage", () => {
           created_at: "2026-05-05T10:00:00Z",
           email: "enabled@example.test",
           enabled: true,
+          suppression_reasons: [],
         },
         {
           contact_id: "contact-2",
           created_at: "2026-05-05T11:00:00Z",
           email: "disabled@example.test",
           enabled: false,
+          suppression_reasons: [],
         },
       ],
       notifications: [],
@@ -437,6 +439,7 @@ describe("NotificationsPage", () => {
           created_at: "2026-05-05T10:00:00Z",
           email: "enabled@example.test",
           enabled: true,
+          suppression_reasons: [],
         },
       ],
       notifications: [],
@@ -453,5 +456,42 @@ describe("NotificationsPage", () => {
         enabled: false,
       });
     });
+  });
+
+  it("renders suppression badges for suppressed contacts", () => {
+    mockedUseNotificationsPageState.mockReturnValue({
+      createNotificationContact: vi.fn(),
+      dueReminders: [],
+      error: null,
+      isLoading: false,
+      markNotificationRead,
+      notificationContacts: [
+        {
+          contact_id: "contact-1",
+          created_at: "2026-05-05T10:00:00Z",
+          email: "suppressed@example.test",
+          enabled: true,
+          suppression_reasons: ["bounce", "complaint"],
+        },
+        {
+          contact_id: "contact-2",
+          created_at: "2026-05-05T11:00:00Z",
+          email: "clean@example.test",
+          enabled: true,
+          suppression_reasons: [],
+        },
+      ],
+      notifications: [],
+      readingNotificationId: null,
+      updatingContactId: null,
+      updateNotificationContact: vi.fn(),
+    });
+
+    render(<NotificationsPage />);
+
+    expect(screen.getByText("Suppressed: bounce")).toBeInTheDocument();
+    expect(screen.getByText("Suppressed: complaint")).toBeInTheDocument();
+    expect(screen.getAllByText("Suppressed: bounce")).toHaveLength(1);
+    expect(screen.getAllByText("Suppressed: complaint")).toHaveLength(1);
   });
 });

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -150,6 +150,12 @@ export function NotificationsPage() {
                   <span className={contact.enabled ? "status-pill" : "status-pill status-pill-unread"}>
                     {contact.enabled ? "Enabled" : "Disabled"}
                   </span>
+                  {contact.suppression_reasons?.includes("bounce") && (
+                    <span className="status-pill status-pill-unread">Suppressed: bounce</span>
+                  )}
+                  {contact.suppression_reasons?.includes("complaint") && (
+                    <span className="status-pill status-pill-unread">Suppressed: complaint</span>
+                  )}
                   <button
                     aria-label={`${contact.enabled ? "Disable" : "Enable"} ${contact.email}`}
                     className="ghost-button resource-edit-button"


### PR DESCRIPTION
## Summary

Exposes safe contact suppression state in the notifications UI. Each
`NotificationContact` API response now includes `suppression_reasons`
(values: `"bounce"`, `"complaint"`) so the browser can show which contacts
are system-suppressed alongside the existing enabled/disabled status.

## Why

The suppression state was recorded in the backend (#209) and applied to
delivery eligibility (#212), but the tenant had no visibility into why a
contact was silently skipped. This makes the state observable without
leaking provider payloads, suppression IDs, or any raw SES data.

## Validation

- [x] `make lint`
- [x] `make test`

## Review Notes

- [x] Tenant-scoped queries explicitly filter by `tenant_id` where applicable
- [x] `tenant_id` comes from validated JWT claims, not client input
- [ ] Write flows keep domain changes and audit records in one transaction where required — ei write-flowta tässä PR:ssä
- [ ] Structured logging or audit logging was updated if the change affects important write flows — ei uusia write-floweja
- [ ] Docs were updated if architecture, security, or MVP scope changed materially — `notification-suppression-unsubscribe-model.md` ei tarvitse päivitystä, tiketti oli jo kirjattu follow-up-na

## Deployment Notes

No migrations, config changes, or feature flags required. The new
`suppression_reasons` field is additive; the frontend uses optional
chaining (`?.includes`) so it degrades gracefully against an older
backend deployment.
