### PR TITLE
feat: process internal jobs tenant by tenant

### DIFF
--- a/backend/src/app/db.py
+++ b/backend/src/app/db.py
@@ -326,6 +326,88 @@ class Database:
         self,
         tenant_id: str | None,
     ) -> NotificationEmailDeliveryPreparationResult:
+        if tenant_id:
+            return self._create_missing_notification_email_deliveries_for_tenant(
+                tenant_id=tenant_id,
+            )
+
+        results = [
+            self._create_missing_notification_email_deliveries_for_tenant(tenant_id=item)
+            for item in self.list_notification_email_delivery_tenants()
+        ]
+        return NotificationEmailDeliveryPreparationResult(
+            tenant_id=None,
+            candidate_count=sum(item.candidate_count for item in results),
+            created_count=sum(item.created_count for item in results),
+            duplicate_count=sum(item.duplicate_count for item in results),
+            suppressed_contact_count=sum(item.suppressed_contact_count for item in results),
+        )
+
+    def list_notification_email_delivery_tenants(
+        self,
+        *,
+        max_attempts: int | None = None,
+    ) -> list[str]:
+        preparation_sql = """
+            SELECT DISTINCT n.tenant_id
+            FROM notifications n
+            JOIN notification_contacts c
+              ON c.tenant_id = n.tenant_id
+             AND c.enabled = true
+            WHERE n.type = 'rent_due_soon'
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM notification_contact_suppressions s
+                  WHERE s.tenant_id = c.tenant_id
+                    AND s.contact_id = c.contact_id
+                    AND s.reason IN ('bounce', 'complaint')
+              )
+        """
+        params: tuple[object, ...] = ()
+        if max_attempts is None:
+            sql = f"""
+                {preparation_sql}
+                ORDER BY tenant_id
+            """
+        else:
+            sql = f"""
+                SELECT tenant_id
+                FROM (
+                    {preparation_sql}
+                    UNION
+                    SELECT DISTINCT d.tenant_id
+                    FROM notification_email_deliveries d
+                    JOIN notifications n
+                      ON n.tenant_id = d.tenant_id
+                     AND n.notification_id = d.notification_id
+                    JOIN notification_contacts c
+                      ON c.tenant_id = d.tenant_id
+                     AND c.contact_id = d.contact_id
+                    WHERE d.status != 'sent'
+                      AND d.attempt_count < %s
+                      AND c.enabled = true
+                      AND n.type = 'rent_due_soon'
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM notification_contact_suppressions s
+                          WHERE s.tenant_id = c.tenant_id
+                            AND s.contact_id = c.contact_id
+                            AND s.reason IN ('bounce', 'complaint')
+                      )
+                ) delivery_tenants
+                ORDER BY tenant_id
+            """
+            params = (max_attempts,)
+
+        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+            rows = conn.execute(sql, params).fetchall()
+        return [row["tenant_id"] for row in rows]
+
+    def _create_missing_notification_email_deliveries_for_tenant(
+        self,
+        *,
+        tenant_id: str,
+    ) -> NotificationEmailDeliveryPreparationResult:
         select_sql = """
             SELECT n.tenant_id, n.notification_id, c.contact_id
             FROM notifications n
@@ -357,16 +439,13 @@ class Database:
               )
         """
         params: tuple[object, ...]
-        if tenant_id:
-            select_sql += """
-              AND n.tenant_id = %s
-            """
-            suppressed_sql += """
-              AND n.tenant_id = %s
-            """
-            params = (tenant_id,)
-        else:
-            params = ()
+        select_sql += """
+          AND n.tenant_id = %s
+        """
+        suppressed_sql += """
+          AND n.tenant_id = %s
+        """
+        params = (tenant_id,)
 
         insert_sql = """
             INSERT INTO notification_email_deliveries (
@@ -380,21 +459,20 @@ class Database:
         """
 
         created_count = 0
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
-            with conn.transaction():
-                candidates = conn.execute(select_sql, params).fetchall()
-                suppressed_row = conn.execute(suppressed_sql, params).fetchone()
-                for candidate in candidates:
-                    created_row = conn.execute(
-                        insert_sql,
-                        (
-                            candidate["tenant_id"],
-                            candidate["notification_id"],
-                            candidate["contact_id"],
-                        ),
-                    ).fetchone()
-                    if created_row:
-                        created_count += 1
+        with self._tenant_transaction(tenant_id) as conn:
+            candidates = conn.execute(select_sql, params).fetchall()
+            suppressed_row = conn.execute(suppressed_sql, params).fetchone()
+            for candidate in candidates:
+                created_row = conn.execute(
+                    insert_sql,
+                    (
+                        candidate["tenant_id"],
+                        candidate["notification_id"],
+                        candidate["contact_id"],
+                    ),
+                ).fetchone()
+                if created_row:
+                    created_count += 1
 
         return NotificationEmailDeliveryPreparationResult(
             tenant_id=tenant_id,
@@ -409,6 +487,32 @@ class Database:
     def list_pending_notification_email_deliveries(
         self,
         tenant_id: str | None,
+        max_attempts: int,
+        limit: int,
+    ) -> list[NotificationEmailDelivery]:
+        if tenant_id:
+            return self._list_pending_notification_email_deliveries_for_tenant(
+                tenant_id=tenant_id,
+                max_attempts=max_attempts,
+                limit=limit,
+            )
+
+        items: list[NotificationEmailDelivery] = []
+        for item in self.list_notification_email_delivery_tenants(max_attempts=max_attempts):
+            items.extend(
+                self._list_pending_notification_email_deliveries_for_tenant(
+                    tenant_id=item,
+                    max_attempts=max_attempts,
+                    limit=limit,
+                )
+            )
+        items.sort(key=lambda item: (item.created_at, item.delivery_id))
+        return items[:limit]
+
+    def _list_pending_notification_email_deliveries_for_tenant(
+        self,
+        *,
+        tenant_id: str,
         max_attempts: int,
         limit: int,
     ) -> list[NotificationEmailDelivery]:
@@ -450,19 +554,16 @@ class Database:
               )
         """
         params: tuple[object, ...]
-        if tenant_id:
-            sql += """
-              AND d.tenant_id = %s
-            """
-            params = (max_attempts, tenant_id, limit)
-        else:
-            params = (max_attempts, limit)
+        sql += """
+          AND d.tenant_id = %s
+        """
+        params = (max_attempts, tenant_id, limit)
         sql += """
             ORDER BY d.created_at ASC, d.delivery_id ASC
             LIMIT %s
         """
 
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+        with self._tenant_transaction(tenant_id) as conn:
             rows = conn.execute(sql, params).fetchall()
         return [self._row_to_notification_email_delivery(row) for row in rows]
 
@@ -674,6 +775,72 @@ class Database:
         as_of_date: date,
         days: int,
     ) -> ReminderScanResult:
+        if tenant_id:
+            return self._create_due_lease_reminder_notifications_for_tenant(
+                tenant_id=tenant_id,
+                as_of_date=as_of_date,
+                days=days,
+            )
+
+        results = [
+            self._create_due_lease_reminder_notifications_for_tenant(
+                tenant_id=item,
+                as_of_date=as_of_date,
+                days=days,
+            )
+            for item in self.list_due_lease_reminder_tenants(
+                as_of_date=as_of_date,
+                days=days,
+            )
+        ]
+        return ReminderScanResult(
+            tenant_id=None,
+            as_of_date=as_of_date,
+            days=days,
+            tenant_count=len(results),
+            candidate_count=sum(item.candidate_count for item in results),
+            created_count=sum(item.created_count for item in results),
+            duplicate_count=sum(item.duplicate_count for item in results),
+        )
+
+    def list_due_lease_reminder_tenants(self, *, as_of_date: date, days: int) -> list[str]:
+        range_end = as_of_date + timedelta(days=days)
+        sql = """
+            SELECT
+                tenant_id,
+                rent_due_day_of_month,
+                start_date,
+                end_date
+            FROM leases
+            WHERE rent_due_day_of_month IS NOT NULL
+              AND start_date <= %s
+              AND end_date >= %s
+            ORDER BY tenant_id
+        """
+        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
+            rows = conn.execute(sql, (range_end, as_of_date)).fetchall()
+
+        tenant_ids: set[str] = set()
+        for row in rows:
+            due_date = _next_due_date(
+                as_of_date=as_of_date,
+                due_day_of_month=int(row["rent_due_day_of_month"]),
+            )
+            if due_date > range_end:
+                continue
+            if due_date < row["start_date"] or due_date > row["end_date"]:
+                continue
+            tenant_ids.add(row["tenant_id"])
+
+        return sorted(tenant_ids)
+
+    def _create_due_lease_reminder_notifications_for_tenant(
+        self,
+        *,
+        tenant_id: str,
+        as_of_date: date,
+        days: int,
+    ) -> ReminderScanResult:
         candidates = self._list_due_lease_reminders(
             tenant_id=tenant_id,
             as_of_date=as_of_date,
@@ -694,28 +861,27 @@ class Database:
         """
 
         created_count = 0
-        with psycopg.connect(self._dsn, row_factory=dict_row) as conn:
-            with conn.transaction():
-                for candidate in candidates:
-                    created_row = conn.execute(
-                        insert_sql,
-                        (
-                            candidate.tenant_id,
-                            candidate.lease_id,
-                            "rent_due_soon",
-                            "Rent due soon",
-                            _rent_due_soon_message(candidate.days_until_due),
-                            candidate.due_date,
-                        ),
-                    ).fetchone()
-                    if created_row:
-                        created_count += 1
+        with self._tenant_transaction(tenant_id) as conn:
+            for candidate in candidates:
+                created_row = conn.execute(
+                    insert_sql,
+                    (
+                        candidate.tenant_id,
+                        candidate.lease_id,
+                        "rent_due_soon",
+                        "Rent due soon",
+                        _rent_due_soon_message(candidate.days_until_due),
+                        candidate.due_date,
+                    ),
+                ).fetchone()
+                if created_row:
+                    created_count += 1
 
         return ReminderScanResult(
             tenant_id=tenant_id,
             as_of_date=as_of_date,
             days=days,
-            tenant_count=1 if tenant_id else len({item.tenant_id for item in candidates}),
+            tenant_count=1,
             candidate_count=len(candidates),
             created_count=created_count,
             duplicate_count=len(candidates) - created_count,

--- a/backend/tests/test_db_tenant_context.py
+++ b/backend/tests/test_db_tenant_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, date, datetime
 from typing import Any
 from uuid import UUID
 
@@ -7,6 +8,11 @@ import pytest
 
 from app import db as db_module
 from app.db import Database
+from app.models import (
+    NotificationEmailDelivery,
+    NotificationEmailDeliveryPreparationResult,
+    ReminderScanResult,
+)
 
 
 class _Settings:
@@ -138,3 +144,170 @@ def test_create_property_sets_tenant_context_before_domain_sql(
     assert execute_events[0][1] == ("tenant-auth",)
     assert "INSERT INTO properties" in execute_events[1][0]
     assert execute_events[1][1] == ("tenant-auth", "Tenant HQ", "Tenant Street")
+
+
+class _RlsSafeJobDatabase(Database):
+    def __init__(self) -> None:
+        super().__init__(_Settings())
+        self.calls: list[tuple[str, object]] = []
+
+    def list_due_lease_reminder_tenants(self, *, as_of_date: date, days: int) -> list[str]:
+        self.calls.append(("discover_reminder_tenants", (as_of_date, days)))
+        return ["tenant-a", "tenant-b"]
+
+    def _create_due_lease_reminder_notifications_for_tenant(
+        self,
+        *,
+        tenant_id: str,
+        as_of_date: date,
+        days: int,
+    ) -> ReminderScanResult:
+        self.calls.append(("scan_tenant", tenant_id))
+        created_count = 2 if tenant_id == "tenant-a" else 1
+        return ReminderScanResult(
+            tenant_id=tenant_id,
+            as_of_date=as_of_date,
+            days=days,
+            tenant_count=1,
+            candidate_count=created_count + 1,
+            created_count=created_count,
+            duplicate_count=1,
+        )
+
+    def list_notification_email_delivery_tenants(
+        self,
+        *,
+        max_attempts: int | None = None,
+    ) -> list[str]:
+        self.calls.append(("discover_delivery_tenants", max_attempts))
+        return ["tenant-a", "tenant-b"]
+
+    def _create_missing_notification_email_deliveries_for_tenant(
+        self,
+        *,
+        tenant_id: str,
+    ) -> NotificationEmailDeliveryPreparationResult:
+        self.calls.append(("prepare_tenant", tenant_id))
+        created_count = 2 if tenant_id == "tenant-a" else 1
+        return NotificationEmailDeliveryPreparationResult(
+            tenant_id=tenant_id,
+            candidate_count=created_count,
+            created_count=created_count,
+            duplicate_count=0,
+            suppressed_contact_count=1,
+        )
+
+    def _list_pending_notification_email_deliveries_for_tenant(
+        self,
+        *,
+        tenant_id: str,
+        max_attempts: int,
+        limit: int,
+    ) -> list[NotificationEmailDelivery]:
+        self.calls.append(("list_pending_tenant", (tenant_id, max_attempts, limit)))
+        if tenant_id == "tenant-a":
+            return [_delivery("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", tenant_id, 2)]
+        return [_delivery("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", tenant_id, 1)]
+
+
+def _delivery(delivery_id: str, tenant_id: str, day: int) -> NotificationEmailDelivery:
+    return NotificationEmailDelivery(
+        delivery_id=UUID(delivery_id),
+        tenant_id=tenant_id,
+        notification_id=UUID("11111111-1111-4111-8111-111111111111"),
+        contact_id=UUID("22222222-2222-4222-8222-222222222222"),
+        event_correlation_token=UUID("33333333-3333-4333-8333-333333333333"),
+        recipient_email="recipient@example.test",
+        subject="Rent due soon",
+        body="Rent is due soon.",
+        due_date=date(2026, 5, day),
+        status="pending",
+        attempt_count=0,
+        last_attempt_at=None,
+        sent_at=None,
+        last_error_code=None,
+        created_at=datetime(2026, 5, day, tzinfo=UTC),
+        updated_at=datetime(2026, 5, day, tzinfo=UTC),
+    )
+
+
+def test_unscoped_reminder_scan_discovers_and_processes_tenants_one_by_one() -> None:
+    database = _RlsSafeJobDatabase()
+
+    result = database.create_due_lease_reminder_notifications(
+        tenant_id=None,
+        as_of_date=date(2026, 5, 13),
+        days=7,
+    )
+
+    assert database.calls == [
+        ("discover_reminder_tenants", (date(2026, 5, 13), 7)),
+        ("scan_tenant", "tenant-a"),
+        ("scan_tenant", "tenant-b"),
+    ]
+    assert result.tenant_id is None
+    assert result.tenant_count == 2
+    assert result.candidate_count == 5
+    assert result.created_count == 3
+    assert result.duplicate_count == 2
+
+
+def test_explicit_reminder_scan_does_not_discover_tenants() -> None:
+    database = _RlsSafeJobDatabase()
+
+    result = database.create_due_lease_reminder_notifications(
+        tenant_id="tenant-a",
+        as_of_date=date(2026, 5, 13),
+        days=7,
+    )
+
+    assert database.calls == [("scan_tenant", "tenant-a")]
+    assert result.tenant_id == "tenant-a"
+    assert result.tenant_count == 1
+
+
+def test_unscoped_delivery_preparation_discovers_and_processes_tenants_one_by_one() -> None:
+    database = _RlsSafeJobDatabase()
+
+    result = database.create_missing_notification_email_deliveries(tenant_id=None)
+
+    assert database.calls == [
+        ("discover_delivery_tenants", None),
+        ("prepare_tenant", "tenant-a"),
+        ("prepare_tenant", "tenant-b"),
+    ]
+    assert result.tenant_id is None
+    assert result.candidate_count == 3
+    assert result.created_count == 3
+    assert result.duplicate_count == 0
+    assert result.suppressed_contact_count == 2
+
+
+def test_unscoped_pending_delivery_discovers_tenants_and_applies_global_limit() -> None:
+    database = _RlsSafeJobDatabase()
+
+    pending = database.list_pending_notification_email_deliveries(
+        tenant_id=None,
+        max_attempts=3,
+        limit=1,
+    )
+
+    assert database.calls == [
+        ("discover_delivery_tenants", 3),
+        ("list_pending_tenant", ("tenant-a", 3, 1)),
+        ("list_pending_tenant", ("tenant-b", 3, 1)),
+    ]
+    assert [item.tenant_id for item in pending] == ["tenant-b"]
+
+
+def test_explicit_pending_delivery_does_not_discover_tenants() -> None:
+    database = _RlsSafeJobDatabase()
+
+    pending = database.list_pending_notification_email_deliveries(
+        tenant_id="tenant-a",
+        max_attempts=3,
+        limit=10,
+    )
+
+    assert database.calls == [("list_pending_tenant", ("tenant-a", 3, 10))]
+    assert [item.tenant_id for item in pending] == ["tenant-a"]

--- a/docs/postgresql-rls-tenant-isolation-hardening.md
+++ b/docs/postgresql-rls-tenant-isolation-hardening.md
@@ -72,17 +72,22 @@ existing application-level tenant predicates remain mandatory.
 
 ## Internal Job Design
 
-Current internal reminder and email delivery jobs can operate across tenants
-when invoked without a tenant ID. RLS enforcement would block or complicate
-those unscoped reads unless the job path is redesigned.
+Internal reminder and email delivery jobs may still be invoked without an
+explicit tenant ID. The backend now discovers candidate tenant IDs first and
+then processes each tenant through the same transaction-local tenant context
+used by normal tenant-scoped methods.
 
-Preferred future direction:
+Current internal direction:
 
 - discover candidate tenants through an explicit safe internal mechanism.
 - process each tenant inside its own transaction.
 - set `SET LOCAL app.tenant_id` before tenant-owned reads and writes.
 - keep internal event payloads sanitized and avoid browser-triggered scan or
   delivery actions.
+
+The discovery step still performs limited distinct-tenant lookup before RLS
+policies exist. If future RLS policies also cover discovery inputs, this may
+need a separate tenant registry or another explicitly justified discovery path.
 
 Any privileged bypass path must be explicitly justified, tested, and kept out of
 browser/API request handling.
@@ -94,6 +99,8 @@ Recommended implementation order:
 1. Add a backend transaction helper that sets tenant context with `SET LOCAL`.
    Completed for normal tenant-scoped `Database` methods.
 2. Adapt internal reminder and delivery jobs so they can run tenant by tenant.
+   Completed for the existing reminder scan and email delivery preparation/list
+   paths.
 3. Add RLS policies for one low-risk table first, then expand table by table.
 4. Add regression tests that intentionally omit application tenant predicates
    and verify RLS blocks cross-tenant access.
@@ -106,7 +113,8 @@ application layer must still enforce tenant filters.
 
 - Pooled or reused DB sessions can leak tenant context if session-level settings
   are used. Use transaction-local `SET LOCAL` only.
-- Internal all-tenant jobs need redesign before broad RLS enforcement.
+- Tenant discovery still needs review when policies are added to the tables it
+  reads.
 - Missing tenant context should fail closed. Policies should not silently allow
   access when `app.tenant_id` is unset.
 - Migration/admin roles must be separated from normal application runtime
@@ -117,6 +125,6 @@ application layer must still enforce tenant filters.
 ## Follow-Up Tickets
 
 - Add RLS tenant context transaction helper.
-- Add PostgreSQL RLS policies for tenant-owned domain tables.
 - Adapt internal reminder and delivery jobs for RLS.
+- Add PostgreSQL RLS policies for tenant-owned domain tables.
 - Add RLS regression and migration smoke tests.


### PR DESCRIPTION
## What changed

Adapts internal reminder and notification email delivery jobs for the RLS hardening path.

- Added tenant discovery helpers for due reminder scans and notification email delivery.
- Changed unscoped reminder scans to discover candidate tenants and process each tenant separately.
- Changed unscoped email delivery preparation/listing to process tenants separately.
- Kept tenant-explicit internal invocations compatible.
- Added unit coverage for tenant discovery orchestration and global pending delivery limiting.
- Updated the PostgreSQL RLS hardening plan documentation.

## Assumptions

- Tenant discovery is allowed before RLS policies are enabled.
- Existing `tenant_id=None` internal semantics remain: process all eligible tenants, but now by tenant iteration.
- Discovery returns tenant IDs only and does not expose recipient, contact, notification, message, or provider payload data.
- RLS policies and discovery-under-RLS design remain separate follow-up work.

## Security validation

- Tenant-owned processing now happens via tenant-scoped helper paths instead of one cross-tenant processing transaction.
- Browser/API routes were not changed.
- Existing application-level tenant predicates remain in place.
- No raw SES payloads, recipient data, tenant IDs in metrics, credentials, or provider responses were added.

## Cost validation

No Terraform, AWS resources, scheduler, NAT Gateway, public RDS, or SES behavior changes.

## Validation

- `cd backend && python -m pytest -q tests/test_db_tenant_context.py tests/test_reminder_scans_route.py tests/test_notification_email_delivery_route.py`
- `cd backend && python -m pytest -q`
- `cd backend && python -m ruff format --check src tests migrations`
- `cd backend && python -m ruff check src tests migrations`
- `git diff --check`

## Remaining risks / TODOs

- Run DB integration tests with `LEASEFLOW_RUN_DB_INTEGRATION=1` in the WSL PostgreSQL environment.
- Tenant discovery may need a dedicated tenant registry or privileged design once RLS policies cover the discovery source tables.
- #235 remains responsible for actual PostgreSQL RLS policies.
