### PR TITLE
test: add route-level tenant isolation coverage (#216)

### DIFF
--- a/backend/tests/test_leases_route.py
+++ b/backend/tests/test_leases_route.py
@@ -27,9 +27,29 @@ class _LeaseRecord:
     created_at: datetime
 
 
+def _lease(*, lease_id: UUID, tenant_id: str) -> _LeaseRecord:
+    return _LeaseRecord(
+        lease_id=lease_id,
+        tenant_id=tenant_id,
+        property_id=UUID("11111111-1111-1111-1111-111111111111"),
+        resident_name="Alice Example",
+        rent_due_day_of_month=5,
+        start_date=date(2026, 5, 1),
+        end_date=date(2027, 4, 30),
+        created_at=datetime(2026, 4, 7, tzinfo=UTC),
+    )
+
+
+_LEASE_UUID = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+
 class _FakeDb:
     def __init__(self) -> None:
         self.create_calls: list[dict[str, object]] = []
+        self.leases: list[_LeaseRecord] = [
+            _lease(lease_id=_LEASE_UUID, tenant_id="tenant-from-token"),
+            _lease(lease_id=_LEASE_UUID, tenant_id="tenant-auth"),
+        ]
         self.list_calls: list[str] = []
         self.update_calls: list[dict[str, object]] = []
 
@@ -87,6 +107,12 @@ class _FakeDb:
         lease_id: UUID,
         updates: dict[str, object],
     ) -> _LeaseRecord:
+        owned = next(
+            (r for r in self.leases if r.tenant_id == tenant_id and r.lease_id == lease_id),
+            None,
+        )
+        if owned is None:
+            raise LookupError("Lease not found for tenant.")
         self.update_calls.append(
             {
                 "tenant_id": tenant_id,
@@ -576,3 +602,19 @@ def test_update_lease_requires_jwt_claims() -> None:
             db,
             UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
         )
+
+
+def test_update_lease_wrong_tenant_raises_lookup_error() -> None:
+    leases = _leases_module()
+    db = _FakeDb()
+    db.leases = [_lease(lease_id=_LEASE_UUID, tenant_id="tenant-other")]
+    event = _event_with_auth(tenant_id="tenant-auth", user_id="user-auth")
+
+    with pytest.raises(LookupError, match="Lease not found for tenant."):
+        leases.update_lease(
+            {**event, "body": '{"resident_name":"Alice Updated"}'},
+            db,
+            _LEASE_UUID,
+        )
+
+    assert db.update_calls == []

--- a/backend/tests/test_notification_contacts_route.py
+++ b/backend/tests/test_notification_contacts_route.py
@@ -105,16 +105,16 @@ class _FakeDb:
         contact_id: UUID,
         enabled: bool,
     ) -> _ContactRecord:
-        self.update_calls.append(
-            {
-                "tenant_id": tenant_id,
-                "actor_user_id": actor_user_id,
-                "contact_id": contact_id,
-                "enabled": enabled,
-            }
-        )
         for index, contact in enumerate(self.contacts):
             if contact.tenant_id == tenant_id and contact.contact_id == contact_id:
+                self.update_calls.append(
+                    {
+                        "tenant_id": tenant_id,
+                        "actor_user_id": actor_user_id,
+                        "contact_id": contact_id,
+                        "enabled": enabled,
+                    }
+                )
                 updated = _contact(
                     contact_id=contact.contact_id,
                     tenant_id=contact.tenant_id,
@@ -517,3 +517,24 @@ def test_remove_suppression_wrong_tenant_raises_lookup_error() -> None:
             UUID("11111111-1111-1111-1111-111111111111"),
             "bounce",
         )
+
+
+def test_update_notification_contact_wrong_tenant_raises_lookup_error() -> None:
+    contacts = _contacts_module()
+    db = _FakeDb()
+    other_contact_id = UUID("99999999-9999-9999-9999-999999999999")
+    db.contacts.append(
+        _contact(
+            contact_id=other_contact_id,
+            tenant_id="tenant-other",
+            email="other@example.test",
+            enabled=True,
+        )
+    )
+    event = _event_with_auth(tenant_id="tenant-auth")
+    event["body"] = '{"enabled": false}'
+
+    with pytest.raises(LookupError):
+        contacts.update_notification_contact(event, db, other_contact_id)
+
+    assert db.update_calls == []

--- a/backend/tests/test_notifications_route.py
+++ b/backend/tests/test_notifications_route.py
@@ -43,6 +43,9 @@ class _FakeDb:
     def __init__(self) -> None:
         self.list_calls: list[str] = []
         self.read_calls: list[tuple[str, UUID]] = []
+        self.notification_owners: dict[UUID, str] = {
+            UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"): "tenant-auth",
+        }
 
     def list_notifications(self, tenant_id: str) -> list[_NotificationRecord]:
         self.list_calls.append(tenant_id)
@@ -74,6 +77,8 @@ class _FakeDb:
         tenant_id: str,
         notification_id: UUID,
     ) -> _NotificationRecord:
+        if self.notification_owners.get(notification_id) != tenant_id:
+            raise LookupError("Notification not found for tenant.")
         self.read_calls.append((tenant_id, notification_id))
         return _NotificationRecord(
             notification_id=notification_id,
@@ -200,3 +205,16 @@ def test_mark_notification_read_requires_jwt_claims() -> None:
             db,
             UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
         )
+
+
+def test_mark_notification_read_wrong_tenant_raises_lookup_error() -> None:
+    notifications = _notifications_module()
+    db = _FakeDb()
+    other_notification_id = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+    db.notification_owners[other_notification_id] = "tenant-other"
+    event = _event_with_auth(tenant_id="tenant-auth", user_id="user-auth")
+
+    with pytest.raises(LookupError, match="Notification not found for tenant."):
+        notifications.mark_notification_read(event, db, other_notification_id)
+
+    assert db.read_calls == []

--- a/backend/tests/test_properties_route.py
+++ b/backend/tests/test_properties_route.py
@@ -15,6 +15,11 @@ class _FakeDb:
         self.calls: list[dict[str, str]] = []
         self.list_calls: list[str] = []
         self.update_calls: list[dict[str, object]] = []
+        self.owned_property_ids: dict[UUID, str] = {
+            UUID("33333333-3333-3333-3333-333333333333"): "tenant-auth",
+            UUID("44444444-4444-4444-4444-444444444444"): "tenant-from-token",
+            UUID("55555555-5555-5555-5555-555555555555"): "tenant-from-token",
+        }
 
     def create_property(
         self,
@@ -65,6 +70,8 @@ class _FakeDb:
         property_id: UUID,
         updates: dict[str, str],
     ) -> Property:
+        if self.owned_property_ids.get(property_id) != tenant_id:
+            raise LookupError("Property not found for tenant.")
         self.update_calls.append(
             {
                 "tenant_id": tenant_id,
@@ -272,3 +279,16 @@ def test_update_property_requires_jwt_claims() -> None:
             db,
             UUID("99999999-9999-9999-9999-999999999999"),
         )
+
+
+def test_update_property_wrong_tenant_raises_lookup_error() -> None:
+    db = _FakeDb()
+    other_property_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    db.owned_property_ids[other_property_id] = "tenant-other"
+    event = _event_with_auth(tenant_id="tenant-auth", user_id="user-auth")
+    event["body"] = '{"name":"Renamed HQ"}'
+
+    with pytest.raises(LookupError, match="Property not found for tenant."):
+        update_property(event, db, other_property_id)
+
+    assert db.update_calls == []


### PR DESCRIPTION
## Summary

Adds cross-tenant isolation tests to all four route-level test files. Each
mutating route that accepts a resource UUID in the URL path now has a test
that seeds a record owned by `tenant-other`, issues the request with a
`tenant-auth` JWT, and asserts `LookupError` is raised and no DB mutation
is recorded.

Closes #216

## Changes

- `test_leases_route.py` — `_FakeDb` gains `self.leases` list with a
  `_lease()` factory; `update_lease` checks ownership before recording the
  call; new `test_update_lease_wrong_tenant_raises_lookup_error`
- `test_properties_route.py` — `_FakeDb` gains `self.owned_property_ids`
  dict seeded from existing tests; `update_property` raises `LookupError`
  for unknown `(tenant_id, property_id)` pairs; new
  `test_update_property_wrong_tenant_raises_lookup_error`
- `test_notifications_route.py` — `_FakeDb` gains `self.notification_owners`
  dict; `mark_notification_read` raises `LookupError` for wrong tenant; new
  `test_mark_notification_read_wrong_tenant_raises_lookup_error`
- `test_notification_contacts_route.py` — `set_notification_contact_enabled`
  stub moved ownership check before recording the call (no behaviour change
  for passing tests); new
  `test_update_notification_contact_wrong_tenant_raises_lookup_error`

No production code changes.

## Test plan

- [x] `python -m pytest backend/tests/test_leases_route.py backend/tests/test_properties_route.py backend/tests/test_notifications_route.py backend/tests/test_notification_contacts_route.py -v` — 54 passed
- [x] `python -m pytest backend/tests/ -v --ignore=backend/tests/test_invoke_local.py` — 133 passed, 43 skipped
- [x] `python -m ruff format --check src tests migrations` — 51 files already formatted
