### PR TITLE
feat: add tenant context transaction helper

### DIFF
--- a/backend/src/app/db.py
+++ b/backend/src/app/db.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import calendar
 import json
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
 from datetime import date, timedelta
 from typing import Any
 from uuid import UUID
@@ -33,6 +34,20 @@ class Database:
     def __init__(self, settings: Settings) -> None:
         self._dsn = settings.db_dsn()
 
+    @contextmanager
+    def _tenant_transaction(self, tenant_id: str) -> Iterator[Any]:
+        normalized_tenant_id = str(tenant_id or "").strip()
+        if not normalized_tenant_id:
+            raise ValueError("Tenant context is required.")
+
+        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+            with conn.transaction():
+                conn.execute(
+                    "SELECT set_config('app.tenant_id', %s, true)",
+                    (normalized_tenant_id,),
+                )
+                yield conn
+
     def create_notification_contact(
         self,
         tenant_id: str,
@@ -56,25 +71,24 @@ class Database:
             ) VALUES (%s, %s, %s, %s, %s, %s::jsonb)
         """
         try:
-            with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
-                with conn.transaction():
-                    contact_row = conn.execute(
-                        contact_sql,
-                        (tenant_id, normalized_email, enabled),
-                    ).fetchone()
-                    if not contact_row:
-                        raise RuntimeError("Failed to create notification contact.")
-                    conn.execute(
-                        audit_sql,
-                        (
-                            tenant_id,
-                            actor_user_id,
-                            "notification_contact.create",
-                            "notification_contact",
-                            contact_row["contact_id"],
-                            json.dumps({"source": audit_source, "enabled": enabled}),
-                        ),
-                    )
+            with self._tenant_transaction(tenant_id) as conn:
+                contact_row = conn.execute(
+                    contact_sql,
+                    (tenant_id, normalized_email, enabled),
+                ).fetchone()
+                if not contact_row:
+                    raise RuntimeError("Failed to create notification contact.")
+                conn.execute(
+                    audit_sql,
+                    (
+                        tenant_id,
+                        actor_user_id,
+                        "notification_contact.create",
+                        "notification_contact",
+                        contact_row["contact_id"],
+                        json.dumps({"source": audit_source, "enabled": enabled}),
+                    ),
+                )
         except psycopg.errors.UniqueViolation as exc:
             raise ValueError("Notification contact already exists for tenant.") from exc
 
@@ -100,7 +114,7 @@ class Database:
         """
         params = (tenant_id,)
 
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+        with self._tenant_transaction(tenant_id) as conn:
             rows = conn.execute(sql, params).fetchall()
         return [self._row_to_notification_contact(row) for row in rows]
 
@@ -123,25 +137,24 @@ class Database:
                 tenant_id, actor_user_id, action, entity_type, entity_id, metadata
             ) VALUES (%s, %s, %s, %s, %s, %s::jsonb)
         """
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
-            with conn.transaction():
-                contact_row = conn.execute(
-                    contact_sql,
-                    (enabled, tenant_id, contact_id),
-                ).fetchone()
-                if contact_row is None:
-                    raise LookupError("Notification contact not found for tenant.")
-                conn.execute(
-                    audit_sql,
-                    (
-                        tenant_id,
-                        actor_user_id,
-                        "notification_contact.update",
-                        "notification_contact",
-                        contact_id,
-                        json.dumps({"source": audit_source, "enabled": enabled}),
-                    ),
-                )
+        with self._tenant_transaction(tenant_id) as conn:
+            contact_row = conn.execute(
+                contact_sql,
+                (enabled, tenant_id, contact_id),
+            ).fetchone()
+            if contact_row is None:
+                raise LookupError("Notification contact not found for tenant.")
+            conn.execute(
+                audit_sql,
+                (
+                    tenant_id,
+                    actor_user_id,
+                    "notification_contact.update",
+                    "notification_contact",
+                    contact_id,
+                    json.dumps({"source": audit_source, "enabled": enabled}),
+                ),
+            )
 
         return self._row_to_notification_contact(contact_row)
 
@@ -183,40 +196,39 @@ class Database:
             ) VALUES (%s, %s, %s, %s, %s, %s::jsonb)
         """
 
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
-            with conn.transaction():
-                contact_row = conn.execute(contact_sql, (tenant_id, contact_id)).fetchone()
-                if contact_row is None:
-                    raise LookupError("Notification contact not found for tenant.")
+        with self._tenant_transaction(tenant_id) as conn:
+            contact_row = conn.execute(contact_sql, (tenant_id, contact_id)).fetchone()
+            if contact_row is None:
+                raise LookupError("Notification contact not found for tenant.")
 
+            suppression_row = conn.execute(
+                insert_sql,
+                (tenant_id, contact_id, normalized_reason),
+            ).fetchone()
+            if suppression_row is not None:
+                conn.execute(
+                    audit_sql,
+                    (
+                        tenant_id,
+                        actor_user_id,
+                        "notification_contact_suppression.create",
+                        "notification_contact_suppression",
+                        suppression_row["suppression_id"],
+                        json.dumps(
+                            {
+                                "source": audit_source,
+                                "reason": normalized_reason,
+                            }
+                        ),
+                    ),
+                )
+            else:
                 suppression_row = conn.execute(
-                    insert_sql,
+                    select_existing_sql,
                     (tenant_id, contact_id, normalized_reason),
                 ).fetchone()
-                if suppression_row is not None:
-                    conn.execute(
-                        audit_sql,
-                        (
-                            tenant_id,
-                            actor_user_id,
-                            "notification_contact_suppression.create",
-                            "notification_contact_suppression",
-                            suppression_row["suppression_id"],
-                            json.dumps(
-                                {
-                                    "source": audit_source,
-                                    "reason": normalized_reason,
-                                }
-                            ),
-                        ),
-                    )
-                else:
-                    suppression_row = conn.execute(
-                        select_existing_sql,
-                        (tenant_id, contact_id, normalized_reason),
-                    ).fetchone()
-                    if suppression_row is None:
-                        raise RuntimeError("Failed to load notification contact suppression.")
+                if suppression_row is None:
+                    raise RuntimeError("Failed to load notification contact suppression.")
 
         return self._row_to_notification_contact_suppression(suppression_row)
 
@@ -225,25 +237,24 @@ class Database:
         tenant_id: str,
         contact_id: UUID | None = None,
     ) -> list[NotificationContactSuppression]:
-        params: tuple[object, ...]
         if contact_id is not None:
             contact_sql = """
                 SELECT contact_id
                 FROM notification_contacts
                 WHERE tenant_id = %s AND contact_id = %s
             """
-            with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+            with self._tenant_transaction(tenant_id) as conn:
                 contact_row = conn.execute(contact_sql, (tenant_id, contact_id)).fetchone()
-            if contact_row is None:
-                raise LookupError("Notification contact not found for tenant.")
+                if contact_row is None:
+                    raise LookupError("Notification contact not found for tenant.")
 
-            sql = """
-                SELECT suppression_id, tenant_id, contact_id, reason, created_at
-                FROM notification_contact_suppressions
-                WHERE tenant_id = %s AND contact_id = %s
-                ORDER BY created_at DESC, suppression_id DESC
-            """
-            params = (tenant_id, contact_id)
+                sql = """
+                    SELECT suppression_id, tenant_id, contact_id, reason, created_at
+                    FROM notification_contact_suppressions
+                    WHERE tenant_id = %s AND contact_id = %s
+                    ORDER BY created_at DESC, suppression_id DESC
+                """
+                rows = conn.execute(sql, (tenant_id, contact_id)).fetchall()
         else:
             sql = """
                 SELECT suppression_id, tenant_id, contact_id, reason, created_at
@@ -251,10 +262,8 @@ class Database:
                 WHERE tenant_id = %s
                 ORDER BY created_at DESC, suppression_id DESC
             """
-            params = (tenant_id,)
-
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
-            rows = conn.execute(sql, params).fetchall()
+            with self._tenant_transaction(tenant_id) as conn:
+                rows = conn.execute(sql, (tenant_id,)).fetchall()
         return [self._row_to_notification_contact_suppression(row) for row in rows]
 
     def delete_notification_contact_suppression(
@@ -288,31 +297,30 @@ class Database:
             WHERE tenant_id = %s AND contact_id = %s AND reason = %s
         """
 
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
-            with conn.transaction():
-                contact_row = conn.execute(contact_sql, (tenant_id, contact_id)).fetchone()
-                if contact_row is None:
-                    raise LookupError("Notification contact not found for tenant.")
+        with self._tenant_transaction(tenant_id) as conn:
+            contact_row = conn.execute(contact_sql, (tenant_id, contact_id)).fetchone()
+            if contact_row is None:
+                raise LookupError("Notification contact not found for tenant.")
 
-                suppression_row = conn.execute(
-                    select_suppression_sql,
-                    (tenant_id, contact_id, normalized_reason),
-                ).fetchone()
-                if suppression_row is None:
-                    raise LookupError("Notification contact suppression not found.")
+            suppression_row = conn.execute(
+                select_suppression_sql,
+                (tenant_id, contact_id, normalized_reason),
+            ).fetchone()
+            if suppression_row is None:
+                raise LookupError("Notification contact suppression not found.")
 
-                conn.execute(delete_sql, (tenant_id, contact_id, normalized_reason))
-                conn.execute(
-                    audit_sql,
-                    (
-                        tenant_id,
-                        actor_user_id,
-                        "notification_contact_suppression.remove",
-                        "notification_contact_suppression",
-                        suppression_row["suppression_id"],
-                        json.dumps({"source": "api", "reason": normalized_reason}),
-                    ),
-                )
+            conn.execute(delete_sql, (tenant_id, contact_id, normalized_reason))
+            conn.execute(
+                audit_sql,
+                (
+                    tenant_id,
+                    actor_user_id,
+                    "notification_contact_suppression.remove",
+                    "notification_contact_suppression",
+                    suppression_row["suppression_id"],
+                    json.dumps({"source": "api", "reason": normalized_reason}),
+                ),
+            )
 
     def create_missing_notification_email_deliveries(
         self,
@@ -482,22 +490,21 @@ class Database:
                 tenant_id, actor_user_id, action, entity_type, entity_id, metadata
             ) VALUES (%s, %s, %s, %s, %s, %s::jsonb)
         """
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
-            with conn.transaction():
-                row = conn.execute(delivery_sql, (tenant_id, delivery_id)).fetchone()
-                if row is None:
-                    raise LookupError("Notification email delivery not found for tenant.")
-                conn.execute(
-                    audit_sql,
-                    (
-                        tenant_id,
-                        "leaseflow.internal",
-                        "notification_email_delivery.sent",
-                        "notification_email_delivery",
-                        delivery_id,
-                        json.dumps({"source": "internal", "status": "sent"}),
-                    ),
-                )
+        with self._tenant_transaction(tenant_id) as conn:
+            row = conn.execute(delivery_sql, (tenant_id, delivery_id)).fetchone()
+            if row is None:
+                raise LookupError("Notification email delivery not found for tenant.")
+            conn.execute(
+                audit_sql,
+                (
+                    tenant_id,
+                    "leaseflow.internal",
+                    "notification_email_delivery.sent",
+                    "notification_email_delivery",
+                    delivery_id,
+                    json.dumps({"source": "internal", "status": "sent"}),
+                ),
+            )
 
     def mark_notification_email_delivery_failed(
         self,
@@ -523,28 +530,27 @@ class Database:
                 tenant_id, actor_user_id, action, entity_type, entity_id, metadata
             ) VALUES (%s, %s, %s, %s, %s, %s::jsonb)
         """
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
-            with conn.transaction():
-                row = conn.execute(delivery_sql, (error_code, tenant_id, delivery_id)).fetchone()
-                if row is None:
-                    raise LookupError("Notification email delivery not found for tenant.")
-                conn.execute(
-                    audit_sql,
-                    (
-                        tenant_id,
-                        "leaseflow.internal",
-                        "notification_email_delivery.failed",
-                        "notification_email_delivery",
-                        delivery_id,
-                        json.dumps(
-                            {
-                                "source": "internal",
-                                "status": "failed",
-                                "error_code": error_code,
-                            }
-                        ),
+        with self._tenant_transaction(tenant_id) as conn:
+            row = conn.execute(delivery_sql, (error_code, tenant_id, delivery_id)).fetchone()
+            if row is None:
+                raise LookupError("Notification email delivery not found for tenant.")
+            conn.execute(
+                audit_sql,
+                (
+                    tenant_id,
+                    "leaseflow.internal",
+                    "notification_email_delivery.failed",
+                    "notification_email_delivery",
+                    delivery_id,
+                    json.dumps(
+                        {
+                            "source": "internal",
+                            "status": "failed",
+                            "error_code": error_code,
+                        }
                     ),
-                )
+                ),
+            )
 
     def process_ses_provider_feedback(
         self,
@@ -761,7 +767,7 @@ class Database:
             WHERE n.tenant_id = %s
             ORDER BY n.created_at DESC
         """
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+        with self._tenant_transaction(tenant_id) as conn:
             rows = conn.execute(sql, (tenant_id, tenant_id)).fetchall()
         return [self._row_to_notification(row) for row in rows]
 
@@ -785,17 +791,16 @@ class Database:
                 created_at,
                 read_at
         """
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
-            with conn.transaction():
-                row = conn.execute(sql, (tenant_id, notification_id)).fetchone()
-                if row is not None:
-                    row.update(
-                        self._notification_email_delivery_summary_row(
-                            conn,
-                            tenant_id=tenant_id,
-                            notification_id=notification_id,
-                        )
+        with self._tenant_transaction(tenant_id) as conn:
+            row = conn.execute(sql, (tenant_id, notification_id)).fetchone()
+            if row is not None:
+                row.update(
+                    self._notification_email_delivery_summary_row(
+                        conn,
+                        tenant_id=tenant_id,
+                        notification_id=notification_id,
                     )
+                )
 
         if row is None:
             raise LookupError("Notification not found for tenant.")
@@ -847,8 +852,12 @@ class Database:
             ORDER BY tenant_id, created_at DESC
             """
             params = (range_end, as_of_date)
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
-            rows = conn.execute(sql, params).fetchall()
+        if tenant_id:
+            with self._tenant_transaction(tenant_id) as conn:
+                rows = conn.execute(sql, params).fetchall()
+        else:
+            with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+                rows = conn.execute(sql, params).fetchall()
 
         candidates: list[LeaseReminderCandidate] = []
         for row in rows:
@@ -891,7 +900,7 @@ class Database:
             WHERE tenant_id = %s
             ORDER BY created_at DESC
         """
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+        with self._tenant_transaction(tenant_id) as conn:
             rows = conn.execute(sql, (tenant_id,)).fetchall()
         return [self._row_to_lease(row) for row in rows]
 
@@ -902,7 +911,7 @@ class Database:
             WHERE tenant_id = %s
             ORDER BY created_at DESC
         """
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+        with self._tenant_transaction(tenant_id) as conn:
             rows = conn.execute(sql, (tenant_id,)).fetchall()
         return [self._row_to_property(row) for row in rows]
 
@@ -938,32 +947,31 @@ class Database:
                 tenant_id, actor_user_id, action, entity_type, entity_id, metadata
             ) VALUES (%s, %s, %s, %s, %s, %s::jsonb)
         """
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
-            with conn.transaction():
-                lease_row = conn.execute(
-                    lease_sql,
-                    (
-                        resident_name,
-                        rent_due_day_of_month,
-                        start_date,
-                        end_date,
-                        tenant_id,
-                        property_id,
-                    ),
-                ).fetchone()
-                if not lease_row:
-                    raise ValueError("Property not found for tenant.")
-                conn.execute(
-                    audit_sql,
-                    (
-                        tenant_id,
-                        actor_user_id,
-                        "lease.create",
-                        "lease",
-                        lease_row["lease_id"],
-                        '{"source":"api"}',
-                    ),
-                )
+        with self._tenant_transaction(tenant_id) as conn:
+            lease_row = conn.execute(
+                lease_sql,
+                (
+                    resident_name,
+                    rent_due_day_of_month,
+                    start_date,
+                    end_date,
+                    tenant_id,
+                    property_id,
+                ),
+            ).fetchone()
+            if not lease_row:
+                raise ValueError("Property not found for tenant.")
+            conn.execute(
+                audit_sql,
+                (
+                    tenant_id,
+                    actor_user_id,
+                    "lease.create",
+                    "lease",
+                    lease_row["lease_id"],
+                    '{"source":"api"}',
+                ),
+            )
         return self._row_to_lease(lease_row)
 
     def update_lease(
@@ -1000,84 +1008,83 @@ class Database:
                 tenant_id, actor_user_id, action, entity_type, entity_id, metadata
             ) VALUES (%s, %s, %s, %s, %s, %s::jsonb)
         """
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
-            with conn.transaction():
-                lease_row = conn.execute(lease_sql, (tenant_id, lease_id)).fetchone()
-                if lease_row is None:
-                    raise LookupError("Lease not found for tenant.")
+        with self._tenant_transaction(tenant_id) as conn:
+            lease_row = conn.execute(lease_sql, (tenant_id, lease_id)).fetchone()
+            if lease_row is None:
+                raise LookupError("Lease not found for tenant.")
 
-                start_date = updates.get("start_date", lease_row["start_date"])
-                end_date = updates.get("end_date", lease_row["end_date"])
-                if end_date < start_date:
-                    raise ValueError("'end_date' must be on or after 'start_date'.")
+            start_date = updates.get("start_date", lease_row["start_date"])
+            end_date = updates.get("end_date", lease_row["end_date"])
+            if end_date < start_date:
+                raise ValueError("'end_date' must be on or after 'start_date'.")
 
-                changed_fields = [
-                    field
-                    for field in (
-                        "resident_name",
-                        "rent_due_day_of_month",
-                        "start_date",
-                        "end_date",
-                    )
-                    if field in updates and updates[field] != lease_row[field]
-                ]
-                if not changed_fields:
-                    return self._row_to_lease(lease_row)
-
-                assignments = SQL(", ").join(
-                    SQL("{} = %s").format(Identifier(field)) for field in changed_fields
+            changed_fields = [
+                field
+                for field in (
+                    "resident_name",
+                    "rent_due_day_of_month",
+                    "start_date",
+                    "end_date",
                 )
-                update_sql = SQL("""
-                    UPDATE leases
-                    SET {assignments}
-                    WHERE tenant_id = %s AND lease_id = %s
-                    RETURNING
-                        lease_id,
-                        tenant_id,
-                        property_id,
-                        resident_name,
-                        rent_due_day_of_month,
-                        start_date,
-                        end_date,
-                        created_at
-                """).format(assignments=assignments)
-                update_params = tuple(updates[field] for field in changed_fields) + (
-                    tenant_id,
+                if field in updates and updates[field] != lease_row[field]
+            ]
+            if not changed_fields:
+                return self._row_to_lease(lease_row)
+
+            assignments = SQL(", ").join(
+                SQL("{} = %s").format(Identifier(field)) for field in changed_fields
+            )
+            update_sql = SQL("""
+                UPDATE leases
+                SET {assignments}
+                WHERE tenant_id = %s AND lease_id = %s
+                RETURNING
                     lease_id,
-                )
-                lease_row = conn.execute(update_sql, update_params).fetchone()
+                    tenant_id,
+                    property_id,
+                    resident_name,
+                    rent_due_day_of_month,
+                    start_date,
+                    end_date,
+                    created_at
+            """).format(assignments=assignments)
+            update_params = tuple(updates[field] for field in changed_fields) + (
+                tenant_id,
+                lease_id,
+            )
+            lease_row = conn.execute(update_sql, update_params).fetchone()
 
-                reminder_fields_changed = any(
-                    field in {"rent_due_day_of_month", "start_date", "end_date"}
-                    for field in changed_fields
+            reminder_fields_changed = any(
+                field in {"rent_due_day_of_month", "start_date", "end_date"}
+                for field in changed_fields
+            )
+            deleted_notification_count = 0
+            if reminder_fields_changed:
+                deleted_notification_count = (
+                    conn.execute(
+                        delete_notifications_sql,
+                        (tenant_id, lease_id, date.today()),
+                    ).rowcount
+                    or 0
                 )
-                deleted_notification_count = 0
-                if reminder_fields_changed:
-                    deleted_notification_count = (
-                        conn.execute(
-                            delete_notifications_sql,
-                            (tenant_id, lease_id, date.today()),
-                        ).rowcount
-                        or 0
-                    )
 
-                conn.execute(
-                    audit_sql,
-                    (
-                        tenant_id,
-                        actor_user_id,
-                        "lease.update",
-                        "lease",
-                        lease_id,
-                        json.dumps(
-                            {
-                                "source": "api",
-                                "changed_fields": changed_fields,
-                                "deleted_notification_count": deleted_notification_count,
-                            }
-                        ),
+            conn.execute(
+                audit_sql,
+                (
+                    tenant_id,
+                    actor_user_id,
+                    "lease.update",
+                    "lease",
+                    lease_id,
+                    json.dumps(
+                        {
+                            "source": "api",
+                            "changed_fields": changed_fields,
+                            "deleted_notification_count": deleted_notification_count,
+                        }
                     ),
-                )
+                ),
+            )
 
         if lease_row is None:
             raise RuntimeError("Failed to update lease.")
@@ -1102,45 +1109,44 @@ class Database:
                 tenant_id, actor_user_id, action, entity_type, entity_id, metadata
             ) VALUES (%s, %s, %s, %s, %s, %s::jsonb)
         """
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
-            with conn.transaction():
-                property_row = conn.execute(property_sql, (tenant_id, property_id)).fetchone()
-                if property_row is None:
-                    raise LookupError("Property not found for tenant.")
+        with self._tenant_transaction(tenant_id) as conn:
+            property_row = conn.execute(property_sql, (tenant_id, property_id)).fetchone()
+            if property_row is None:
+                raise LookupError("Property not found for tenant.")
 
-                changed_fields = [
-                    field
-                    for field in ("name", "address")
-                    if field in updates and updates[field] != property_row[field]
-                ]
-                if not changed_fields:
-                    return self._row_to_property(property_row)
+            changed_fields = [
+                field
+                for field in ("name", "address")
+                if field in updates and updates[field] != property_row[field]
+            ]
+            if not changed_fields:
+                return self._row_to_property(property_row)
 
-                assignments = SQL(", ").join(
-                    SQL("{} = %s").format(Identifier(field)) for field in changed_fields
-                )
-                update_sql = SQL("""
-                    UPDATE properties
-                    SET {assignments}
-                    WHERE tenant_id = %s AND property_id = %s
-                    RETURNING property_id, tenant_id, name, address, created_at
-                """).format(assignments=assignments)
-                update_params = tuple(updates[field] for field in changed_fields) + (
+            assignments = SQL(", ").join(
+                SQL("{} = %s").format(Identifier(field)) for field in changed_fields
+            )
+            update_sql = SQL("""
+                UPDATE properties
+                SET {assignments}
+                WHERE tenant_id = %s AND property_id = %s
+                RETURNING property_id, tenant_id, name, address, created_at
+            """).format(assignments=assignments)
+            update_params = tuple(updates[field] for field in changed_fields) + (
+                tenant_id,
+                property_id,
+            )
+            property_row = conn.execute(update_sql, update_params).fetchone()
+            conn.execute(
+                audit_sql,
+                (
                     tenant_id,
+                    actor_user_id,
+                    "property.update",
+                    "property",
                     property_id,
-                )
-                property_row = conn.execute(update_sql, update_params).fetchone()
-                conn.execute(
-                    audit_sql,
-                    (
-                        tenant_id,
-                        actor_user_id,
-                        "property.update",
-                        "property",
-                        property_id,
-                        json.dumps({"source": "api", "changed_fields": changed_fields}),
-                    ),
-                )
+                    json.dumps({"source": "api", "changed_fields": changed_fields}),
+                ),
+            )
 
         if property_row is None:
             raise RuntimeError("Failed to update property.")
@@ -1164,22 +1170,21 @@ class Database:
                 tenant_id, actor_user_id, action, entity_type, entity_id, metadata
             ) VALUES (%s, %s, %s, %s, %s, %s::jsonb)
         """
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
-            with conn.transaction():
-                property_row = conn.execute(property_sql, (tenant_id, name, address)).fetchone()
-                if not property_row:
-                    raise RuntimeError("Failed to create property.")
-                conn.execute(
-                    audit_sql,
-                    (
-                        tenant_id,
-                        actor_user_id,
-                        "property.create",
-                        "property",
-                        property_row["property_id"],
-                        '{"source":"api"}',
-                    ),
-                )
+        with self._tenant_transaction(tenant_id) as conn:
+            property_row = conn.execute(property_sql, (tenant_id, name, address)).fetchone()
+            if not property_row:
+                raise RuntimeError("Failed to create property.")
+            conn.execute(
+                audit_sql,
+                (
+                    tenant_id,
+                    actor_user_id,
+                    "property.create",
+                    "property",
+                    property_row["property_id"],
+                    '{"source":"api"}',
+                ),
+            )
         return self._row_to_property(property_row)
 
     @staticmethod

--- a/backend/tests/test_db_tenant_context.py
+++ b/backend/tests/test_db_tenant_context.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from app import db as db_module
+from app.db import Database
+
+
+class _Settings:
+    def db_dsn(self) -> str:
+        return "postgresql://example"
+
+
+class _Result:
+    def __init__(self, row: dict[str, Any] | None = None) -> None:
+        self._row = row
+
+    def fetchone(self) -> dict[str, Any] | None:
+        return self._row
+
+
+class _Transaction:
+    def __init__(self, events: list[tuple[str, object]]) -> None:
+        self._events = events
+
+    def __enter__(self) -> _Transaction:
+        self._events.append(("transaction_enter", None))
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self._events.append(("transaction_exit", None))
+
+
+class _Connection:
+    def __init__(self, events: list[tuple[str, object]]) -> None:
+        self._events = events
+
+    def __enter__(self) -> _Connection:
+        self._events.append(("connection_enter", None))
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self._events.append(("connection_exit", None))
+
+    def transaction(self) -> _Transaction:
+        self._events.append(("transaction_requested", None))
+        return _Transaction(self._events)
+
+    def execute(self, sql: object, params: tuple[object, ...] = ()) -> _Result:
+        sql_text = str(sql)
+        self._events.append(("execute", (sql_text, params)))
+        if "INSERT INTO properties" in sql_text:
+            return _Result(
+                {
+                    "property_id": UUID("11111111-1111-4111-8111-111111111111"),
+                    "tenant_id": "tenant-auth",
+                    "name": "Tenant HQ",
+                    "address": "Tenant Street",
+                    "created_at": None,
+                }
+            )
+        return _Result()
+
+
+def _install_fake_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[tuple[str, object]]:
+    events: list[tuple[str, object]] = []
+
+    def _connect(dsn: str, *, row_factory: object) -> _Connection:
+        events.append(("connect", (dsn, row_factory)))
+        return _Connection(events)
+
+    monkeypatch.setattr(db_module.psycopg, "connect", _connect)
+    return events
+
+
+def _execute_events(events: list[tuple[str, object]]) -> list[tuple[str, tuple[object, ...]]]:
+    return [event[1] for event in events if event[0] == "execute"]  # type: ignore[misc]
+
+
+def test_tenant_transaction_rejects_missing_or_blank_tenant_before_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events = _install_fake_connect(monkeypatch)
+    database = Database(_Settings())
+
+    for tenant_id in (None, "", "   "):
+        with pytest.raises(ValueError, match="Tenant context is required."):
+            with database._tenant_transaction(tenant_id):  # type: ignore[arg-type]
+                raise AssertionError("tenant transaction should not yield")
+
+    assert events == []
+
+
+def test_tenant_transaction_sets_transaction_local_context_before_yield(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events = _install_fake_connect(monkeypatch)
+    database = Database(_Settings())
+
+    with database._tenant_transaction("tenant-auth") as conn:
+        conn.execute("SELECT current_setting('app.tenant_id', true)", ())
+
+    execute_events = _execute_events(events)
+    assert events[:4] == [
+        ("connect", ("postgresql://example", db_module.dict_row)),
+        ("connection_enter", None),
+        ("transaction_requested", None),
+        ("transaction_enter", None),
+    ]
+    assert "set_config" in execute_events[0][0]
+    assert "app.tenant_id" in execute_events[0][0]
+    assert execute_events[0][1] == ("tenant-auth",)
+    assert "tenant-auth" not in execute_events[0][0]
+    assert "current_setting" in execute_events[1][0]
+
+
+def test_create_property_sets_tenant_context_before_domain_sql(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events = _install_fake_connect(monkeypatch)
+    database = Database(_Settings())
+
+    item = database.create_property(
+        tenant_id="tenant-auth",
+        actor_user_id="user-auth",
+        name="Tenant HQ",
+        address="Tenant Street",
+    )
+
+    execute_events = _execute_events(events)
+    assert item.tenant_id == "tenant-auth"
+    assert "set_config" in execute_events[0][0]
+    assert execute_events[0][1] == ("tenant-auth",)
+    assert "INSERT INTO properties" in execute_events[1][0]
+    assert execute_events[1][1] == ("tenant-auth", "Tenant HQ", "Tenant Street")

--- a/docs/postgresql-rls-tenant-isolation-hardening.md
+++ b/docs/postgresql-rls-tenant-isolation-hardening.md
@@ -66,6 +66,10 @@ The future application DB role must not have `BYPASSRLS`. A separate migration
 or admin role may own schema changes, but that role must not be used for normal
 API request handling.
 
+The backend now has a transaction helper that sets this context for normal
+tenant-scoped `Database` methods. RLS policies are still future work, so the
+existing application-level tenant predicates remain mandatory.
+
 ## Internal Job Design
 
 Current internal reminder and email delivery jobs can operate across tenants
@@ -88,10 +92,10 @@ browser/API request handling.
 Recommended implementation order:
 
 1. Add a backend transaction helper that sets tenant context with `SET LOCAL`.
-2. Convert normal tenant-scoped DB methods to use the helper.
-3. Adapt internal reminder and delivery jobs so they can run tenant by tenant.
-4. Add RLS policies for one low-risk table first, then expand table by table.
-5. Add regression tests that intentionally omit application tenant predicates
+   Completed for normal tenant-scoped `Database` methods.
+2. Adapt internal reminder and delivery jobs so they can run tenant by tenant.
+3. Add RLS policies for one low-risk table first, then expand table by table.
+4. Add regression tests that intentionally omit application tenant predicates
    and verify RLS blocks cross-tenant access.
 
 Rollback must be documented in each migration. A safe rollback should be able to


### PR DESCRIPTION
## What changed

Adds the RLS tenant context foundation for backend database access.

- Added private `Database._tenant_transaction(tenant_id)` helper.
- Helper rejects blank/missing tenant context before opening a DB connection.
- Helper opens a transaction and sets transaction-local `app.tenant_id` with a bound parameter.
- Migrated normal tenant-scoped `Database` methods with required `tenant_id: str` to use the helper.
- Left intentionally all-tenant `tenant_id: str | None` internal job paths for #233.
- Updated the RLS hardening plan docs.

## Assumptions

- `set_config('app.tenant_id', %s, true)` is the preferred parameterized equivalent of `SET LOCAL`.
- Existing `WHERE tenant_id = %s` predicates remain mandatory.
- Internal all-tenant reminder/delivery paths are intentionally deferred to #233.

## Security validation

- Tenant context is transaction-local, not session-level.
- Tenant value is bound as a parameter, not interpolated into SQL.
- No RLS policies, `BYPASSRLS`, Terraform, IAM, API, or frontend changes were added.
- Browser/client tenant input rules are unchanged.

## Cost validation

No AWS resources or runtime infrastructure changes.

## Validation

- `cd backend && python -m pytest -q tests/test_db_tenant_context.py`
- `cd backend && python -m pytest -q`
- `cd backend && python -m ruff format --check src tests migrations`
- `cd backend && python -m ruff check src tests migrations`
- `git diff --check`

## Remaining risks / TODOs

- DB integration tests with `LEASEFLOW_RUN_DB_INTEGRATION=1` should be run in the WSL PostgreSQL environment.
- #233 still needs to redesign all-tenant internal jobs before RLS policies can be enabled broadly.
