### PR TITLE
feat(infra,backend): replace SSM-backed RDS password with Secrets Manager

### DIFF
--- a/backend/src/app/config.py
+++ b/backend/src/app/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from dataclasses import dataclass
 from functools import lru_cache
@@ -21,7 +22,7 @@ class Settings:
     db_name: str
     db_user: str
     db_password: str | None
-    db_password_ssm_param: str | None
+    db_password_secret_arn: str | None
     notification_email_delivery_enabled: bool
     notification_email_sender: str
     notification_email_smtp_host: str
@@ -35,10 +36,14 @@ class Settings:
     def resolve_db_password(self) -> str:
         if self.db_password:
             return self.db_password
-        if not self.db_password_ssm_param:
-            raise ConfigError("Set DB_PASSWORD or DB_PASSWORD_SSM_PARAM.")
+        if not self.db_password_secret_arn:
+            raise ConfigError("Set DB_PASSWORD or DB_PASSWORD_SECRET_ARN.")
+        return self._resolve_secrets_manager_secret(self.db_password_secret_arn)
 
-        return self._resolve_ssm_parameter(self.db_password_ssm_param)
+    def _resolve_secrets_manager_secret(self, secret_arn: str) -> str:
+        client = boto3.client("secretsmanager", region_name=self.aws_region)
+        response = client.get_secret_value(SecretId=secret_arn)
+        return json.loads(response["SecretString"])["password"]
 
     def resolve_notification_email_smtp_credentials(self) -> tuple[str, str]:
         if (
@@ -61,10 +66,6 @@ class Settings:
                 self.notification_email_smtp_password_ssm_param,
             ),
         )
-
-    def _resolve_ssm_parameter(self, name: str) -> str:
-        ssm_client = boto3.client("ssm", region_name=self.aws_region)
-        return _resolve_ssm_parameter(ssm_client, name)
 
     def db_dsn(self) -> str:
         password = self.resolve_db_password()
@@ -123,7 +124,7 @@ def load_settings() -> Settings:
         db_name=_env("DB_NAME", required=True),
         db_user=_env("DB_USER", required=True),
         db_password=os.getenv("DB_PASSWORD"),
-        db_password_ssm_param=os.getenv("DB_PASSWORD_SSM_PARAM"),
+        db_password_secret_arn=os.getenv("DB_PASSWORD_SECRET_ARN"),
         notification_email_delivery_enabled=_env_bool(
             "NOTIFICATION_EMAIL_DELIVERY_ENABLED",
             False,

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -124,7 +124,10 @@ def test_load_settings_reads_secret_arn_password_configuration_from_environment(
         assert settings.db_name == "leaseflow"
         assert settings.db_user == "leaseflow_app"
         assert settings.db_password is None
-        assert settings.db_password_secret_arn == "arn:aws:secretsmanager:eu-west-1:123456789012:secret:rds-master"
+        assert (
+            settings.db_password_secret_arn
+            == "arn:aws:secretsmanager:eu-west-1:123456789012:secret:rds-master"
+        )
         assert settings.notification_email_delivery_enabled is False
         assert settings.notification_email_sender == ""
         assert settings.notification_email_smtp_host == "email-smtp.eu-west-1.amazonaws.com"

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -19,7 +19,9 @@ def _settings(**overrides: object) -> config.Settings:
         "db_name": "leaseflow",
         "db_user": "leaseflow_app",
         "db_password": "direct-password",
-        "db_password_secret_arn": "arn:aws:secretsmanager:eu-north-1:123456789012:secret:rds-master",
+        "db_password_secret_arn": (
+            "arn:aws:secretsmanager:eu-north-1:123456789012:secret:rds-master"
+        ),
         "notification_email_delivery_enabled": False,
         "notification_email_sender": "",
         "notification_email_smtp_host": "email-smtp.eu-north-1.amazonaws.com",

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -19,7 +19,7 @@ def _settings(**overrides: object) -> config.Settings:
         "db_name": "leaseflow",
         "db_user": "leaseflow_app",
         "db_password": "direct-password",
-        "db_password_ssm_param": "/leaseflow/dev/db/password",
+        "db_password_secret_arn": "arn:aws:secretsmanager:eu-north-1:123456789012:secret:rds-master",
         "notification_email_delivery_enabled": False,
         "notification_email_sender": "",
         "notification_email_smtp_host": "email-smtp.eu-north-1.amazonaws.com",
@@ -45,7 +45,7 @@ def _set_valid_load_settings_env(
         "DB_PORT": "6543",
         "DB_NAME": "leaseflow",
         "DB_USER": "leaseflow_app",
-        "DB_PASSWORD_SSM_PARAM": "/leaseflow/dev/db/password",
+        "DB_PASSWORD_SECRET_ARN": "arn:aws:secretsmanager:eu-west-1:123456789012:secret:rds-master",
     }
     for name, value in values.items():
         if name == missing:
@@ -77,34 +77,38 @@ def test_resolve_db_password_returns_direct_password_without_ssm(
     boto_client.assert_not_called()
 
 
-def test_resolve_db_password_loads_value_from_ssm(monkeypatch: pytest.MonkeyPatch) -> None:
-    ssm_client = Mock()
-    ssm_client.get_parameter.return_value = {"Parameter": {"Value": "ssm-password"}}
-    boto_client = Mock(return_value=ssm_client)
+def test_resolve_db_password_loads_value_from_secrets_manager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import json
+
+    secret_arn = "arn:aws:secretsmanager:eu-west-1:123456789012:secret:rds-master"
+    sm_client = Mock()
+    sm_client.get_secret_value.return_value = {
+        "SecretString": json.dumps({"password": "sm-password", "username": "admin"})
+    }
+    boto_client = Mock(return_value=sm_client)
     monkeypatch.setattr(config.boto3, "client", boto_client)
 
     settings = _settings(
         aws_region="eu-west-1",
         db_password=None,
-        db_password_ssm_param="/leaseflow/dev/db/password",
+        db_password_secret_arn=secret_arn,
     )
 
-    assert settings.resolve_db_password() == "ssm-password"
-    boto_client.assert_called_once_with("ssm", region_name="eu-west-1")
-    ssm_client.get_parameter.assert_called_once_with(
-        Name="/leaseflow/dev/db/password",
-        WithDecryption=True,
-    )
+    assert settings.resolve_db_password() == "sm-password"
+    boto_client.assert_called_once_with("secretsmanager", region_name="eu-west-1")
+    sm_client.get_secret_value.assert_called_once_with(SecretId=secret_arn)
 
 
 def test_resolve_db_password_raises_when_no_password_source_is_configured() -> None:
-    settings = _settings(db_password=None, db_password_ssm_param=None)
+    settings = _settings(db_password=None, db_password_secret_arn=None)
 
-    with pytest.raises(config.ConfigError, match="Set DB_PASSWORD or DB_PASSWORD_SSM_PARAM."):
+    with pytest.raises(config.ConfigError, match="Set DB_PASSWORD or DB_PASSWORD_SECRET_ARN."):
         settings.resolve_db_password()
 
 
-def test_load_settings_reads_ssm_password_configuration_from_environment(
+def test_load_settings_reads_secret_arn_password_configuration_from_environment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     with _fresh_load_settings_cache():
@@ -120,7 +124,7 @@ def test_load_settings_reads_ssm_password_configuration_from_environment(
         assert settings.db_name == "leaseflow"
         assert settings.db_user == "leaseflow_app"
         assert settings.db_password is None
-        assert settings.db_password_ssm_param == "/leaseflow/dev/db/password"
+        assert settings.db_password_secret_arn == "arn:aws:secretsmanager:eu-west-1:123456789012:secret:rds-master"
         assert settings.notification_email_delivery_enabled is False
         assert settings.notification_email_sender == ""
         assert settings.notification_email_smtp_host == "email-smtp.eu-west-1.amazonaws.com"

--- a/docs/iam-least-privilege-review.md
+++ b/docs/iam-least-privilege-review.md
@@ -31,19 +31,15 @@ chain redesign.
 |-----|---------|----------|-----------|------------|
 | `CloudWatchLogs` | `logs:CreateLogStream`, `logs:PutLogEvents` | `<log_group_arn>:*` | — | Well-scoped. Specific log group ARN, no wildcards. |
 | `VpcNetworkingForLambda` | `ec2:CreateNetworkInterface`, `ec2:DescribeNetworkInterfaces`, `ec2:DeleteNetworkInterface`, `ec2:AssignPrivateIpAddresses`, `ec2:UnassignPrivateIpAddresses` | `*` | — | **Broadest statement.** AWS requires `Resource: "*"` for `Describe*` and for ENI create/delete at launch time. See note below. |
-| `ReadDbPasswordParameter` | `ssm:GetParameter` | Specific parameter ARN | — | Well-scoped. Single named parameter. |
-| `DecryptDbPasswordParameter` | `kms:Decrypt` | Specific KMS key ARN | `kms:EncryptionContext:PARAMETER_ARN` equals parameter ARN | Well-scoped. Encryption context condition prevents key reuse for other parameters. |
+| `ReadDbPasswordSecret` | `secretsmanager:GetSecretValue` | Specific Secrets Manager secret ARN | — | Well-scoped. Single secret ARN (RDS master user secret). AWS-managed key; no explicit `kms:Decrypt` needed. |
 | `ReadNotificationEmailSmtpCredentialParameters` | `ssm:GetParameter` | Two specific parameter ARNs | — | Well-scoped. Only added when SMTP is configured (`length > 0`). |
 | `DecryptNotificationEmailSmtpCredentialParameters` | `kms:Decrypt` | Specific KMS key ARN | `ForAnyValue:StringEquals kms:EncryptionContext:PARAMETER_ARN` over both parameter ARNs | Well-scoped. Same KMS key; context conditions prevent decrypt of other parameters. |
 
 **Note on `VpcNetworkingForLambda` — required wildcard:**
-AWS Lambda ENI management requires `Resource: "*"` for `ec2:DescribeNetworkInterfaces`
-because the Lambda service creates the ENI before the ARN is known to the caller.
-`ec2:CreateNetworkInterface` also cannot be pre-scoped to a specific ENI ARN for the
-same reason. However, a `Condition` block using `ec2:SubnetID` and `ec2:VpcID` keys
-**can** be added to `CreateNetworkInterface` to limit creation to the specific subnets
-and VPC that Lambda uses. `DescribeNetworkInterfaces` does not support resource-level
-conditions; the wildcard is unavoidable. See narrowing opportunity #1 below.
+AWS Lambda ENI management requires `Resource: "*"` for all five actions. The Lambda
+service validates the execution role during `CreateFunction` without VPC/subnet context,
+so `ec2:Vpc`/`ec2:Subnet` conditions on `CreateNetworkInterface` would deny the role at
+creation time. See narrowing opportunity #1 below for the full investigation.
 
 ---
 

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -51,20 +51,6 @@ module "github_frontend_deploy_role" {
   tags                        = local.common_tags
 }
 
-resource "random_password" "db_master" {
-  length  = 32
-  special = false
-}
-
-resource "aws_ssm_parameter" "db_password" {
-  name        = var.db_password_ssm_param
-  description = "Runtime DB password for ${local.name_prefix}."
-  type        = "SecureString"
-  value       = random_password.db_master.result
-
-  tags = merge(local.common_tags, { Name = "${local.name_prefix}-db-password" })
-}
-
 module "rds_postgres" {
   source = "../../modules/rds_postgres"
 
@@ -73,7 +59,6 @@ module "rds_postgres" {
   rds_security_group_id     = module.network.rds_security_group_id
   db_name                   = var.db_name
   db_username               = var.db_username
-  db_password               = random_password.db_master.result
   instance_class            = var.db_instance_class
   allocated_storage         = var.db_allocated_storage
   engine_version            = var.db_engine_version
@@ -109,7 +94,7 @@ module "lambda_backend" {
   db_port                                    = module.rds_postgres.port
   db_name                                    = var.db_name
   db_user                                    = var.db_username
-  db_password_ssm_param                      = var.db_password_ssm_param
+  db_password_secret_arn                     = module.rds_postgres.master_user_secret_arn
   notification_email_delivery_enabled        = var.notification_email_delivery_enabled
   notification_email_sender                  = var.notification_email_sender
   notification_email_smtp_host               = var.notification_email_smtp_host
@@ -224,4 +209,12 @@ module "api_http" {
   cognito_user_pool_id        = module.cognito.user_pool_id
   cognito_user_pool_client_id = module.cognito.user_pool_client_id
   tags                        = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_rotation" "rds_master" {
+  secret_id = module.rds_postgres.master_user_secret_arn
+
+  rotation_rules {
+    automatically_after_days = 30
+  }
 }

--- a/infra/environments/dev/terraform.tfvars.example
+++ b/infra/environments/dev/terraform.tfvars.example
@@ -16,9 +16,7 @@ db_deletion_protection       = false
 db_skip_final_snapshot       = true
 db_final_snapshot_identifier = null
 
-# Terraform generates the DB password and stores it in SSM SecureString at this path.
-lambda_package_file   = "../../../dist/leaseflow-backend.zip"
-db_password_ssm_param = "/leaseflow/dev/db/password"
+lambda_package_file = "../../../dist/leaseflow-backend.zip"
 
 # Required. Must be globally unique within Cognito managed domains.
 cognito_hosted_ui_domain_prefix = "replace-with-a-unique-dev-prefix"

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -133,12 +133,6 @@ variable "cognito_hosted_ui_domain_prefix" {
   description = "Globally unique Cognito managed Hosted UI domain prefix for the dev frontend auth flow."
 }
 
-variable "db_password_ssm_param" {
-  type        = string
-  description = "SSM parameter path for generated runtime DB password."
-  default     = "/leaseflow/dev/db/password"
-}
-
 variable "reminder_scan_schedule_expression" {
   type        = string
   description = "EventBridge Scheduler expression for the daily reminder scan."

--- a/infra/modules/lambda_backend/main.tf
+++ b/infra/modules/lambda_backend/main.tf
@@ -130,12 +130,12 @@ resource "aws_lambda_function" "this" {
 
   environment {
     variables = {
-      APP_ENV               = var.environment
-      LOG_LEVEL             = var.log_level
-      DB_HOST               = var.db_host
-      DB_PORT               = tostring(var.db_port)
-      DB_NAME               = var.db_name
-      DB_USER               = var.db_user
+      APP_ENV                = var.environment
+      LOG_LEVEL              = var.log_level
+      DB_HOST                = var.db_host
+      DB_PORT                = tostring(var.db_port)
+      DB_NAME                = var.db_name
+      DB_USER                = var.db_user
       DB_PASSWORD_SECRET_ARN = var.db_password_secret_arn
 
       NOTIFICATION_EMAIL_DELIVERY_ENABLED        = tostring(var.notification_email_delivery_enabled)

--- a/infra/modules/lambda_backend/main.tf
+++ b/infra/modules/lambda_backend/main.tf
@@ -5,7 +5,6 @@ data "aws_kms_alias" "ssm" {
 data "aws_region" "current" {}
 
 locals {
-  db_password_parameter_arn = "arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter${var.db_password_ssm_param}"
   notification_email_smtp_parameter_names = compact([
     var.notification_email_smtp_username_ssm_param,
     var.notification_email_smtp_password_ssm_param
@@ -69,21 +68,10 @@ locals {
           Resource = "*"
         },
         {
-          Sid      = "ReadDbPasswordParameter"
+          Sid      = "ReadDbPasswordSecret"
           Effect   = "Allow"
-          Action   = ["ssm:GetParameter"]
-          Resource = local.db_password_parameter_arn
-        },
-        {
-          Sid      = "DecryptDbPasswordParameter"
-          Effect   = "Allow"
-          Action   = ["kms:Decrypt"]
-          Resource = data.aws_kms_alias.ssm.target_key_arn
-          Condition = {
-            StringEquals = {
-              "kms:EncryptionContext:PARAMETER_ARN" = local.db_password_parameter_arn
-            }
-          }
+          Action   = ["secretsmanager:GetSecretValue"]
+          Resource = var.db_password_secret_arn
         }
       ],
       local.notification_email_smtp_policy_statements
@@ -148,7 +136,7 @@ resource "aws_lambda_function" "this" {
       DB_PORT               = tostring(var.db_port)
       DB_NAME               = var.db_name
       DB_USER               = var.db_user
-      DB_PASSWORD_SSM_PARAM = var.db_password_ssm_param
+      DB_PASSWORD_SECRET_ARN = var.db_password_secret_arn
 
       NOTIFICATION_EMAIL_DELIVERY_ENABLED        = tostring(var.notification_email_delivery_enabled)
       NOTIFICATION_EMAIL_SENDER                  = var.notification_email_sender

--- a/infra/modules/lambda_backend/tests/defaults.tftest.hcl
+++ b/infra/modules/lambda_backend/tests/defaults.tftest.hcl
@@ -31,38 +31,23 @@ variables {
   db_port                  = 5432
   db_name                  = "leaseflow"
   db_user                  = "leaseflow_admin"
-  db_password_ssm_param    = "/leaseflow/dev/db/password"
+  db_password_secret_arn   = "arn:aws:secretsmanager:eu-north-1:123456789012:secret:leaseflow-dev-rds-master"
   tags = {
     Project = "leaseflow"
   }
 }
 
-run "scopes_runtime_secret_permissions_to_the_db_password_parameter" {
+run "scopes_runtime_secret_permissions_to_the_db_password_secret" {
   command = plan
 
   assert {
-    condition     = local.lambda_policy.Statement[2].Action[0] == "ssm:GetParameter"
-    error_message = "Lambda policy should allow reading the DB password parameter from SSM."
+    condition     = local.lambda_policy.Statement[2].Action[0] == "secretsmanager:GetSecretValue"
+    error_message = "Lambda policy should allow reading the DB password secret from Secrets Manager."
   }
 
   assert {
-    condition     = local.lambda_policy.Statement[2].Resource == "arn:aws:ssm:eu-north-1:123456789012:parameter/leaseflow/dev/db/password"
-    error_message = "SSM access should be scoped to the DB password parameter ARN."
-  }
-
-  assert {
-    condition     = local.lambda_policy.Statement[3].Action[0] == "kms:Decrypt"
-    error_message = "Lambda policy should allow KMS decrypt for SecureString resolution."
-  }
-
-  assert {
-    condition     = local.lambda_policy.Statement[3].Resource == "arn:aws:kms:eu-north-1:123456789012:key/11111111-2222-3333-4444-555555555555"
-    error_message = "KMS decrypt should be scoped to the AWS-managed key backing alias/aws/ssm."
-  }
-
-  assert {
-    condition     = local.lambda_policy.Statement[3].Condition.StringEquals["kms:EncryptionContext:PARAMETER_ARN"] == "arn:aws:ssm:eu-north-1:123456789012:parameter/leaseflow/dev/db/password"
-    error_message = "KMS decrypt should be limited to the DB password parameter encryption context."
+    condition     = local.lambda_policy.Statement[2].Resource == "arn:aws:secretsmanager:eu-north-1:123456789012:secret:leaseflow-dev-rds-master"
+    error_message = "Secrets Manager access should be scoped to the RDS master user secret ARN."
   }
 }
 
@@ -122,7 +107,7 @@ run "scopes_notification_email_smtp_secret_permissions_to_configured_parameters"
 
   assert {
     condition = contains(
-      local.lambda_policy.Statement[4].Action,
+      local.lambda_policy.Statement[3].Action,
       "ssm:GetParameter",
     )
     error_message = "Lambda policy should allow reading configured SMTP credential parameters."
@@ -133,13 +118,13 @@ run "scopes_notification_email_smtp_secret_permissions_to_configured_parameters"
       for arn in [
         "arn:aws:ssm:eu-north-1:123456789012:parameter/leaseflow/dev/notification-email/smtp/username",
         "arn:aws:ssm:eu-north-1:123456789012:parameter/leaseflow/dev/notification-email/smtp/password",
-      ] : contains(local.lambda_policy.Statement[4].Resource, arn)
+      ] : contains(local.lambda_policy.Statement[3].Resource, arn)
     ])
     error_message = "SMTP SSM access should be scoped to the configured credential parameter ARNs."
   }
 
   assert {
-    condition     = local.lambda_policy.Statement[5].Action[0] == "kms:Decrypt"
+    condition     = local.lambda_policy.Statement[4].Action[0] == "kms:Decrypt"
     error_message = "Lambda policy should allow KMS decrypt for SMTP SecureString resolution."
   }
 
@@ -149,7 +134,7 @@ run "scopes_notification_email_smtp_secret_permissions_to_configured_parameters"
         "arn:aws:ssm:eu-north-1:123456789012:parameter/leaseflow/dev/notification-email/smtp/username",
         "arn:aws:ssm:eu-north-1:123456789012:parameter/leaseflow/dev/notification-email/smtp/password",
         ] : contains(
-        local.lambda_policy.Statement[5].Condition["ForAnyValue:StringEquals"]["kms:EncryptionContext:PARAMETER_ARN"],
+        local.lambda_policy.Statement[4].Condition["ForAnyValue:StringEquals"]["kms:EncryptionContext:PARAMETER_ARN"],
         arn,
       )
     ])

--- a/infra/modules/lambda_backend/variables.tf
+++ b/infra/modules/lambda_backend/variables.tf
@@ -79,9 +79,9 @@ variable "db_user" {
   description = "Database user."
 }
 
-variable "db_password_ssm_param" {
+variable "db_password_secret_arn" {
   type        = string
-  description = "SSM parameter path for DB password. Example: /leaseflow/dev/db/password"
+  description = "ARN of the Secrets Manager secret containing the RDS master user password."
 }
 
 variable "notification_email_delivery_enabled" {

--- a/infra/modules/network/main.tf
+++ b/infra/modules/network/main.tf
@@ -127,3 +127,14 @@ resource "aws_vpc_endpoint" "kms" {
 
   tags = merge(var.tags, { Name = "${var.name_prefix}-kms-vpce" })
 }
+
+resource "aws_vpc_endpoint" "secretsmanager" {
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.secretsmanager"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  subnet_ids          = aws_subnet.private[*].id
+  security_group_ids  = [aws_security_group.private_service_endpoints.id]
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-secretsmanager-vpce" })
+}

--- a/infra/modules/network/outputs.tf
+++ b/infra/modules/network/outputs.tf
@@ -32,3 +32,8 @@ output "kms_vpc_endpoint_id" {
   value       = aws_vpc_endpoint.kms.id
   description = "KMS interface VPC endpoint ID."
 }
+
+output "secretsmanager_vpc_endpoint_id" {
+  value       = aws_vpc_endpoint.secretsmanager.id
+  description = "Secrets Manager interface VPC endpoint ID."
+}

--- a/infra/modules/rds_postgres/main.tf
+++ b/infra/modules/rds_postgres/main.tf
@@ -16,9 +16,9 @@ resource "aws_db_instance" "this" {
   storage_type          = "gp3"
   storage_encrypted     = true
 
-  db_name  = var.db_name
-  username = var.db_username
-  password = var.db_password
+  db_name                     = var.db_name
+  username                    = var.db_username
+  manage_master_user_password = true
 
   db_subnet_group_name   = aws_db_subnet_group.this.name
   vpc_security_group_ids = [var.rds_security_group_id]

--- a/infra/modules/rds_postgres/outputs.tf
+++ b/infra/modules/rds_postgres/outputs.tf
@@ -27,3 +27,8 @@ output "skip_final_snapshot" {
   value       = aws_db_instance.this.skip_final_snapshot
   description = "Whether RDS final snapshot creation is skipped on destroy."
 }
+
+output "master_user_secret_arn" {
+  value       = aws_db_instance.this.master_user_secret[0].secret_arn
+  description = "ARN of the Secrets Manager secret for the RDS master user password."
+}

--- a/infra/modules/rds_postgres/variables.tf
+++ b/infra/modules/rds_postgres/variables.tf
@@ -23,12 +23,6 @@ variable "db_username" {
   description = "Master username."
 }
 
-variable "db_password" {
-  type        = string
-  description = "Master password."
-  sensitive   = true
-}
-
 variable "instance_class" {
   type        = string
   description = "RDS instance class."


### PR DESCRIPTION
## Summary

- Switches `aws_db_instance` to `manage_master_user_password = true`, removing
  the `random_password` resource and `aws_ssm_parameter` for the DB password.
  AWS now owns the secret lifecycle; the master password is no longer in
  Terraform state.
- Adds `aws_secretsmanager_secret_rotation` with a 30-day cadence.
- Adds a Secrets Manager VPC interface endpoint to the network module — required
  because Lambda runs in a private VPC with no NAT gateway.
- Updates Lambda IAM policy: removes `ReadDbPasswordParameter` (SSM) and its
  KMS decrypt statement; adds `ReadDbPasswordSecret`
  (`secretsmanager:GetSecretValue` scoped to the specific secret ARN).
- Updates backend `config.py` to read the DB password from Secrets Manager
  (`DB_PASSWORD_SECRET_ARN` env var) instead of SSM.

## Why

`docs/production-readiness-hardening.md` flags the long-lived SSM-backed RDS
master password as a production gap. Secrets Manager managed rotation removes
operator toil, eliminates the sensitive value from Terraform state and SSM, and
provides an auditable rotation trail.

## Validation

- [x] `make tf-fmt` (if `infra/` changed)
- [x] `make test` — 9/9 config tests pass with updated Secrets Manager mocks
- [ ] `terraform plan` in `infra/environments/dev/` — confirm RDS modify, new SM VPC endpoint, IAM diff, SSM/random_password destroy
- [ ] `terraform apply` + Lambda health endpoint smoke test
- [ ] Rotation test: `aws secretsmanager rotate-secret --secret-id <arn> --region eu-north-1`, then verify Lambda reconnects after cold start

## Review Notes

- [ ] Tenant-scoped queries explicitly filter by `tenant_id` where applicable
- [ ] `tenant_id` comes from validated JWT claims, not client input
- [ ] Write flows keep domain changes and audit records in one transaction where required
- [ ] Structured logging or audit logging was updated if the change affects important write flows
- [x] Docs were updated if architecture, security, or MVP scope changed materially — `docs/iam-least-privilege-review.md` updated

## Deployment Notes

Warm Lambda execution environments hold the old DSN (old password from SSM) and
will fail with auth errors after `terraform apply` changes the RDS master
password. They recover automatically on the next cold start. In dev this is
acceptable; schedule the apply during low-traffic or immediately trigger a
Lambda function update to force cold starts.
