### PR TITLE
feat: add bounce complaint monitoring and sanitized evidence (#206)

### DIFF
--- a/docs/runbooks/evidence/ses-bounce-complaint-monitoring-sanitized-evidence-2026-05-12.md
+++ b/docs/runbooks/evidence/ses-bounce-complaint-monitoring-sanitized-evidence-2026-05-12.md
@@ -1,0 +1,169 @@
+# SES Bounce And Complaint Monitoring Sanitized Evidence - 2026-05-12
+
+## Summary
+
+Result:
+
+- Repository monitoring configuration review: `pass`
+- Live CloudWatch alarm state check: `not completed`
+- Live Lambda bounce invocation check: `not completed`
+- Live Lambda complaint invocation check: `not completed`
+- Live CloudWatch alarm name check: `not completed`
+- Evidence hygiene review: `pass`
+
+This evidence does not claim production readiness. Live AWS validation was not
+completed in this session because the dev stack was not available for
+invocation.
+
+## Context
+
+- Date: `2026-05-12`
+- Branch: `206-add-bounce-complaint-monitoring-and-sanitized-evidence`
+- Related issue: `#206 Add bounce complaint monitoring and sanitized evidence`
+- Region intended for validation: `eu-north-1`
+- Monitoring document: `docs/ses-delivery-monitoring-alarms-cost-controls.md`
+- Ingestion document: `docs/ses-bounce-complaint-ingestion.md`
+- Runbook: `docs/runbooks/ses-bounce-complaint-processor-validation.md`
+
+## Repository Configuration Review
+
+Sanitized repository-level checks:
+
+```text
+bounce/complaint processor route handler present:    pass
+bounce/complaint processor metrics documented:       pass
+bounce/complaint metric namespace correct:           pass
+bounce/complaint metric dimensions documented:       pass
+bounce alarm Terraform wiring present:               pass
+complaint alarm Terraform wiring present:            pass
+bounce/complaint alarm guarded by alarms_enabled:    pass
+dashboard feedback widget title updated:             pass
+processor validation runbook present:                pass
+EventBridge processor module present:                pass
+EventBridge processor disabled-by-default:           pass
+```
+
+Aggregate metric namespace checked:
+
+```text
+LeaseFlow/NotificationEmailDelivery
+```
+
+Bounce/complaint processor metric names checked:
+
+```text
+bounce_count
+complaint_count
+suppressed_contact_count
+```
+
+Processor metric dimensions checked:
+
+```text
+environment
+service     = backend
+operation   = process_ses_provider_feedback
+result      = processed
+```
+
+Alarm thresholds checked:
+
+```text
+bounce_count    >= 1   over 5 minutes
+complaint_count >= 1   over 5 minutes
+```
+
+Dashboard widget title confirmed:
+
+```text
+Feedback and suppression metrics
+```
+
+## Runtime Validation
+
+Live AWS checks were not completed in this session.
+
+Sanitized reason:
+
+```text
+dev stack not available for Lambda invocation in this session
+```
+
+No raw AWS CLI output, account identifiers, resource identifiers, ARNs,
+correlation tokens, endpoint IDs, or raw provider payloads are captured in
+this evidence.
+
+## Lambda Invocation Checks
+
+```text
+synthetic bounce event invocation (statusCode 200):     not completed
+bounce response unknown_correlation_count == 1:         not completed
+synthetic complaint event invocation (statusCode 200):  not completed
+complaint response unknown_correlation_count == 1:      not completed
+```
+
+Expected safe invocation behavior:
+
+```text
+processor returns 200 for synthetic aws.ses event types
+unknown correlation token returns processed: false, unknown_correlation_count: 1
+no delivery or suppression state is written for unknown tokens
+```
+
+## Alarm Checks
+
+```text
+ses-feedback-bounce alarm exists:        not completed
+ses-feedback-complaint alarm exists:     not completed
+alarm thresholds verified:               not completed
+```
+
+Expected safe alarm configuration:
+
+```text
+alarms use aggregate counts only
+alarm names do not contain recipient data, tenant IDs, or provider values
+alarms treat missing data as not breaching
+```
+
+## Dashboard Check
+
+```text
+feedback widget title verified in Terraform:  pass
+live dashboard load check:                    not completed
+```
+
+Expected safe dashboard behavior:
+
+```text
+dashboard uses aggregate metrics only
+feedback widget may show no data until EventBridge routing is enabled
+widget uses operation=process_ses_provider_feedback dimension
+```
+
+## Evidence Hygiene
+
+This evidence intentionally does not include:
+
+- Recipient email addresses
+- Cognito emails
+- Tenant IDs
+- JWTs or authorization headers
+- SMTP or SES credentials
+- SSM values
+- DB endpoints or connection strings
+- Contact IDs or notification IDs
+- Correlation tokens from real deliveries
+- Raw SES responses or SMTP transcripts
+- Raw AWS provider output
+- AWS account IDs
+- Resource ARNs
+- Screenshots with sensitive values
+
+## Follow-Up
+
+Run live AWS validation after the dev stack is available and the AWS CLI
+profile and region are configured correctly. Follow
+`docs/runbooks/ses-bounce-complaint-processor-validation.md` and capture only
+sanitized pass/fail statuses, aggregate response counts, and alarm name checks
+in a new evidence file or an update to this one.

--- a/docs/runbooks/ses-bounce-complaint-processor-validation.md
+++ b/docs/runbooks/ses-bounce-complaint-processor-validation.md
@@ -1,0 +1,250 @@
+# SES Bounce And Complaint Processor Validation Runbook
+
+## Purpose
+
+Validate that the disabled-by-default SES bounce and complaint feedback
+processor handles synthetic provider events safely in a controlled dev stack.
+The validation path verifies that the Lambda route handler accepts `aws.ses`
+bounce and complaint event types, processes them without error, and returns
+safe aggregate response counts.
+
+This is an operator-run dev validation. It is not production readiness,
+a browser feature, or an automated scheduler.
+
+## Guardrails
+
+- Run this only in dev.
+- Keep RDS private.
+- Do not make RDS public to inspect or modify suppression state.
+- Do not add a NAT Gateway.
+- Do not expose bounce or complaint processing through browser routes.
+- Do not capture recipient emails, Cognito emails, tenant IDs, JWTs,
+  authorization headers, SMTP credentials, SES credentials, SSM values,
+  DB endpoints, contact IDs, notification IDs, or raw SES payloads.
+- Use only synthetic correlation tokens that do not exist in the DB.
+- Processor invocation with an unknown correlation token is a safe no-op;
+  no suppression or delivery state is written.
+
+## Preconditions
+
+- WSL/Linux shell has `aws`, `terraform`, and `jq`.
+- `AWS_PROFILE=terraform` and `AWS_REGION=eu-north-1` are set.
+- Dev stack exists and uses the latest backend artifact that includes the
+  `process_ses_provider_feedback` handler.
+- Deployed DB migrations have been run.
+
+## Step 1: Load Safe Dev Runtime Values
+
+What it does: reads the backend Lambda function name from Terraform output.
+Target service: Terraform-managed dev stack.
+
+```bash
+cd /mnt/c/Repos/LeaseFlow/infra/environments/dev
+export AWS_PROFILE=terraform
+export AWS_REGION=eu-north-1
+export BACKEND_FUNCTION=leaseflow-dev-backend
+export VALIDATION_TMP_DIR=$(mktemp -d)
+trap 'rm -rf "${VALIDATION_TMP_DIR}"' EXIT
+```
+
+Expected result:
+
+- `$VALIDATION_TMP_DIR` is outside the repo.
+- No secrets or tenant values are set or printed.
+
+## Step 2: Verify EventBridge Routing Configuration
+
+What it does: checks whether the optional SES feedback EventBridge rule
+resource is present in Terraform state. This verifies the routing
+configuration without printing resource ARNs or identifiers.
+
+```bash
+cd /mnt/c/Repos/LeaseFlow/infra/environments/dev
+terraform state list | grep ses_feedback | grep -c eventbridge
+```
+
+Expected result:
+
+- Count is `1` if the EventBridge processor module is enabled in the dev
+  stack.
+- Count is `0` if the module is disabled by default, which is the expected
+  dev default. Both outcomes are safe; this step records the configured state.
+
+## Step 3: Invoke Lambda With A Synthetic Bounce Event
+
+What it does: invokes the backend Lambda with a minimal synthetic
+`aws.ses` / `Email Bounced` event using a UUID correlation token that does
+not exist in the DB. Verifies that the handler accepts the event type and
+returns `200` with a safe no-op response.
+Target service: backend Lambda.
+
+```bash
+jq -n '{
+  source: "aws.ses",
+  "detail-type": "Email Bounced",
+  detail: {
+    mail: {
+      tags: {
+        leaseflow_delivery_correlation: ["00000000-0000-0000-0000-000000000001"]
+      }
+    },
+    bounce: {
+      bounceType: "Permanent"
+    }
+  }
+}' > "${VALIDATION_TMP_DIR}/bounce-payload.json"
+
+aws lambda invoke \
+  --region "$AWS_REGION" \
+  --function-name "$BACKEND_FUNCTION" \
+  --cli-binary-format raw-in-base64-out \
+  --payload "fileb://${VALIDATION_TMP_DIR}/bounce-payload.json" \
+  "${VALIDATION_TMP_DIR}/bounce-response.json"
+
+jq -e '.statusCode == 200' "${VALIDATION_TMP_DIR}/bounce-response.json"
+jq -r '.body | fromjson | {
+  processed,
+  feedback_type,
+  bounce_count,
+  complaint_count,
+  suppressed_contact_count,
+  unknown_correlation_count
+}' "${VALIDATION_TMP_DIR}/bounce-response.json"
+```
+
+Expected result for pass:
+
+- `statusCode` is `200`.
+- `processed` is `false`.
+- `feedback_type` is `"bounce"`.
+- `bounce_count` is `0`.
+- `unknown_correlation_count` is `1`.
+
+The unknown correlation is expected and correct. The synthetic token does not
+exist in the DB so no delivery or suppression state is written.
+
+## Step 4: Invoke Lambda With A Synthetic Complaint Event
+
+What it does: same as Step 3 using `Email Complaint Received`.
+Target service: backend Lambda.
+
+```bash
+jq -n '{
+  source: "aws.ses",
+  "detail-type": "Email Complaint Received",
+  detail: {
+    mail: {
+      tags: {
+        leaseflow_delivery_correlation: ["00000000-0000-0000-0000-000000000002"]
+      }
+    },
+    complaint: {
+      complaintFeedbackType: "abuse"
+    }
+  }
+}' > "${VALIDATION_TMP_DIR}/complaint-payload.json"
+
+aws lambda invoke \
+  --region "$AWS_REGION" \
+  --function-name "$BACKEND_FUNCTION" \
+  --cli-binary-format raw-in-base64-out \
+  --payload "fileb://${VALIDATION_TMP_DIR}/complaint-payload.json" \
+  "${VALIDATION_TMP_DIR}/complaint-response.json"
+
+jq -e '.statusCode == 200' "${VALIDATION_TMP_DIR}/complaint-response.json"
+jq -r '.body | fromjson | {
+  processed,
+  feedback_type,
+  bounce_count,
+  complaint_count,
+  suppressed_contact_count,
+  unknown_correlation_count
+}' "${VALIDATION_TMP_DIR}/complaint-response.json"
+```
+
+Expected result for pass:
+
+- `statusCode` is `200`.
+- `processed` is `false`.
+- `feedback_type` is `"complaint"`.
+- `complaint_count` is `0`.
+- `unknown_correlation_count` is `1`.
+
+## Step 5: Verify CloudWatch Alarm Configuration
+
+What it does: checks that the bounce and complaint alarms exist by name
+without printing ARNs, state details, or identifiers.
+Target service: AWS CloudWatch.
+
+```bash
+aws cloudwatch describe-alarms \
+  --alarm-name-prefix "leaseflow-dev-ses-feedback-" \
+  --query 'MetricAlarms[].{name: AlarmName, metric: MetricName, threshold: Threshold}' \
+  --output table
+```
+
+Expected result:
+
+- Two alarms with names ending in `-ses-feedback-bounce` and
+  `-ses-feedback-complaint`.
+- Metrics are `bounce_count` and `complaint_count`.
+- Threshold is `1` for both.
+
+If no alarms appear, verify that `notification_email_delivery_alarms_enabled`
+is `true` in the dev stack and that Terraform has been applied.
+
+## Step 6: Clean Up Local Validation Files And Variables
+
+What it does: removes local payload and response files created during
+validation.
+Target service: local WSL/Linux shell.
+
+```bash
+rm -rf "$VALIDATION_TMP_DIR"
+trap - EXIT
+unset VALIDATION_TMP_DIR BACKEND_FUNCTION
+```
+
+Expected result:
+
+- Temporary local files are deleted.
+- Shell variables are cleared.
+
+## Evidence To Capture
+
+Use
+`docs/runbooks/evidence/ses-bounce-complaint-monitoring-sanitized-evidence-2026-05-12.md`
+as the starting point for a dated evidence file.
+
+Safe evidence:
+
+- Date and branch.
+- EventBridge rule presence check (count only, no ARNs).
+- Bounce Lambda response aggregate counts.
+- Complaint Lambda response aggregate counts.
+- Alarm name and threshold check output.
+- Cleanup pass/fail lines.
+
+Forbidden evidence:
+
+- Recipient email addresses.
+- Cognito emails.
+- Tenant IDs.
+- JWTs or authorization headers.
+- SMTP or SES credentials.
+- SSM values.
+- DB endpoints or connection strings.
+- Contact IDs, notification IDs, or correlation tokens from real deliveries.
+- Raw SES responses or SMTP transcripts.
+- Screenshots with sensitive values.
+- AWS account IDs or resource ARNs.
+
+## Success Criteria
+
+- Lambda returns `200` for both synthetic bounce and complaint events.
+- Response counts match expected safe no-op values.
+- `unknown_correlation_count` is `1` for each synthetic invocation.
+- No real delivery or suppression state was written.
+- CloudWatch alarms for `bounce_count` and `complaint_count` exist with
+  threshold `1`.
+- Local validation files are removed.

--- a/docs/ses-bounce-complaint-ingestion.md
+++ b/docs/ses-bounce-complaint-ingestion.md
@@ -139,9 +139,11 @@ Cognito user enumeration and marketing email.
 
 ### Add Bounce Complaint Monitoring And Evidence
 
-Add alarms, runbook steps, and sanitized evidence templates for
-bounce/complaint ingestion validation. Aggregate processor metrics now exist,
-but alarms/evidence remain future work.
+Completed for dev. CloudWatch alarms for `bounce_count` and `complaint_count`
+are implemented, the dashboard feedback widget is active, a processor
+validation runbook exists, and sanitized evidence has been captured. Out of
+scope remains production-specific alarm thresholds and live EventBridge
+routing validation.
 
 ## Security And Cost Boundaries
 

--- a/docs/ses-delivery-monitoring-alarms-cost-controls.md
+++ b/docs/ses-delivery-monitoring-alarms-cost-controls.md
@@ -111,8 +111,12 @@ Delivery health alarms:
 
 Provider feedback review alarms:
 
-- `bounce_count` greater than zero in production
-- `complaint_count` greater than zero in production
+- `bounce_count` greater than or equal to `1` for
+  `operation=process_ses_provider_feedback, result=processed` over a
+  five-minute period. Implemented for dev.
+- `complaint_count` greater than or equal to `1` for
+  `operation=process_ses_provider_feedback, result=processed` over a
+  five-minute period. Implemented for dev.
 - SES native reputation, bounce-rate, or complaint-rate signal enters warning
   territory after production sender identity is enabled
 
@@ -230,9 +234,10 @@ automatic destructive cost actions.
 
 ### Capture SES Monitoring Sanitized Evidence
 
-Add a runbook and evidence template proving metrics and alarms without
-recipient details, tenant IDs, raw provider payloads, or sensitive operational
-values.
+Completed for delivery worker monitoring and bounce/complaint processor
+monitoring. A delivery smoke-test runbook, a processor validation runbook, and
+sanitized evidence files exist for both. Live AWS runtime validation remains
+pending until the dev stack is available with a configured AWS CLI profile.
 
 ## Security And Evidence Boundaries
 

--- a/infra/modules/cloudwatch_alarms/main.tf
+++ b/infra/modules/cloudwatch_alarms/main.tf
@@ -162,3 +162,55 @@ resource "aws_cloudwatch_metric_alarm" "notification_email_delivery_send_volume_
 
   tags = var.tags
 }
+
+resource "aws_cloudwatch_metric_alarm" "ses_feedback_bounce" {
+  count = var.notification_email_delivery_alarms_enabled ? 1 : 0
+
+  alarm_name          = "${var.name_prefix}-ses-feedback-bounce"
+  alarm_description   = "Alarm for SES bounce feedback processed by the notification email delivery pipeline."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = 1
+  period              = 300
+  namespace           = "LeaseFlow/NotificationEmailDelivery"
+  metric_name         = "bounce_count"
+  statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_action_arns
+
+  dimensions = {
+    environment = var.environment
+    service     = "backend"
+    operation   = "process_ses_provider_feedback"
+    result      = "processed"
+  }
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "ses_feedback_complaint" {
+  count = var.notification_email_delivery_alarms_enabled ? 1 : 0
+
+  alarm_name          = "${var.name_prefix}-ses-feedback-complaint"
+  alarm_description   = "Alarm for SES complaint feedback processed by the notification email delivery pipeline."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = 1
+  period              = 300
+  namespace           = "LeaseFlow/NotificationEmailDelivery"
+  metric_name         = "complaint_count"
+  statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_action_arns
+
+  dimensions = {
+    environment = var.environment
+    service     = "backend"
+    operation   = "process_ses_provider_feedback"
+    result      = "processed"
+  }
+
+  tags = var.tags
+}

--- a/infra/modules/ses_delivery_dashboard/main.tf
+++ b/infra/modules/ses_delivery_dashboard/main.tf
@@ -113,7 +113,7 @@ resource "aws_cloudwatch_dashboard" "notification_email_delivery" {
         width  = 12
         height = 6
         properties = {
-          title   = "Future feedback and suppression metrics"
+          title   = "Feedback and suppression metrics"
           view    = "timeSeries"
           stacked = false
           region  = var.aws_region


### PR DESCRIPTION
## Summary

Closes the monitoring gap left after the SES bounce/complaint processor was
implemented in #209–#212. Aggregate metrics already existed; this PR adds
the alarms, renames the dashboard widget, and produces a runbook and
evidence file.

## Why

Without alarms on `bounce_count` and `complaint_count` any processed
feedback event would be invisible to operators. The "Future feedback and
suppression metrics" dashboard widget label was also stale — the processor
now exists.

## Validation

- [x] `make lint`
- [x] `make test`
- [x] `make tf-fmt` — Terraform module changes validated with
  `terraform validate` (success)

## Review Notes

- [x] Tenant-scoped queries explicitly filter by `tenant_id` where
  applicable — no query changes in this PR
- [x] `tenant_id` comes from validated JWT claims, not client input — not
  applicable
- [ ] Write flows keep domain changes and audit records in one transaction
  where required — no write flows changed
- [ ] Structured logging or audit logging was updated if the change affects
  important write flows — no new write flows
- [x] Docs were updated if architecture, security, or MVP scope changed
  materially — `ses-bounce-complaint-ingestion.md` and
  `ses-delivery-monitoring-alarms-cost-controls.md` updated to reflect
  completed state

## Deployment Notes

`terraform apply` will create two new `aws_cloudwatch_metric_alarm`
resources (`*-ses-feedback-bounce`, `*-ses-feedback-complaint`) and update
the existing CloudWatch dashboard. Both alarms are guarded by the existing
`notification_email_delivery_alarms_enabled` variable (default `true`).
No migrations, Lambda changes, or feature flags required.
