### PR TITLE
feat(infra): add scheduled backend synthetic health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
           - infra/modules/network
           - infra/modules/reminder_scheduler
           - infra/modules/ses_email_foundation
+          - infra/modules/synthetic_health_check
 
     steps:
       - name: Check out repository

--- a/backend/src/app/routes/db_migrations.py
+++ b/backend/src/app/routes/db_migrations.py
@@ -22,7 +22,7 @@ class _MigrationPaths:
 def run_db_migrations(settings: Settings) -> dict[str, str | None]:
     dsn = settings.db_dsn()
     previous_revision = _current_revision(dsn)
-    _upgrade_to_head(sqlalchemy_url=_sqlalchemy_url(dsn), paths=_resolve_migration_paths())
+    _upgrade_to_head(dsn=dsn, paths=_resolve_migration_paths())
     current_revision = _current_revision(dsn)
     if not current_revision:
         raise RuntimeError("Alembic did not report a current revision after upgrade.")
@@ -75,8 +75,10 @@ def _current_revision(dsn: str) -> str | None:
     return str(row[0])
 
 
-def _upgrade_to_head(*, sqlalchemy_url: str, paths: _MigrationPaths) -> None:
+def _upgrade_to_head(*, dsn: str, paths: _MigrationPaths) -> None:
     config = Config(str(paths.alembic_ini))
     config.set_main_option("script_location", str(paths.migrations_dir))
-    config.set_main_option("sqlalchemy.url", sqlalchemy_url)
+    # Alembic stores this through ConfigParser, so URL-encoded percent signs
+    # must be escaped before the migration env reads sqlalchemy.url.
+    config.set_main_option("sqlalchemy.url", _sqlalchemy_url(dsn).replace("%", "%%"))
     command.upgrade(config, "head")

--- a/backend/tests/test_db_migrations_route.py
+++ b/backend/tests/test_db_migrations_route.py
@@ -19,15 +19,10 @@ def test_run_db_migrations_returns_previous_and_current_revision(monkeypatch) ->
     )
 
     monkeypatch.setattr(db_migrations, "_resolve_migration_paths", lambda: paths)
-    monkeypatch.setattr(
-        db_migrations,
-        "_sqlalchemy_url",
-        lambda settings: "postgresql+psycopg://leaseflow_admin:secret@db:5432/leaseflow",
-    )
     monkeypatch.setattr(db_migrations, "_current_revision", lambda dsn: next(revisions))
 
-    def _fake_upgrade(*, sqlalchemy_url: str, paths: object) -> None:
-        upgrade_calls.append({"sqlalchemy_url": sqlalchemy_url, "paths": paths})
+    def _fake_upgrade(*, dsn: str, paths: object) -> None:
+        upgrade_calls.append({"dsn": dsn, "paths": paths})
 
     monkeypatch.setattr(db_migrations, "_upgrade_to_head", _fake_upgrade)
 
@@ -42,7 +37,7 @@ def test_run_db_migrations_returns_previous_and_current_revision(monkeypatch) ->
     }
     assert upgrade_calls == [
         {
-            "sqlalchemy_url": "postgresql+psycopg://leaseflow_admin:secret@db:5432/leaseflow",
+            "dsn": "host=db port=5432 dbname=leaseflow user=leaseflow_admin",
             "paths": paths,
         }
     ]
@@ -62,11 +57,6 @@ def test_run_db_migrations_reports_null_previous_revision_when_version_table_mis
             migrations_dir=Path("/var/task/migrations"),
         ),
     )
-    monkeypatch.setattr(
-        db_migrations,
-        "_sqlalchemy_url",
-        lambda settings: "postgresql+psycopg://leaseflow_admin:secret@db:5432/leaseflow",
-    )
     monkeypatch.setattr(db_migrations, "_current_revision", lambda dsn: next(revisions))
     monkeypatch.setattr(db_migrations, "_upgrade_to_head", lambda **kwargs: None)
 
@@ -79,3 +69,44 @@ def test_run_db_migrations_reports_null_previous_revision_when_version_table_mis
         "previous_revision": None,
         "current_revision": "20260407_0005",
     }
+
+
+def test_upgrade_escapes_url_percent_signs_for_alembic_config(
+    monkeypatch,
+) -> None:
+    db_migrations = _db_migrations_module()
+    paths = SimpleNamespace(
+        alembic_ini=Path("/var/task/alembic.ini"),
+        migrations_dir=Path("/var/task/migrations"),
+    )
+    calls: list[tuple[str, str, str]] = []
+
+    def fake_upgrade(config, target):
+        calls.append(
+            (
+                "upgrade",
+                target,
+                config.file_config.get(
+                    config.config_ini_section,
+                    "sqlalchemy.url",
+                    raw=True,
+                ),
+            )
+        )
+
+    monkeypatch.setattr(db_migrations.command, "upgrade", fake_upgrade)
+
+    dsn = (
+        "host=db port=5432 dbname=leaseflow user=leaseflow_admin "
+        "password='>yJGis#_[#6>FAJp5[V!VTkFIil'"
+    )
+
+    db_migrations._upgrade_to_head(dsn=dsn, paths=paths)
+
+    assert calls == [
+        (
+            "upgrade",
+            "head",
+            "postgresql+psycopg://leaseflow_admin:%%3EyJGis%%23_%%5B%%236%%3EFAJp5%%5BV%%21VTkFIil@db:5432/leaseflow",
+        ),
+    ]

--- a/docs/production-readiness-hardening.md
+++ b/docs/production-readiness-hardening.md
@@ -193,12 +193,16 @@ Current state:
 - Deployed smoke test runbook exists.
 - One deployed smoke test evidence note exists.
 - Local demo client can exercise the MVP path manually.
-- No scheduled synthetic check exists.
+- Scheduled synthetic health check implemented (Lambda + EventBridge Scheduler,
+  every 15 minutes). Hits GET /health (unauthenticated) and GET /properties
+  (authenticated via dedicated synthetic Cognito user). Failures publish to the
+  baseline alarm SNS topic. Cost: ~$0.003/month (Lambda free tier) vs ~$3.46/month
+  for CloudWatch Synthetics Canary at the same cadence.
 
 Target posture:
 
-- Decide whether production-like environments need scheduled synthetic checks.
-- Keep synthetic checks tenant-safe and free of sensitive evidence.
+- Keep synthetic checks tenant-safe and free of sensitive evidence (synthetic
+  Cognito user uses @leaseflow.internal email and a dedicated tenant UUID).
 - Separate demo tooling from continuous monitoring.
 
 Cost impact: low to medium.

--- a/infra/environments/dev/.terraform.lock.hcl
+++ b/infra/environments/dev/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.8.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:i4jOdktQW0SDbjM3IC2ZSqdd881FzVY+V11XKkLPHrk=",
+    "h1:jdmKm+xl6ZcQrijxapnZ94RVuz/G4vk7hsIa1N0VT5Q=",
+    "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
+    "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
+    "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
+    "zh:5c547549e26e083573c78a966ca68ce6d7df6bb8f3948f66a575f07da46b74ea",
+    "zh:6de093e62a975eb19a5e3017ce38e6e3cb639c17b79648d2000e0a8348f0e997",
+    "zh:7267936c2cdbc448efeb594d73e6b56a53d6a7ae14fe88cdd2a4133adc3302f0",
+    "zh:7482f023050ed426b4b45116e1761643bc33b1fd4ce4a6fab207ae2571f35940",
+    "zh:76bbd93b234e5a2927d98b511d86565700f549b570871a194c35f944b96cefb7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c6afc4bc1f002bac9c173007dd4da05fde788cd14c2916089f958c33fedb0dfa",
+    "zh:d3ba40bd806a3a08e9237dece679193c99afb2085de6b45d7f5d1f673cfcd368",
+    "zh:e1ad7ded53ecd6f0e5b473a3b44eae2b2e885653a56050ab583d387332be02e4",
+    "zh:e93e78575ce82be6084cc153c24ba8f385dc8d6880888ee66e918460c870953d",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.44.0"
   constraints = "~> 6.37, ~> 6.38"

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -218,3 +218,17 @@ resource "aws_secretsmanager_secret_rotation" "rds_master" {
     automatically_after_days = 30
   }
 }
+
+module "synthetic_health_check" {
+  source = "../../modules/synthetic_health_check"
+
+  name_prefix         = local.name_prefix
+  user_pool_id        = module.cognito.user_pool_id
+  user_pool_client_id = module.cognito.user_pool_client_id
+  api_url             = module.api_http.stage_invoke_url
+  environment         = var.environment
+  schedule_enabled    = var.synthetic_health_check_schedule_enabled
+  alarm_action_arns   = [aws_sns_topic.baseline_alarm_notifications.arn]
+  schedule_expression = var.synthetic_health_check_schedule_expression
+  tags                = local.common_tags
+}

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -157,6 +157,18 @@ variable "reminder_scan_enabled" {
   default     = true
 }
 
+variable "synthetic_health_check_schedule_enabled" {
+  type        = bool
+  description = "Whether the synthetic API health check EventBridge Scheduler is enabled."
+  default     = true
+}
+
+variable "synthetic_health_check_schedule_expression" {
+  type        = string
+  description = "EventBridge Scheduler expression for the synthetic API health check."
+  default     = "rate(15 minutes)"
+}
+
 variable "baseline_alarm_notification_email" {
   type        = string
   description = "Optional email endpoint subscribed to dev baseline alarm SNS notifications."

--- a/infra/modules/synthetic_health_check/.gitignore
+++ b/infra/modules/synthetic_health_check/.gitignore
@@ -1,0 +1,1 @@
+lambda_handler.zip

--- a/infra/modules/synthetic_health_check/.terraform.lock.hcl
+++ b/infra/modules/synthetic_health_check/.terraform.lock.hcl
@@ -1,0 +1,67 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.8.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:i4jOdktQW0SDbjM3IC2ZSqdd881FzVY+V11XKkLPHrk=",
+    "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
+    "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
+    "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
+    "zh:5c547549e26e083573c78a966ca68ce6d7df6bb8f3948f66a575f07da46b74ea",
+    "zh:6de093e62a975eb19a5e3017ce38e6e3cb639c17b79648d2000e0a8348f0e997",
+    "zh:7267936c2cdbc448efeb594d73e6b56a53d6a7ae14fe88cdd2a4133adc3302f0",
+    "zh:7482f023050ed426b4b45116e1761643bc33b1fd4ce4a6fab207ae2571f35940",
+    "zh:76bbd93b234e5a2927d98b511d86565700f549b570871a194c35f944b96cefb7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c6afc4bc1f002bac9c173007dd4da05fde788cd14c2916089f958c33fedb0dfa",
+    "zh:d3ba40bd806a3a08e9237dece679193c99afb2085de6b45d7f5d1f673cfcd368",
+    "zh:e1ad7ded53ecd6f0e5b473a3b44eae2b2e885653a56050ab583d387332be02e4",
+    "zh:e93e78575ce82be6084cc153c24ba8f385dc8d6880888ee66e918460c870953d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.46.0"
+  constraints = "~> 6.37"
+  hashes = [
+    "h1:SbQ3sCRV99tzNDyCaq6O+UZpmYgzsCnXuJ6BhHmlwu8=",
+    "zh:0a771c2981bb31b8a8e6790f800f5ae9c860a0e05d39a249d16d557713299f6c",
+    "zh:0dd5ca8f1997a73f3fbadca80aefdc4e47785f2dcec189dd8828c4f835a02318",
+    "zh:56f6972652aa038b320c96de6460c48dd350244e5d2cdf6d43d62d27a7de8828",
+    "zh:792f9a16a3567795a8c7ad91a67253ee84a2a462791a7b920ef9c607529e324f",
+    "zh:7d8a41d268006a98e70457c606c60de5948c7e22e1192c40c8b2fe4d9c069450",
+    "zh:876a1033ebdd05b99d3f4e565881c7c4832c92aab5c91ee4c04903001d19a79f",
+    "zh:90aa9d7925be5a1d31f38c9c29117e68b91c7d0367f8f76f26df458935ea4f18",
+    "zh:94c8f5a40a646fbd1b85bc7a6efa88b3e260d9aef4c432091f26fa4319297631",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a002ee5fa9d5d1010c59c266e64da989f60958321f8fa95c212460ea486412f0",
+    "zh:c5498f9502a209d1e51f1ac46ae53419a2fa60f6f307805ebf8a458535f06bfc",
+    "zh:c8a0ac2465d19ad85cddfa0e0f25f92688b1d1f39ff756a908138b9b1246d039",
+    "zh:d3c117dd5a332f072df84f60b7521ff8913c00586f325454baf6afc8816ee61d",
+    "zh:d5891fcb437e878274ab9f4047bf12a1878489d1474d5bb8c0049eb05de158da",
+    "zh:e3ac26177953ddf1d72e28b9a1f33d029675e9ea6652f7cc844a86c02b0ebd68",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:q/uaUTBdKgAmZESrwsoeDQff9uUA/cI/N5ZKNgVwa9c=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/modules/synthetic_health_check/lambda_handler.py
+++ b/infra/modules/synthetic_health_check/lambda_handler.py
@@ -1,0 +1,63 @@
+import json
+import os
+import urllib.request
+
+import boto3
+
+
+def handler(event, context):
+    sm = boto3.client("secretsmanager")
+    secret = json.loads(
+        sm.get_secret_value(SecretId=os.environ["SYNTHETIC_CREDENTIALS_SECRET_ARN"])[
+            "SecretString"
+        ]
+    )
+
+    cognito = boto3.client("cognito-idp")
+    auth_resp = cognito.admin_initiate_auth(
+        UserPoolId=secret["user_pool_id"],
+        ClientId=secret["client_id"],
+        AuthFlow="ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters={
+            "USERNAME": secret["username"],
+            "PASSWORD": secret["password"],
+        },
+    )
+    id_token = auth_resp["AuthenticationResult"]["IdToken"]
+
+    api_url = os.environ["API_URL"].rstrip("/")
+    health_ok = _http_get(f"{api_url}/health")
+    props_ok = _http_get(
+        f"{api_url}/properties", {"Authorization": f"Bearer {id_token}"}
+    )
+    success = health_ok and props_ok
+
+    boto3.client("cloudwatch").put_metric_data(
+        Namespace="LeaseFlow/SyntheticChecks",
+        MetricData=[
+            {
+                "MetricName": "HealthCheckSuccess",
+                "Dimensions": [
+                    {"Name": "Environment", "Value": os.environ["ENVIRONMENT"]}
+                ],
+                "Value": 1.0 if success else 0.0,
+                "Unit": "Count",
+            }
+        ],
+    )
+
+    if not success:
+        raise RuntimeError(
+            f"Synthetic health check failed — health={health_ok} props={props_ok}"
+        )
+
+    return {"health_ok": True, "props_ok": True}
+
+
+def _http_get(url: str, headers: dict | None = None) -> bool:
+    try:
+        req = urllib.request.Request(url, headers=headers or {})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status == 200
+    except Exception:
+        return False

--- a/infra/modules/synthetic_health_check/main.tf
+++ b/infra/modules/synthetic_health_check/main.tf
@@ -1,0 +1,224 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+locals {
+  schedule_group_name = "default"
+  schedule_group_arn  = "arn:aws:scheduler:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:schedule-group/${local.schedule_group_name}"
+  metric_namespace    = "LeaseFlow/SyntheticChecks"
+}
+
+resource "random_password" "synthetic_user" {
+  length           = 20
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+  min_upper        = 1
+  min_lower        = 1
+  min_numeric      = 1
+  min_special      = 1
+}
+
+resource "random_uuid" "synthetic_tenant_id" {}
+
+resource "aws_cognito_user" "synthetic" {
+  user_pool_id = var.user_pool_id
+  username     = "synthetic-health-check@leaseflow.internal"
+
+  attributes = {
+    email              = "synthetic-health-check@leaseflow.internal"
+    email_verified     = "true"
+    "custom:tenant_id" = random_uuid.synthetic_tenant_id.result
+  }
+
+  password       = random_password.synthetic_user.result
+  message_action = "SUPPRESS"
+}
+
+resource "aws_secretsmanager_secret" "synthetic_credentials" {
+  name                    = "${var.name_prefix}-synthetic-health-check-credentials"
+  description             = "Synthetic health check Cognito credentials. No real tenant data."
+  recovery_window_in_days = 0
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-synthetic-health-check-credentials" })
+}
+
+resource "aws_secretsmanager_secret_version" "synthetic_credentials" {
+  secret_id = aws_secretsmanager_secret.synthetic_credentials.id
+
+  secret_string = jsonencode({
+    username     = aws_cognito_user.synthetic.username
+    password     = random_password.synthetic_user.result
+    user_pool_id = var.user_pool_id
+    client_id    = var.user_pool_client_id
+  })
+}
+
+resource "aws_cloudwatch_log_group" "synthetic_hc" {
+  name              = "/aws/lambda/${var.name_prefix}-synthetic-health-check"
+  retention_in_days = 14
+
+  tags = var.tags
+}
+
+resource "aws_iam_role" "lambda" {
+  name = "${var.name_prefix}-synthetic-hc-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-synthetic-hc-lambda-role" })
+}
+
+resource "aws_iam_role_policy" "lambda" {
+  name = "${var.name_prefix}-synthetic-hc-lambda-policy"
+  role = aws_iam_role.lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Logs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = "${aws_cloudwatch_log_group.synthetic_hc.arn}:*"
+      },
+      {
+        Sid      = "PublishMetric"
+        Effect   = "Allow"
+        Action   = ["cloudwatch:PutMetricData"]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "cloudwatch:namespace" = local.metric_namespace
+          }
+        }
+      },
+      {
+        Sid      = "GetCredentials"
+        Effect   = "Allow"
+        Action   = ["secretsmanager:GetSecretValue"]
+        Resource = aws_secretsmanager_secret.synthetic_credentials.arn
+      },
+      {
+        Sid      = "AdminAuth"
+        Effect   = "Allow"
+        Action   = ["cognito-idp:AdminInitiateAuth"]
+        Resource = "arn:aws:cognito-idp:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:userpool/${var.user_pool_id}"
+      },
+    ]
+  })
+}
+
+data "archive_file" "lambda_code" {
+  type        = "zip"
+  source_file = "${path.module}/lambda_handler.py"
+  output_path = "${path.module}/lambda_handler.zip"
+}
+
+resource "aws_lambda_function" "synthetic_hc" {
+  function_name    = "${var.name_prefix}-synthetic-health-check"
+  description      = "Periodic synthetic API health check for LeaseFlow."
+  role             = aws_iam_role.lambda.arn
+  filename         = data.archive_file.lambda_code.output_path
+  source_code_hash = data.archive_file.lambda_code.output_base64sha256
+  handler          = "lambda_handler.handler"
+  runtime          = "python3.12"
+  timeout          = 30
+
+  environment {
+    variables = {
+      SYNTHETIC_CREDENTIALS_SECRET_ARN = aws_secretsmanager_secret.synthetic_credentials.arn
+      API_URL                          = var.api_url
+      ENVIRONMENT                      = var.environment
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.synthetic_hc]
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-synthetic-health-check" })
+}
+
+resource "aws_iam_role" "scheduler" {
+  name = "${var.name_prefix}-synthetic-hc-scheduler-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "scheduler.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+      Condition = {
+        StringEquals = {
+          "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+        }
+        ArnEquals = {
+          "aws:SourceArn" = local.schedule_group_arn
+        }
+      }
+    }]
+  })
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-synthetic-hc-scheduler-role" })
+}
+
+resource "aws_iam_role_policy" "scheduler" {
+  name = "${var.name_prefix}-synthetic-hc-scheduler-policy"
+  role = aws_iam_role.scheduler.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid      = "InvokeSyntheticHcLambda"
+      Effect   = "Allow"
+      Action   = ["lambda:InvokeFunction"]
+      Resource = aws_lambda_function.synthetic_hc.arn
+    }]
+  })
+}
+
+resource "aws_scheduler_schedule" "synthetic_hc" {
+  name                         = "${var.name_prefix}-synthetic-health-check"
+  group_name                   = local.schedule_group_name
+  description                  = "Runs the LeaseFlow synthetic API health check."
+  schedule_expression          = var.schedule_expression
+  schedule_expression_timezone = var.schedule_timezone
+  state                        = var.schedule_enabled ? "ENABLED" : "DISABLED"
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  target {
+    arn      = aws_lambda_function.synthetic_hc.arn
+    role_arn = aws_iam_role.scheduler.arn
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "synthetic_hc_failure" {
+  alarm_name          = "${var.name_prefix}-synthetic-health-check-failure"
+  alarm_description   = "Synthetic API health check failed or stopped reporting."
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 2
+  datapoints_to_alarm = 2
+  threshold           = 1
+  period              = 900
+  namespace           = local.metric_namespace
+  metric_name         = "HealthCheckSuccess"
+  statistic           = "Minimum"
+  treat_missing_data  = "breaching"
+  alarm_actions       = var.alarm_action_arns
+
+  dimensions = {
+    Environment = var.environment
+  }
+
+  tags = var.tags
+}

--- a/infra/modules/synthetic_health_check/outputs.tf
+++ b/infra/modules/synthetic_health_check/outputs.tf
@@ -1,0 +1,14 @@
+output "lambda_function_arn" {
+  value       = aws_lambda_function.synthetic_hc.arn
+  description = "Synthetic health check Lambda function ARN."
+}
+
+output "lambda_function_name" {
+  value       = aws_lambda_function.synthetic_hc.function_name
+  description = "Synthetic health check Lambda function name."
+}
+
+output "alarm_name" {
+  value       = aws_cloudwatch_metric_alarm.synthetic_hc_failure.alarm_name
+  description = "CloudWatch alarm name for synthetic health check failures."
+}

--- a/infra/modules/synthetic_health_check/tests/defaults.tftest.hcl
+++ b/infra/modules/synthetic_health_check/tests/defaults.tftest.hcl
@@ -1,0 +1,81 @@
+mock_provider "aws" {}
+mock_provider "random" {}
+mock_provider "archive" {}
+
+variables {
+  name_prefix         = "leaseflow-test"
+  user_pool_id        = "eu-north-1_abc123"
+  user_pool_client_id = "client123"
+  api_url             = "https://abc123.execute-api.eu-north-1.amazonaws.com/dev"
+  environment         = "dev"
+  alarm_action_arns   = ["arn:aws:sns:eu-north-1:123456789012:leaseflow-test-alarms"]
+}
+
+run "defaults_alarm_posture" {
+  command = plan
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.synthetic_hc_failure.treat_missing_data == "breaching"
+    error_message = "Alarm must treat missing data as breaching to detect scheduler failures."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.synthetic_hc_failure.evaluation_periods == 2
+    error_message = "Alarm should require 2 consecutive failing periods before firing."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.synthetic_hc_failure.datapoints_to_alarm == 2
+    error_message = "Alarm should require 2 failing datapoints before firing."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.synthetic_hc_failure.comparison_operator == "LessThanThreshold"
+    error_message = "Alarm should fire when HealthCheckSuccess drops below threshold."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.synthetic_hc_failure.period == 900
+    error_message = "Alarm period should match the 15-minute schedule (900 s)."
+  }
+}
+
+run "defaults_scheduler_enabled" {
+  command = plan
+
+  assert {
+    condition     = aws_scheduler_schedule.synthetic_hc.state == "ENABLED"
+    error_message = "Scheduler must be ENABLED by default."
+  }
+}
+
+run "disabled_scheduler" {
+  command = plan
+
+  variables {
+    schedule_enabled = false
+  }
+
+  assert {
+    condition     = aws_scheduler_schedule.synthetic_hc.state == "DISABLED"
+    error_message = "Scheduler must be DISABLED when schedule_enabled = false."
+  }
+}
+
+run "synthetic_user_no_welcome_email" {
+  command = plan
+
+  assert {
+    condition     = aws_cognito_user.synthetic.message_action == "SUPPRESS"
+    error_message = "Synthetic user creation must suppress the welcome email."
+  }
+}
+
+run "lambda_timeout_sufficient" {
+  command = plan
+
+  assert {
+    condition     = aws_lambda_function.synthetic_hc.timeout == 30
+    error_message = "Lambda timeout must be at least 30 s to allow two HTTP calls plus auth."
+  }
+}

--- a/infra/modules/synthetic_health_check/variables.tf
+++ b/infra/modules/synthetic_health_check/variables.tf
@@ -1,0 +1,53 @@
+variable "name_prefix" {
+  type        = string
+  description = "Resource name prefix."
+}
+
+variable "user_pool_id" {
+  type        = string
+  description = "Cognito user pool ID."
+}
+
+variable "user_pool_client_id" {
+  type        = string
+  description = "Cognito app client ID."
+}
+
+variable "api_url" {
+  type        = string
+  description = "API stage invoke URL."
+}
+
+variable "environment" {
+  type        = string
+  description = "Environment name (used as a CloudWatch metric dimension)."
+}
+
+variable "alarm_action_arns" {
+  type        = list(string)
+  description = "SNS topic ARNs to notify when the health check alarm fires."
+}
+
+variable "schedule_enabled" {
+  type        = bool
+  default     = true
+  description = "Whether the synthetic health check EventBridge Scheduler is enabled. When false, the Lambda and supporting resources remain but are not invoked automatically."
+}
+
+variable "schedule_expression" {
+  type        = string
+  default     = "rate(15 minutes)"
+  description = "EventBridge Scheduler schedule expression."
+}
+
+variable "schedule_timezone" {
+  type        = string
+  default     = "UTC"
+  description = "IANA timezone for the schedule expression."
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Tags to apply to all resources."
+}

--- a/infra/modules/synthetic_health_check/versions.tf
+++ b/infra/modules/synthetic_health_check/versions.tf
@@ -1,8 +1,6 @@
 terraform {
   required_version = ">= 1.6.0"
 
-  backend "s3" {}
-
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -17,8 +15,4 @@ terraform {
       version = "~> 2.0"
     }
   }
-}
-
-provider "aws" {
-  region = var.aws_region
 }


### PR DESCRIPTION
## What changed and why

Adds a scheduled Lambda-based synthetic health check for the dev backend API.

The check uses a dedicated synthetic Cognito user and tenant, then verifies:
- unauthenticated `GET /health`
- authenticated `GET /properties`

Failures publish through the existing baseline alarm SNS topic. This closes the previous gap where deployed smoke validation was operator-run only and not continuously checked.

This PR also fixes the deployed migration runner so Alembic can handle RDS passwords whose URL-encoded form contains `%` characters.

## Key changes

- Added `infra/modules/synthetic_health_check`.
- Added dev wiring and variables for `synthetic_health_check_schedule_enabled` and `synthetic_health_check_schedule_expression`.
- Added the `archive` Terraform provider for packaging the synthetic Lambda.
- Added Terraform module tests and included the module in CI.
- Updated production-readiness docs with synthetic check status and cost note.
- Fixed Alembic migration URL interpolation by escaping `%` before setting `sqlalchemy.url`.
- Added a regression test for the migration password interpolation issue.

## Assumptions

- The synthetic Cognito user and tenant are dev-only and contain no real customer data.
- `schedule_enabled=false` disables scheduled execution, but keeps supporting resources present.
- The Lambda-based approach is preferred here over CloudWatch Synthetics Canary for cost and simplicity.

## Security validation

- Synthetic credentials are stored in Secrets Manager, not committed.
- Synthetic tenant data is isolated from real tenants.
- The health check uses a dedicated synthetic Cognito user with its own `custom:tenant_id`.
- No tenant ID, JWT, password, or real customer data is added to docs or outputs.
- IAM is scoped to the synthetic secret, Cognito user pool admin auth, CloudWatch metric namespace, and Lambda logs.

## Cost validation

- Adds one small Lambda, one EventBridge Scheduler schedule, one Secrets Manager secret, one custom CloudWatch metric/alarm path, and one synthetic Cognito user.
- Expected dev cost is low and documented.
- No NAT Gateway, public RDS, CloudWatch Synthetics Canary, or new always-on compute was added.

## Validation

- `terraform test` in `infra/modules/synthetic_health_check`
- `terraform validate` in `infra/environments/dev`
- `terraform fmt -check -recursive infra`
- `python -m pytest -q tests/test_db_migrations_route.py`
- `python -m ruff check src tests migrations`
- `python -m ruff format --check src tests migrations`
- `git diff --check`

## Remaining risks / TODOs

- First deploy should be reviewed with `terraform plan` because this adds scheduled AWS resources.
- Synthetic check evidence should be captured after the first successful scheduled run.
- If dev cost needs to be minimized temporarily, set `synthetic_health_check_schedule_enabled=false`.