### PR TITLE
feat: add suppression removal workflow (#215)

### DIFF
--- a/backend/src/app/db.py
+++ b/backend/src/app/db.py
@@ -257,6 +257,63 @@ class Database:
             rows = conn.execute(sql, params).fetchall()
         return [self._row_to_notification_contact_suppression(row) for row in rows]
 
+    def delete_notification_contact_suppression(
+        self,
+        tenant_id: str,
+        actor_user_id: str,
+        contact_id: UUID,
+        reason: str,
+    ) -> None:
+        normalized_reason = reason.strip().lower()
+        if normalized_reason not in _NOTIFICATION_CONTACT_SUPPRESSION_REASONS:
+            raise ValueError("Notification contact suppression reason must be bounce or complaint.")
+
+        contact_sql = """
+            SELECT contact_id
+            FROM notification_contacts
+            WHERE tenant_id = %s AND contact_id = %s
+        """
+        delete_sql = """
+            DELETE FROM notification_contact_suppressions
+            WHERE tenant_id = %s AND contact_id = %s AND reason = %s
+        """
+        audit_sql = """
+            INSERT INTO audit_logs (
+                tenant_id, actor_user_id, action, entity_type, entity_id, metadata
+            ) VALUES (%s, %s, %s, %s, %s, %s::jsonb)
+        """
+        select_suppression_sql = """
+            SELECT suppression_id
+            FROM notification_contact_suppressions
+            WHERE tenant_id = %s AND contact_id = %s AND reason = %s
+        """
+
+        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+            with conn.transaction():
+                contact_row = conn.execute(contact_sql, (tenant_id, contact_id)).fetchone()
+                if contact_row is None:
+                    raise LookupError("Notification contact not found for tenant.")
+
+                suppression_row = conn.execute(
+                    select_suppression_sql,
+                    (tenant_id, contact_id, normalized_reason),
+                ).fetchone()
+                if suppression_row is None:
+                    raise LookupError("Notification contact suppression not found.")
+
+                conn.execute(delete_sql, (tenant_id, contact_id, normalized_reason))
+                conn.execute(
+                    audit_sql,
+                    (
+                        tenant_id,
+                        actor_user_id,
+                        "notification_contact_suppression.remove",
+                        "notification_contact_suppression",
+                        suppression_row["suppression_id"],
+                        json.dumps({"source": "api", "reason": normalized_reason}),
+                    ),
+                )
+
     def create_missing_notification_email_deliveries(
         self,
         tenant_id: str | None,

--- a/backend/src/app/handler.py
+++ b/backend/src/app/handler.py
@@ -18,6 +18,7 @@ from app.routes.notification_contact_setup import configure_notification_contact
 from app.routes.notification_contacts import (
     create_notification_contact,
     list_notification_contacts,
+    remove_notification_contact_suppression,
     update_notification_contact,
 )
 from app.routes.notification_email_delivery import deliver_notification_emails
@@ -30,6 +31,9 @@ setup_logging()
 LOGGER = get_logger(__name__)
 _LEASE_PATH = re.compile(r"^/leases/(?P<lease_id>[^/]+)$")
 _NOTIFICATION_CONTACT_PATH = re.compile(r"^/notification-contacts/(?P<contact_id>[^/]+)$")
+_NOTIFICATION_CONTACT_SUPPRESSION_PATH = re.compile(
+    r"^/notification-contacts/(?P<contact_id>[^/]+)/suppressions/(?P<reason>[^/]+)$"
+)
 _NOTIFICATION_READ_PATH = re.compile(r"^/notifications/(?P<notification_id>[^/]+)/read$")
 _PROPERTY_PATH = re.compile(r"^/properties/(?P<property_id>[^/]+)$")
 
@@ -88,6 +92,18 @@ def _notification_contact_id(path: str) -> UUID | None:
         raise ValueError("Invalid notification contact ID.") from exc
 
 
+def _notification_contact_suppression(path: str) -> tuple[UUID, str] | None:
+    match = _NOTIFICATION_CONTACT_SUPPRESSION_PATH.fullmatch(path)
+    if match is None:
+        return None
+
+    try:
+        contact_id = UUID(match.group("contact_id"))
+    except ValueError as exc:
+        raise ValueError("Invalid notification contact ID.") from exc
+    return contact_id, match.group("reason")
+
+
 def _property_id(path: str) -> UUID | None:
     match = _PROPERTY_PATH.fullmatch(path)
     if match is None:
@@ -125,6 +141,9 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
 
         lease_id = _lease_id(path) if method == "PATCH" else None
         notification_contact_id = _notification_contact_id(path) if method == "PATCH" else None
+        notification_contact_suppression_args = (
+            _notification_contact_suppression(path) if method == "DELETE" else None
+        )
         notification_id = _notification_read_id(path) if method == "PATCH" else None
         property_id = _property_id(path) if method == "PATCH" else None
         settings = load_settings()
@@ -155,6 +174,12 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             "Email Complaint Received",
         }:
             return _response(HTTPStatus.OK, process_ses_provider_feedback(event, db, settings))
+        if method == "DELETE" and notification_contact_suppression_args is not None:
+            contact_id, reason = notification_contact_suppression_args
+            return _response(
+                HTTPStatus.OK,
+                remove_notification_contact_suppression(event, db, contact_id, reason),
+            )
         if method == "PATCH" and notification_contact_id is not None:
             return _response(
                 HTTPStatus.OK,

--- a/backend/src/app/routes/notification_contacts.py
+++ b/backend/src/app/routes/notification_contacts.py
@@ -77,6 +77,30 @@ def update_notification_contact(
     return notification_contact_to_dict(updated, [s.reason for s in suppressions])
 
 
+def remove_notification_contact_suppression(
+    event: dict[str, Any],
+    db: Database,
+    contact_id: UUID,
+    reason: str,
+) -> dict[str, Any]:
+    auth = extract_auth_context(event)
+    db.delete_notification_contact_suppression(
+        tenant_id=auth.tenant_id,
+        actor_user_id=auth.user_id,
+        contact_id=contact_id,
+        reason=reason,
+    )
+    contact = db.list_notification_contacts(tenant_id=auth.tenant_id)
+    contact_item = next((c for c in contact if c.contact_id == contact_id), None)
+    if contact_item is None:
+        raise LookupError("Notification contact not found for tenant.")
+    suppressions = db.list_notification_contact_suppressions(
+        tenant_id=auth.tenant_id,
+        contact_id=contact_id,
+    )
+    return notification_contact_to_dict(contact_item, [s.reason for s in suppressions])
+
+
 def notification_contact_to_dict(
     item: NotificationContact, suppression_reasons: list[str]
 ) -> dict[str, Any]:

--- a/backend/tests/test_notification_contacts_route.py
+++ b/backend/tests/test_notification_contacts_route.py
@@ -125,6 +125,30 @@ class _FakeDb:
                 return updated
         raise LookupError("Notification contact not found for tenant.")
 
+    def delete_notification_contact_suppression(
+        self,
+        tenant_id: str,
+        actor_user_id: str,
+        contact_id: UUID,
+        reason: str,
+    ) -> None:
+        if reason not in {"bounce", "complaint"}:
+            raise ValueError("Notification contact suppression reason must be bounce or complaint.")
+        contact_exists = any(
+            c.tenant_id == tenant_id and c.contact_id == contact_id for c in self.contacts
+        )
+        if not contact_exists:
+            raise LookupError("Notification contact not found for tenant.")
+        for index, suppression in enumerate(self.suppressions):
+            if (
+                suppression.tenant_id == tenant_id
+                and suppression.contact_id == contact_id
+                and suppression.reason == reason
+            ):
+                del self.suppressions[index]
+                return
+        raise LookupError("Notification contact suppression not found.")
+
 
 def _contact(
     *,
@@ -389,3 +413,107 @@ def test_update_notification_contact_includes_suppression_reasons() -> None:
     )
 
     assert payload["suppression_reasons"] == ["bounce"]
+
+
+def test_remove_suppression_returns_updated_contact() -> None:
+    contacts = _contacts_module()
+    db = _FakeDb()
+    db.suppressions = [
+        _suppression(
+            contact_id=UUID("11111111-1111-1111-1111-111111111111"),
+            tenant_id="tenant-auth",
+            reason="bounce",
+        ),
+    ]
+    event = _event_with_auth()
+
+    payload = contacts.remove_notification_contact_suppression(
+        event,
+        db,
+        UUID("11111111-1111-1111-1111-111111111111"),
+        "bounce",
+    )
+
+    assert payload == {
+        "contact_id": "11111111-1111-1111-1111-111111111111",
+        "email": "enabled@example.test",
+        "enabled": True,
+        "created_at": "2026-05-05T00:00:00+00:00",
+        "suppression_reasons": [],
+    }
+
+
+def test_remove_suppression_only_removes_targeted_reason() -> None:
+    contacts = _contacts_module()
+    db = _FakeDb()
+    db.suppressions = [
+        _suppression(
+            contact_id=UUID("11111111-1111-1111-1111-111111111111"),
+            tenant_id="tenant-auth",
+            reason="bounce",
+        ),
+        _suppression(
+            contact_id=UUID("11111111-1111-1111-1111-111111111111"),
+            tenant_id="tenant-auth",
+            reason="complaint",
+        ),
+    ]
+    event = _event_with_auth()
+
+    payload = contacts.remove_notification_contact_suppression(
+        event,
+        db,
+        UUID("11111111-1111-1111-1111-111111111111"),
+        "bounce",
+    )
+
+    assert payload["suppression_reasons"] == ["complaint"]
+
+
+def test_remove_suppression_not_found_raises_lookup_error() -> None:
+    contacts = _contacts_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+
+    with pytest.raises(LookupError, match="Notification contact suppression not found."):
+        contacts.remove_notification_contact_suppression(
+            event,
+            db,
+            UUID("11111111-1111-1111-1111-111111111111"),
+            "bounce",
+        )
+
+
+def test_remove_suppression_invalid_reason_raises_value_error() -> None:
+    contacts = _contacts_module()
+    db = _FakeDb()
+    event = _event_with_auth()
+
+    with pytest.raises(ValueError, match="bounce or complaint"):
+        contacts.remove_notification_contact_suppression(
+            event,
+            db,
+            UUID("11111111-1111-1111-1111-111111111111"),
+            "unknown",
+        )
+
+
+def test_remove_suppression_wrong_tenant_raises_lookup_error() -> None:
+    contacts = _contacts_module()
+    db = _FakeDb()
+    db.suppressions = [
+        _suppression(
+            contact_id=UUID("11111111-1111-1111-1111-111111111111"),
+            tenant_id="tenant-other",
+            reason="bounce",
+        ),
+    ]
+    event = _event_with_auth(tenant_id="tenant-auth")
+
+    with pytest.raises(LookupError):
+        contacts.remove_notification_contact_suppression(
+            event,
+            db,
+            UUID("11111111-1111-1111-1111-111111111111"),
+            "bounce",
+        )

--- a/frontend/src/features/notifications/useNotificationsPage.ts
+++ b/frontend/src/features/notifications/useNotificationsPage.ts
@@ -22,6 +22,8 @@ type NotificationsPageState = {
   notificationContacts: NotificationContact[];
   notifications: NotificationItem[];
   readingNotificationId: string | null;
+  removeContactSuppression: (contactId: string, reason: string) => Promise<void>;
+  removingSuppressionKey: string | null;
   updatingContactId: string | null;
   updateNotificationContact: (
     contactId: string,
@@ -38,6 +40,7 @@ export function useNotificationsPageState(): NotificationsPageState {
   const [isLoading, setIsLoading] = useState(true);
   const [readingNotificationId, setReadingNotificationId] = useState<string | null>(null);
   const [updatingContactId, setUpdatingContactId] = useState<string | null>(null);
+  const [removingSuppressionKey, setRemovingSuppressionKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -198,6 +201,39 @@ export function useNotificationsPageState(): NotificationsPageState {
     }
   }
 
+  async function removeContactSuppression(contactId: string, reason: string) {
+    if (!auth.session) {
+      navigate("/", { replace: true });
+      return;
+    }
+
+    setRemovingSuppressionKey(`${contactId}:${reason}`);
+    setError(null);
+
+    try {
+      const client = createApiClient({
+        config: getRuntimeConfig(),
+        onUnauthorized: auth.markSessionExpired,
+        session: auth.session,
+      });
+      const updated = await client.removeNotificationContactSuppression(contactId, reason);
+      setNotificationContacts((current) => upsertContact(current, updated));
+    } catch (errorValue) {
+      if (errorValue instanceof UnauthorizedApiError) {
+        navigate("/", { replace: true });
+        return;
+      }
+      setError(
+        errorValue instanceof ApiError
+          ? errorValue.message
+          : "Could not remove notification contact suppression."
+      );
+      throw errorValue;
+    } finally {
+      setRemovingSuppressionKey(null);
+    }
+  }
+
   return {
     createNotificationContact,
     dueReminders,
@@ -207,6 +243,8 @@ export function useNotificationsPageState(): NotificationsPageState {
     notificationContacts,
     notifications,
     readingNotificationId,
+    removeContactSuppression,
+    removingSuppressionKey,
     updatingContactId,
     updateNotificationContact,
   };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -201,6 +201,12 @@ export function createApiClient({ config, onUnauthorized, session }: ApiClientOp
         method: "PATCH",
       });
     },
+    removeNotificationContactSuppression(contactId: string, reason: string) {
+      return request<NotificationContact>(
+        `/notification-contacts/${encodeURIComponent(contactId)}/suppressions/${encodeURIComponent(reason)}`,
+        { method: "DELETE" }
+      );
+    },
     updateNotificationContact(contactId: string, input: UpdateNotificationContactInput) {
       return request<NotificationContact>(
         `/notification-contacts/${encodeURIComponent(contactId)}`,

--- a/frontend/src/pages/NotificationsPage.test.tsx
+++ b/frontend/src/pages/NotificationsPage.test.tsx
@@ -46,6 +46,8 @@ describe("NotificationsPage", () => {
       notificationContacts: [],
       notifications: [],
       readingNotificationId: null,
+      removeContactSuppression: vi.fn(),
+      removingSuppressionKey: null,
       updatingContactId: null,
       updateNotificationContact: vi.fn(),
     });
@@ -75,6 +77,8 @@ describe("NotificationsPage", () => {
       notificationContacts: [],
       notifications: [],
       readingNotificationId: null,
+      removeContactSuppression: vi.fn(),
+      removingSuppressionKey: null,
       updatingContactId: null,
       updateNotificationContact: vi.fn(),
     });
@@ -113,6 +117,8 @@ describe("NotificationsPage", () => {
         },
       ],
       readingNotificationId: null,
+      removeContactSuppression: vi.fn(),
+      removingSuppressionKey: null,
       updatingContactId: null,
       updateNotificationContact: vi.fn(),
     });
@@ -150,6 +156,8 @@ describe("NotificationsPage", () => {
         },
       ],
       readingNotificationId: null,
+      removeContactSuppression: vi.fn(),
+      removingSuppressionKey: null,
       updatingContactId: null,
       updateNotificationContact: vi.fn(),
     });
@@ -239,6 +247,8 @@ describe("NotificationsPage", () => {
         },
       ],
       readingNotificationId: null,
+      removeContactSuppression: vi.fn(),
+      removingSuppressionKey: null,
       updatingContactId: null,
       updateNotificationContact: vi.fn(),
     });
@@ -275,6 +285,8 @@ describe("NotificationsPage", () => {
         },
       ],
       readingNotificationId: null,
+      removeContactSuppression: vi.fn(),
+      removingSuppressionKey: null,
       updatingContactId: null,
       updateNotificationContact: vi.fn(),
     });
@@ -307,6 +319,8 @@ describe("NotificationsPage", () => {
         },
       ],
       readingNotificationId: null,
+      removeContactSuppression: vi.fn(),
+      removingSuppressionKey: null,
       updatingContactId: null,
       updateNotificationContact: vi.fn(),
     });
@@ -354,6 +368,8 @@ describe("NotificationsPage", () => {
       ],
       notifications: [],
       readingNotificationId: null,
+      removeContactSuppression: vi.fn(),
+      removingSuppressionKey: null,
       updatingContactId: null,
       updateNotificationContact: vi.fn(),
     });
@@ -377,6 +393,8 @@ describe("NotificationsPage", () => {
       notificationContacts: [],
       notifications: [],
       readingNotificationId: null,
+      removeContactSuppression: vi.fn(),
+      removingSuppressionKey: null,
       updatingContactId: null,
       updateNotificationContact: vi.fn(),
     });
@@ -408,6 +426,8 @@ describe("NotificationsPage", () => {
       notificationContacts: [],
       notifications: [],
       readingNotificationId: null,
+      removeContactSuppression: vi.fn(),
+      removingSuppressionKey: null,
       updatingContactId: null,
       updateNotificationContact: vi.fn(),
     });
@@ -444,6 +464,8 @@ describe("NotificationsPage", () => {
       ],
       notifications: [],
       readingNotificationId: null,
+      removeContactSuppression: vi.fn(),
+      removingSuppressionKey: null,
       updatingContactId: null,
       updateNotificationContact,
     });
@@ -458,7 +480,7 @@ describe("NotificationsPage", () => {
     });
   });
 
-  it("renders suppression badges for suppressed contacts", () => {
+  it("renders suppression remove buttons for suppressed contacts", () => {
     mockedUseNotificationsPageState.mockReturnValue({
       createNotificationContact: vi.fn(),
       dueReminders: [],
@@ -483,15 +505,103 @@ describe("NotificationsPage", () => {
       ],
       notifications: [],
       readingNotificationId: null,
+      removeContactSuppression: vi.fn(),
+      removingSuppressionKey: null,
       updatingContactId: null,
       updateNotificationContact: vi.fn(),
     });
 
     render(<NotificationsPage />);
 
-    expect(screen.getByText("Suppressed: bounce")).toBeInTheDocument();
-    expect(screen.getByText("Suppressed: complaint")).toBeInTheDocument();
-    expect(screen.getAllByText("Suppressed: bounce")).toHaveLength(1);
-    expect(screen.getAllByText("Suppressed: complaint")).toHaveLength(1);
+    expect(
+      screen.getByRole("button", {
+        name: "Remove bounce suppression for suppressed@example.test",
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Remove complaint suppression for suppressed@example.test",
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: /Remove.*suppression for clean@example.test/,
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it("clicking remove suppression calls removeContactSuppression with correct args", async () => {
+    const removeContactSuppression = vi.fn().mockResolvedValue(undefined);
+    mockedUseNotificationsPageState.mockReturnValue({
+      createNotificationContact: vi.fn(),
+      dueReminders: [],
+      error: null,
+      isLoading: false,
+      markNotificationRead,
+      notificationContacts: [
+        {
+          contact_id: "contact-1",
+          created_at: "2026-05-05T10:00:00Z",
+          email: "suppressed@example.test",
+          enabled: true,
+          suppression_reasons: ["bounce"],
+        },
+      ],
+      notifications: [],
+      readingNotificationId: null,
+      removeContactSuppression,
+      removingSuppressionKey: null,
+      updatingContactId: null,
+      updateNotificationContact: vi.fn(),
+    });
+
+    render(<NotificationsPage />);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Remove bounce suppression for suppressed@example.test",
+      })
+    );
+
+    await waitFor(() => {
+      expect(removeContactSuppression).toHaveBeenCalledWith("contact-1", "bounce");
+    });
+  });
+
+  it("remove suppression button is disabled while that removal is in progress", () => {
+    mockedUseNotificationsPageState.mockReturnValue({
+      createNotificationContact: vi.fn(),
+      dueReminders: [],
+      error: null,
+      isLoading: false,
+      markNotificationRead,
+      notificationContacts: [
+        {
+          contact_id: "contact-1",
+          created_at: "2026-05-05T10:00:00Z",
+          email: "suppressed@example.test",
+          enabled: true,
+          suppression_reasons: ["bounce", "complaint"],
+        },
+      ],
+      notifications: [],
+      readingNotificationId: null,
+      removeContactSuppression: vi.fn(),
+      removingSuppressionKey: "contact-1:bounce",
+      updatingContactId: null,
+      updateNotificationContact: vi.fn(),
+    });
+
+    render(<NotificationsPage />);
+
+    expect(
+      screen.getByRole("button", {
+        name: "Remove bounce suppression for suppressed@example.test",
+      })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: "Remove complaint suppression for suppressed@example.test",
+      })
+    ).not.toBeDisabled();
   });
 });

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -70,6 +70,8 @@ export function NotificationsPage() {
     notificationContacts,
     notifications,
     readingNotificationId,
+    removeContactSuppression,
+    removingSuppressionKey,
     updatingContactId,
     updateNotificationContact,
   } = useNotificationsPageState();
@@ -151,10 +153,32 @@ export function NotificationsPage() {
                     {contact.enabled ? "Enabled" : "Disabled"}
                   </span>
                   {contact.suppression_reasons?.includes("bounce") && (
-                    <span className="status-pill status-pill-unread">Suppressed: bounce</span>
+                    <span className="status-pill status-pill-unread">
+                      Suppressed: bounce
+                      <button
+                        aria-label={`Remove bounce suppression for ${contact.email}`}
+                        className="ghost-button resource-edit-button"
+                        disabled={removingSuppressionKey === `${contact.contact_id}:bounce`}
+                        onClick={() => void removeContactSuppression(contact.contact_id, "bounce")}
+                        type="button"
+                      >
+                        Remove
+                      </button>
+                    </span>
                   )}
                   {contact.suppression_reasons?.includes("complaint") && (
-                    <span className="status-pill status-pill-unread">Suppressed: complaint</span>
+                    <span className="status-pill status-pill-unread">
+                      Suppressed: complaint
+                      <button
+                        aria-label={`Remove complaint suppression for ${contact.email}`}
+                        className="ghost-button resource-edit-button"
+                        disabled={removingSuppressionKey === `${contact.contact_id}:complaint`}
+                        onClick={() => void removeContactSuppression(contact.contact_id, "complaint")}
+                        type="button"
+                      >
+                        Remove
+                      </button>
+                    </span>
                   )}
                   <button
                     aria-label={`${contact.enabled ? "Disable" : "Enable"} ${contact.email}`}

--- a/scripts/dev/seed-demo-data.sh
+++ b/scripts/dev/seed-demo-data.sh
@@ -68,6 +68,40 @@ api_post_json() {
   fi
 }
 
+api_patch_json() {
+  local route="$1"
+  local payload="$2"
+  local status_code
+
+  status_code="$(
+    curl -sS \
+      -X PATCH \
+      -H "Authorization: Bearer ${ID_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "${payload}" \
+      -o /dev/null \
+      -w "%{http_code}" \
+      "${API_URL}${route}"
+  )"
+
+  if [[ "${status_code}" != "200" ]]; then
+    die "PATCH ${route} failed with HTTP ${status_code}."
+  fi
+}
+
+write_contact_payload() {
+  local payload_file="$1"
+  local email="$2"
+
+  python3 - "${payload_file}" "${email}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "w", encoding="utf-8") as payload_file:
+    json.dump({"email": sys.argv[2]}, payload_file)
+PY
+}
+
 write_property_payload() {
   local payload_file="$1"
   local name="$2"
@@ -162,12 +196,22 @@ PROPERTY_ONE_PAYLOAD="${TMP_DIR}/property-one.json"
 PROPERTY_ONE_RESPONSE="${TMP_DIR}/property-one-response.json"
 PROPERTY_TWO_PAYLOAD="${TMP_DIR}/property-two.json"
 PROPERTY_TWO_RESPONSE="${TMP_DIR}/property-two-response.json"
+PROPERTY_THREE_PAYLOAD="${TMP_DIR}/property-three.json"
+PROPERTY_THREE_RESPONSE="${TMP_DIR}/property-three-response.json"
 LEASE_ONE_PAYLOAD="${TMP_DIR}/lease-one.json"
 LEASE_ONE_RESPONSE="${TMP_DIR}/lease-one-response.json"
 LEASE_TWO_PAYLOAD="${TMP_DIR}/lease-two.json"
 LEASE_TWO_RESPONSE="${TMP_DIR}/lease-two-response.json"
+LEASE_THREE_PAYLOAD="${TMP_DIR}/lease-three.json"
+LEASE_THREE_RESPONSE="${TMP_DIR}/lease-three-response.json"
 REMINDER_SCAN_PAYLOAD="${TMP_DIR}/reminder-scan.json"
 REMINDER_SCAN_RESPONSE="${TMP_DIR}/reminder-scan-response.json"
+CONTACT_ONE_PAYLOAD="${TMP_DIR}/contact-one.json"
+CONTACT_ONE_RESPONSE="${TMP_DIR}/contact-one-response.json"
+CONTACT_TWO_PAYLOAD="${TMP_DIR}/contact-two.json"
+CONTACT_TWO_RESPONSE="${TMP_DIR}/contact-two-response.json"
+CONTACT_THREE_PAYLOAD="${TMP_DIR}/contact-three.json"
+CONTACT_THREE_RESPONSE="${TMP_DIR}/contact-three-response.json"
 
 write_property_payload "${PROPERTY_ONE_PAYLOAD}" "Demo Harbor Flats" "Demo Harbor Street 12"
 api_post_json "/properties" "${PROPERTY_ONE_PAYLOAD}" "${PROPERTY_ONE_RESPONSE}"
@@ -176,6 +220,10 @@ PROPERTY_ONE_ID="$(json_field "${PROPERTY_ONE_RESPONSE}" "property_id")"
 write_property_payload "${PROPERTY_TWO_PAYLOAD}" "Demo Forest Homes" "Demo Forest Road 8"
 api_post_json "/properties" "${PROPERTY_TWO_PAYLOAD}" "${PROPERTY_TWO_RESPONSE}"
 PROPERTY_TWO_ID="$(json_field "${PROPERTY_TWO_RESPONSE}" "property_id")"
+
+write_property_payload "${PROPERTY_THREE_PAYLOAD}" "Demo City Studio" "Demo City Lane 3B"
+api_post_json "/properties" "${PROPERTY_THREE_PAYLOAD}" "${PROPERTY_THREE_RESPONSE}"
+PROPERTY_THREE_ID="$(json_field "${PROPERTY_THREE_RESPONSE}" "property_id")"
 
 write_lease_payload \
   "${LEASE_ONE_PAYLOAD}" \
@@ -194,6 +242,21 @@ write_lease_payload \
   "${TODAY}" \
   "${END_DATE}"
 api_post_json "/leases" "${LEASE_TWO_PAYLOAD}" "${LEASE_TWO_RESPONSE}"
+
+PAST_DUE_DAY="$(python3 - "${RENT_DUE_DAY}" <<'PY'
+import sys
+day = int(sys.argv[1])
+print(28 if day <= 15 else 3)
+PY
+)"
+write_lease_payload \
+  "${LEASE_THREE_PAYLOAD}" \
+  "${PROPERTY_THREE_ID}" \
+  "Demo Resident Three" \
+  "${PAST_DUE_DAY}" \
+  "${START_DATE}" \
+  "${END_DATE}"
+api_post_json "/leases" "${LEASE_THREE_PAYLOAD}" "${LEASE_THREE_RESPONSE}"
 
 python3 - "${REMINDER_SCAN_PAYLOAD}" "${SEED_TENANT}" "${TODAY}" <<'PY'
 import json
@@ -249,8 +312,39 @@ if status_code != 200:
     sys.exit(1)
 PY
 
+# Notification contacts: active, disabled, and one reserved for suppression testing.
+info "Creating notification contacts"
+
+write_contact_payload "${CONTACT_ONE_PAYLOAD}" "demo-notify-alpha-${SEED_STAMP}@example.com"
+api_post_json "/notification-contacts" "${CONTACT_ONE_PAYLOAD}" "${CONTACT_ONE_RESPONSE}"
+CONTACT_ONE_ID="$(json_field "${CONTACT_ONE_RESPONSE}" "contact_id")"
+
+write_contact_payload "${CONTACT_TWO_PAYLOAD}" "demo-notify-beta-${SEED_STAMP}@example.com"
+api_post_json "/notification-contacts" "${CONTACT_TWO_PAYLOAD}" "${CONTACT_TWO_RESPONSE}"
+CONTACT_TWO_ID="$(json_field "${CONTACT_TWO_RESPONSE}" "contact_id")"
+api_patch_json "/notification-contacts/${CONTACT_TWO_ID}" '{"enabled": false}'
+
+write_contact_payload "${CONTACT_THREE_PAYLOAD}" "demo-notify-gamma-${SEED_STAMP}@example.com"
+api_post_json "/notification-contacts" "${CONTACT_THREE_PAYLOAD}" "${CONTACT_THREE_RESPONSE}"
+CONTACT_THREE_ID="$(json_field "${CONTACT_THREE_RESPONSE}" "contact_id")"
+
 printf 'EMAIL=%s\n' "${SEED_EMAIL}"
 printf 'PASSWORD=%s\n' "${SEED_PASSWORD}"
-printf 'PROPERTY_CREATED_COUNT=%s\n' "2"
-printf 'LEASE_CREATED_COUNT=%s\n' "2"
+printf 'TENANT_ID=%s\n' "${SEED_TENANT}"
+printf 'PROPERTY_CREATED_COUNT=%s\n' "3"
+printf 'LEASE_CREATED_COUNT=%s\n' "3"
+printf 'CONTACT_CREATED_COUNT=%s\n' "3"
+printf 'CONTACT_ALPHA_ID=%s\n' "${CONTACT_ONE_ID}"
+printf 'CONTACT_BETA_ID=%s (disabled)\n' "${CONTACT_TWO_ID}"
+printf 'CONTACT_GAMMA_ID=%s\n' "${CONTACT_THREE_ID}"
 echo "Seed data is synthetic and disposable. Do not commit or paste credentials into evidence."
+cat <<HINT
+
+To test suppression removal (ticket #215), seed a bounce suppression for
+CONTACT_GAMMA after enabling the delivery worker and running a delivery cycle
+so that a correlation token exists in notification_email_deliveries. Then
+invoke the Lambda with a synthetic SES feedback event referencing that token.
+Alternatively, insert directly via psql if you have DB access:
+  INSERT INTO notification_contact_suppressions (tenant_id, contact_id, reason)
+  VALUES ('${SEED_TENANT}', '${CONTACT_THREE_ID}', 'bounce');
+HINT


### PR DESCRIPTION
## Summary

Adds a `DELETE /notification-contacts/{id}/suppressions/{reason}` endpoint
and a Remove button in the notifications UI for each active suppression pill.
Removing a suppression is auditable: the DB method writes an
`notification_contact_suppression.remove` audit log entry. The endpoint
returns the updated contact with remaining `suppression_reasons`.

## Why

Once the SES feedback processor marks a contact as suppressed (bounce or
complaint), there was no way to lift the suppression — not for corrected
email addresses, not for contacts mistakenly suppressed. The suppression
model doc explicitly requires an auditable removal path before suppressions
are usable in production.

## Validation

- [x] `make lint`
- [x] `make test`
- [x] `make tf-fmt` (if `infra/` changed) — no infra changes
- [x] 5 new backend tests (success, partial removal, not-found, invalid reason, wrong-tenant)
- [x] 3 new frontend tests (render, click, disabled-during-removal)

## Review Notes

- [x] Tenant-scoped queries explicitly filter by `tenant_id` where applicable — `delete_notification_contact_suppression` validates contact belongs to tenant before deleting
- [x] `tenant_id` comes from validated JWT claims, not client input — reason comes from URL path, tenant_id always from `extract_auth_context`
- [x] Write flows keep domain changes and audit records in one transaction where required — DELETE and audit INSERT are in one `conn.transaction()`
- [x] Structured logging or audit logging was updated if the change affects important write flows — audit log entry with `action="notification_contact_suppression.remove"`
- [x] Docs were updated if architecture, security, or MVP scope changed materially — no architecture change, this was already scoped in the suppression model doc

## Deployment Notes

No migrations required. No Terraform changes. The new endpoint is backend-only and wired through the existing Lambda handler.
