### PR TITLE
infra: add configurable RDS protection baseline

### DIFF
--- a/docs/rds-production-protection-baseline.md
+++ b/docs/rds-production-protection-baseline.md
@@ -5,8 +5,9 @@
 Define the RDS protection posture LeaseFlow would need before storing real
 tenant data or running a production-like environment.
 
-This is a design baseline, not an implementation ticket. The current dev
-Terraform behavior remains cost-controlled.
+The shared RDS Terraform module now exposes production-like protection inputs.
+The current dev environment still defaults to a cost-controlled, destroyable
+posture.
 
 Not included in this baseline:
 
@@ -18,7 +19,7 @@ Not included in this baseline:
 
 ## Current Dev Posture
 
-Current Terraform-managed dev RDS settings:
+Default Terraform-managed dev RDS settings:
 
 | Control | Current dev value | Reason |
 | --- | --- | --- |
@@ -31,6 +32,33 @@ Current Terraform-managed dev RDS settings:
 
 This posture is acceptable for short-lived portfolio/dev validation. It is not
 production-ready database protection.
+
+## Implemented Module Controls
+
+The `rds_postgres` module accepts these protection inputs:
+
+| Input | Dev default | Production-like expectation |
+| --- | --- | --- |
+| `backup_retention_period` | `1` | At least `7` when deletion protection is enabled. |
+| `deletion_protection` | `false` | `true` for production-like data. |
+| `skip_final_snapshot` | `true` | `false` when deletion protection is enabled. |
+| `final_snapshot_identifier` | `null` | Required when final snapshots are enabled. |
+
+The module keeps `publicly_accessible = false`, `storage_encrypted = true`, and
+`multi_az = false` for the current low-cost dev shape.
+
+The module validates these combinations:
+
+- `backup_retention_period` must be at least `7` when
+  `deletion_protection = true`.
+- `deletion_protection = true` requires `skip_final_snapshot = false`.
+- `skip_final_snapshot = false` requires a non-empty
+  `final_snapshot_identifier`.
+
+`lifecycle.prevent_destroy` is intentionally not variable-controlled in the
+shared dev module. Terraform lifecycle meta-arguments require literal values, so
+a future dedicated production environment can hardcode `prevent_destroy` without
+breaking dev destroy workflows.
 
 ## Production-Like Baseline
 

--- a/docs/runbooks/dev-rds-restore-validation.md
+++ b/docs/runbooks/dev-rds-restore-validation.md
@@ -15,6 +15,8 @@ This is an operator-run dev procedure, not an automated disaster recovery platfo
 - Public access: disabled.
 - Multi-AZ: disabled for dev cost control.
 - Final snapshot on destroy: disabled for dev cost control.
+- Production-like protection variables exist, but this runbook assumes the
+  default destroyable dev posture unless stated otherwise.
 
 ## Guardrails
 
@@ -54,7 +56,12 @@ Backup retention review triggers:
 
 Current decision:
 
-- Keep dev `backup_retention_period = 1` for cost control.
+- Keep dev `db_backup_retention_period = 1` for cost control.
+- Keep dev `db_deletion_protection = false` and
+  `db_skip_final_snapshot = true` unless production-like validation is
+  explicitly needed.
+- If `db_skip_final_snapshot = false`, provide a unique
+  `db_final_snapshot_identifier` before planning any destroy.
 - Do not add Multi-AZ, cross-region replication, AWS Backup, or production DR
   automation in this dev runbook.
 - Increase retention only when the recoverability benefit is explicitly accepted

--- a/infra/README.md
+++ b/infra/README.md
@@ -393,7 +393,6 @@ CI runs Terraform checks without AWS credentials.
 - `infra/environments/dev` runs `terraform init -backend=false` and `terraform validate`.
 - Modules with `.tftest.hcl` coverage run `terraform init -backend=false` and `terraform test`.
 - Module tests use mocked providers and do not create AWS resources.
-- `modules/rds_postgres` is excluded until it has `.tftest.hcl` coverage.
 
 ## Dev cost expectation
 
@@ -411,6 +410,25 @@ CI runs Terraform checks without AWS credentials.
 - If the SES SMTP VPC endpoint is enabled for smoke testing, review after the
   test whether it should be disabled again to avoid idle endpoint cost.
 
+## RDS protection controls
+
+- Dev remains cost-aware and destroyable by default:
+  - `db_backup_retention_period = 1`
+  - `db_deletion_protection = false`
+  - `db_skip_final_snapshot = true`
+  - `db_final_snapshot_identifier = null`
+- Production-like validation can opt into longer automated backups, deletion
+  protection, and required final snapshots through the dev Terraform variables.
+- If `db_skip_final_snapshot = false`, set a unique
+  `db_final_snapshot_identifier` before planning destroy. Reusing a static final
+  snapshot name can collide across repeated destroy attempts.
+- If `db_deletion_protection = true`, the module requires at least seven days of
+  backup retention and `db_skip_final_snapshot = false`.
+- `lifecycle.prevent_destroy` is intentionally not variable-controlled in the
+  shared module. Terraform lifecycle meta-arguments require literal values, so a
+  future dedicated production environment should hardcode `prevent_destroy` if
+  it needs that safeguard.
+
 ## Apply and destroy rule
 
 - Use `terraform apply` only when you are ready to test the deployed AWS environment.
@@ -422,7 +440,11 @@ CI runs Terraform checks without AWS credentials.
 - Use the same working copy and Terraform backend config that created the resources.
 - Use the same AWS profile and region that were used during `apply`.
 - Do not delete Terraform state before destroying the environment.
-- The current dev RDS config uses `skip_final_snapshot = true`, so destroying the stack will permanently delete the dev database contents.
+- The default dev RDS config uses `db_skip_final_snapshot = true`, so destroying
+  the stack will permanently delete the dev database contents.
+- If production-like RDS protection variables are enabled, disable deletion
+  protection intentionally and provide/review the final snapshot identifier
+  before applying a destroy plan.
 - If you need to keep portfolio/demo tenant data, run `scripts/dev/export-tenant-data.sh` before destroy and store the ignored export file locally.
 
 ```bash

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -68,16 +68,20 @@ resource "aws_ssm_parameter" "db_password" {
 module "rds_postgres" {
   source = "../../modules/rds_postgres"
 
-  name_prefix           = local.name_prefix
-  private_subnet_ids    = module.network.private_subnet_ids
-  rds_security_group_id = module.network.rds_security_group_id
-  db_name               = var.db_name
-  db_username           = var.db_username
-  db_password           = random_password.db_master.result
-  instance_class        = var.db_instance_class
-  allocated_storage     = var.db_allocated_storage
-  engine_version        = var.db_engine_version
-  tags                  = local.common_tags
+  name_prefix               = local.name_prefix
+  private_subnet_ids        = module.network.private_subnet_ids
+  rds_security_group_id     = module.network.rds_security_group_id
+  db_name                   = var.db_name
+  db_username               = var.db_username
+  db_password               = random_password.db_master.result
+  instance_class            = var.db_instance_class
+  allocated_storage         = var.db_allocated_storage
+  engine_version            = var.db_engine_version
+  backup_retention_period   = var.db_backup_retention_period
+  deletion_protection       = var.db_deletion_protection
+  skip_final_snapshot       = var.db_skip_final_snapshot
+  final_snapshot_identifier = var.db_final_snapshot_identifier
+  tags                      = local.common_tags
 }
 
 module "cognito" {

--- a/infra/environments/dev/outputs.tf
+++ b/infra/environments/dev/outputs.tf
@@ -48,6 +48,21 @@ output "rds_endpoint" {
   value       = module.rds_postgres.endpoint
 }
 
+output "rds_backup_retention_period" {
+  description = "Configured RDS automated backup retention period in days."
+  value       = module.rds_postgres.backup_retention_period
+}
+
+output "rds_deletion_protection" {
+  description = "Whether RDS deletion protection is enabled."
+  value       = module.rds_postgres.deletion_protection
+}
+
+output "rds_skip_final_snapshot" {
+  description = "Whether RDS final snapshot creation is skipped on destroy."
+  value       = module.rds_postgres.skip_final_snapshot
+}
+
 output "reminder_scan_schedule_name" {
   description = "Reminder scan schedule name."
   value       = module.reminder_scheduler.schedule_name

--- a/infra/environments/dev/terraform.tfvars.example
+++ b/infra/environments/dev/terraform.tfvars.example
@@ -9,6 +9,13 @@ db_username       = "leaseflow_admin"
 db_instance_class = "db.t3.micro"
 db_engine_version = "15.17"
 
+# Dev defaults are cost-aware and destroyable. Production-like validation can
+# opt into longer retention, deletion protection, and required final snapshots.
+db_backup_retention_period   = 1
+db_deletion_protection       = false
+db_skip_final_snapshot       = true
+db_final_snapshot_identifier = null
+
 # Terraform generates the DB password and stores it in SSM SecureString at this path.
 lambda_package_file   = "../../../dist/leaseflow-backend.zip"
 db_password_ssm_param = "/leaseflow/dev/db/password"

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -58,6 +58,31 @@ variable "db_engine_version" {
   default     = "15.17"
 }
 
+variable "db_backup_retention_period" {
+  type        = number
+  description = "RDS automated backup retention period in days."
+  default     = 1
+}
+
+variable "db_deletion_protection" {
+  type        = bool
+  description = "Whether RDS deletion protection is enabled."
+  default     = false
+}
+
+variable "db_skip_final_snapshot" {
+  type        = bool
+  description = "Whether to skip the final DB snapshot when destroying the RDS instance."
+  default     = true
+}
+
+variable "db_final_snapshot_identifier" {
+  type        = string
+  description = "Final DB snapshot identifier required when db_skip_final_snapshot is false."
+  default     = null
+  nullable    = true
+}
+
 variable "lambda_package_file" {
   type        = string
   description = "Path to Lambda deployment zip."

--- a/infra/modules/rds_postgres/.terraform.lock.hcl
+++ b/infra/modules/rds_postgres/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.44.0"
+  hashes = [
+    "h1:lJvGaC4YNXk3TIdrd5GCIyV0gxU1WigQIao8rmcpplc=",
+    "zh:0462747d28f6dcd7b1b723bea9da1600526b7cdcf929ed4be54352d74b0746e6",
+    "zh:0c9b7e7b04050360f609ff5700d8a76227fb4ea84dac92b844d82a2013706705",
+    "zh:2877a6854edf237f9d6c66dc928294cbbcf29d3f52577fb8f232d0cfd11d5c0d",
+    "zh:3347b82e222bbfad326b79c408e53a9252b80c6c762f4dd4f4617583394f0a4e",
+    "zh:33997dbe611b5abf49c87a31f29d8f797c97421f67b71fec8aa688799511b758",
+    "zh:5d5c37375c5e776e6e8f95fb8cbd8009258618b9f51c55551a18adc09ef5814a",
+    "zh:67d6bd61c52ca5f4c37c96a76f6820c9f1902e4b83f89faddf9fd7f17ba0b160",
+    "zh:739588639fa30db7084d6939c2eb9b4dd2d7f58dbb5d5b3b2c4bda2a35dcf521",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a953797142df4245bd8f456b9e78690f501a0fff2f58552db4eb2da409cd99e9",
+    "zh:aeb8d616dd34a9f1c5048ed4cdd6d7692db93cd33a468872618d4cd38c4784aa",
+    "zh:dc8420556aca50658247b097de6734259fc3a6012ff1cf96612fca10b3982f9d",
+    "zh:f9083d6d9fb9cbdcd91e38c92f96e67223ecc7ce6d0986bd5eb8e6d52e9aa02b",
+    "zh:f9418aa1e4d29f9026aa6f521e97d085e000902ea929debbbef61135185e3ad4",
+    "zh:fb2494a6c92118055cfb2c114a4fe5c750946a1b0d6be6bf02ab3e37a091fb8b",
+  ]
+}

--- a/infra/modules/rds_postgres/main.tf
+++ b/infra/modules/rds_postgres/main.tf
@@ -25,10 +25,33 @@ resource "aws_db_instance" "this" {
   publicly_accessible    = false
   multi_az               = false
 
-  backup_retention_period = 1
-  skip_final_snapshot     = true
-  deletion_protection     = false
-  apply_immediately       = true
+  backup_retention_period   = var.backup_retention_period
+  skip_final_snapshot       = var.skip_final_snapshot
+  final_snapshot_identifier = var.final_snapshot_identifier
+  deletion_protection       = var.deletion_protection
+  apply_immediately         = true
+
+  lifecycle {
+    precondition {
+      condition     = var.backup_retention_period >= 1
+      error_message = "backup_retention_period must be at least 1."
+    }
+
+    precondition {
+      condition     = !var.deletion_protection || var.backup_retention_period >= 7
+      error_message = "deletion_protection requires backup_retention_period to be at least 7."
+    }
+
+    precondition {
+      condition     = var.skip_final_snapshot || try(length(trimspace(var.final_snapshot_identifier)), 0) > 0
+      error_message = "final_snapshot_identifier is required when skip_final_snapshot is false."
+    }
+
+    precondition {
+      condition     = !var.deletion_protection || !var.skip_final_snapshot
+      error_message = "deletion_protection requires skip_final_snapshot to be false."
+    }
+  }
 
   tags = merge(var.tags, { Name = "${var.name_prefix}-postgres" })
 }

--- a/infra/modules/rds_postgres/outputs.tf
+++ b/infra/modules/rds_postgres/outputs.tf
@@ -12,3 +12,18 @@ output "db_name" {
   value       = aws_db_instance.this.db_name
   description = "Database name."
 }
+
+output "backup_retention_period" {
+  value       = aws_db_instance.this.backup_retention_period
+  description = "Configured RDS automated backup retention period in days."
+}
+
+output "deletion_protection" {
+  value       = aws_db_instance.this.deletion_protection
+  description = "Whether RDS deletion protection is enabled."
+}
+
+output "skip_final_snapshot" {
+  value       = aws_db_instance.this.skip_final_snapshot
+  description = "Whether RDS final snapshot creation is skipped on destroy."
+}

--- a/infra/modules/rds_postgres/tests/defaults.tftest.hcl
+++ b/infra/modules/rds_postgres/tests/defaults.tftest.hcl
@@ -1,0 +1,133 @@
+mock_provider "aws" {}
+
+variables {
+  name_prefix           = "leaseflow-test"
+  private_subnet_ids    = ["subnet-123", "subnet-456"]
+  rds_security_group_id = "sg-123"
+  db_name               = "leaseflow"
+  db_username           = "leaseflow_admin"
+  db_password           = "not-a-real-password"
+}
+
+run "defaults_preserve_dev_posture" {
+  command = plan
+
+  assert {
+    condition     = aws_db_instance.this.backup_retention_period == 1
+    error_message = "Default backup retention should remain 1 day for cost-aware dev."
+  }
+
+  assert {
+    condition     = aws_db_instance.this.deletion_protection == false
+    error_message = "Default deletion protection should remain disabled for dev destroy."
+  }
+
+  assert {
+    condition     = aws_db_instance.this.skip_final_snapshot == true
+    error_message = "Default final snapshot should remain skipped for dev destroy."
+  }
+
+  assert {
+    condition     = aws_db_instance.this.final_snapshot_identifier == null
+    error_message = "Default final snapshot identifier should be unset."
+  }
+
+  assert {
+    condition     = aws_db_instance.this.publicly_accessible == false
+    error_message = "RDS must remain private."
+  }
+
+  assert {
+    condition     = aws_db_instance.this.storage_encrypted == true
+    error_message = "RDS storage must remain encrypted."
+  }
+
+  assert {
+    condition     = aws_db_instance.this.multi_az == false
+    error_message = "Multi-AZ remains out of scope for this baseline."
+  }
+}
+
+run "production_like_protection_inputs" {
+  command = plan
+
+  variables {
+    backup_retention_period   = 7
+    deletion_protection       = true
+    skip_final_snapshot       = false
+    final_snapshot_identifier = "leaseflow-prod-final-20260513"
+  }
+
+  assert {
+    condition     = aws_db_instance.this.backup_retention_period == 7
+    error_message = "Production-like backup retention should be configurable to 7 days."
+  }
+
+  assert {
+    condition     = aws_db_instance.this.deletion_protection == true
+    error_message = "Production-like deletion protection should be configurable."
+  }
+
+  assert {
+    condition     = aws_db_instance.this.skip_final_snapshot == false
+    error_message = "Production-like destroy should require a final snapshot."
+  }
+
+  assert {
+    condition     = aws_db_instance.this.final_snapshot_identifier == "leaseflow-prod-final-20260513"
+    error_message = "Production-like final snapshot identifier should be configurable."
+  }
+}
+
+run "deletion_protection_requires_final_snapshot" {
+  command = plan
+
+  variables {
+    backup_retention_period = 7
+    deletion_protection     = true
+    skip_final_snapshot     = true
+  }
+
+  expect_failures = [
+    aws_db_instance.this,
+  ]
+}
+
+run "final_snapshot_requires_identifier" {
+  command = plan
+
+  variables {
+    skip_final_snapshot = false
+  }
+
+  expect_failures = [
+    aws_db_instance.this,
+  ]
+}
+
+run "deletion_protection_requires_seven_day_retention" {
+  command = plan
+
+  variables {
+    backup_retention_period   = 1
+    deletion_protection       = true
+    skip_final_snapshot       = false
+    final_snapshot_identifier = "leaseflow-prod-final-20260513"
+  }
+
+  expect_failures = [
+    aws_db_instance.this,
+  ]
+}
+
+run "backup_retention_must_be_at_least_one" {
+  command = plan
+
+  variables {
+    backup_retention_period = 0
+  }
+
+  expect_failures = [
+    aws_db_instance.this,
+  ]
+}

--- a/infra/modules/rds_postgres/variables.tf
+++ b/infra/modules/rds_postgres/variables.tf
@@ -47,6 +47,31 @@ variable "engine_version" {
   default     = "15.17"
 }
 
+variable "backup_retention_period" {
+  type        = number
+  description = "Automated backup retention period in days."
+  default     = 1
+}
+
+variable "deletion_protection" {
+  type        = bool
+  description = "Whether RDS deletion protection is enabled."
+  default     = false
+}
+
+variable "skip_final_snapshot" {
+  type        = bool
+  description = "Whether to skip the final DB snapshot when destroying the instance."
+  default     = true
+}
+
+variable "final_snapshot_identifier" {
+  type        = string
+  description = "Final DB snapshot identifier required when skip_final_snapshot is false."
+  default     = null
+  nullable    = true
+}
+
 variable "tags" {
   type        = map(string)
   description = "Common tags."


### PR DESCRIPTION
## What changed and why

Adds configurable production-like RDS protection controls to the shared `rds_postgres` Terraform module while preserving current dev defaults.

Dev remains cost-aware and destroyable by default:
- backup retention: 1 day
- deletion protection: disabled
- final snapshot on destroy: skipped

Production-like users can opt into longer retention, deletion protection, and required final snapshots through Terraform variables.

## Assumptions

- This repository still has only a dev Terraform environment.
- `lifecycle.prevent_destroy` is intentionally not variable-controlled because Terraform lifecycle meta-arguments require literal values.
- A future production environment can hardcode `prevent_destroy` if needed.

## Security validation

- RDS remains private: `publicly_accessible = false`.
- Storage encryption remains enabled.
- No tenant data, DB endpoints, passwords, SSM values, or snapshot contents were added to docs/tests/outputs.
- Tenant isolation behavior is unchanged; this PR only changes Terraform RDS protection configuration.

## Cost validation

- No new AWS services are added.
- Dev defaults remain low-cost and destroyable.
- Longer backup retention and final snapshots are opt-in and documented as cost-affecting.

## Validation

- `terraform fmt -recursive infra`
- `cd infra/modules/rds_postgres && terraform init -backend=false && terraform test`
- `cd infra/environments/dev && terraform init -backend=false && terraform validate`
- `git diff --check`

## Remaining risks / TODOs

- No real AWS destroy/plan was run in this PR.
- Multi-AZ, AWS Backup, password rotation, and production RTO/RPO definition remain separate future work.
