### PR TITLE
docs: define production rto and rpo targets

### DIFF
--- a/docs/production-readiness-hardening.md
+++ b/docs/production-readiness-hardening.md
@@ -79,7 +79,9 @@ Target posture:
 - Explicit backup retention aligned with recovery expectations.
 - Deletion protection and final snapshot behavior reviewed for production-like use.
 - Multi-AZ tradeoff reviewed against availability needs and cost.
-- Restore objectives and evidence cadence defined before real tenant data exists.
+- Production-like recovery objectives are defined in
+  `docs/rto-rpo-targets.md`: RTO 4 hours and RPO 24 hours.
+- Restore evidence must prove those targets before production-readiness claims.
 - Production-like defaults are defined in
   `docs/rds-production-protection-baseline.md`.
 
@@ -225,12 +227,15 @@ Current state:
 
 - Dev RDS restore validation runbook and evidence exist.
 - Restore validation cadence is documented for MVP development.
+- Production-like RTO/RPO targets are defined in `docs/rto-rpo-targets.md`.
 - Private data-level validation path is documented, but not automated.
 
 Target posture:
 
-- Define RTO and RPO before production use.
-- Align backup retention and restore validation cadence with those objectives.
+- Validate production-like restore against the 4-hour RTO and 24-hour RPO
+  before real tenant data or production-readiness claims.
+- Keep backup retention and restore validation cadence aligned with those
+  objectives.
 - Add a private read-only data validation path if evidence needs to be executable.
 
 Cost impact: medium.

--- a/docs/rds-production-protection-baseline.md
+++ b/docs/rds-production-protection-baseline.md
@@ -62,6 +62,10 @@ breaking dev destroy workflows.
 
 ## Production-Like Baseline
 
+Recovery targets are defined in `docs/rto-rpo-targets.md`: RTO 4 hours and RPO
+24 hours. The baseline below is the minimum RDS posture expected to support
+those targets at the planning level.
+
 | Control | Production-like baseline | Cost impact | Why |
 | --- | --- | --- | --- |
 | Public access | Keep disabled. | None | Public RDS access is not an acceptable shortcut. |
@@ -80,9 +84,10 @@ These are project assumptions, not AWS service guarantees:
   recovery.
 - Dev RPO: bounded by the current one-day backup retention and latest
   restorable time.
-- Production-like RTO and RPO must be defined before go-live.
-- Backup retention must be increased when recovery expectations exceed the dev
-  one-day window.
+- Production-like RTO: 4 hours.
+- Production-like RPO: 24 hours.
+- Backup retention must stay at least `7` days for production-like use so the
+  24-hour RPO has restore-window margin.
 - Restore validation evidence must be kept for production-like readiness claims.
 
 ## Decision Rules
@@ -114,6 +119,7 @@ For production-like use, restore validation must include:
 - source DB identifier
 - latest restorable time
 - restore start and completion time
+- pass/fail against the 4-hour RTO and 24-hour RPO targets
 - restored DB privacy and encryption posture
 - migration/schema validation through a private path
 - cleanup confirmation or documented reason for retention

--- a/docs/rto-rpo-targets.md
+++ b/docs/rto-rpo-targets.md
@@ -1,0 +1,72 @@
+# Production RTO/RPO Targets
+
+## Purpose
+
+Define LeaseFlow's recovery targets for a future production-like stack.
+
+This is a planning document. It does not implement disaster recovery
+automation, change Terraform defaults, change RDS configuration, or prove that
+the targets have been met.
+
+## Targets
+
+| Objective | Target | Meaning |
+| --- | --- | --- |
+| Recovery Time Objective (RTO) | 4 hours | Restore the application to usable service within 4 hours of declaring a production recovery event. |
+| Recovery Point Objective (RPO) | 24 hours | Limit production database data loss to no more than 24 hours. |
+
+These targets are intentionally modest. They fit a small SaaS or portfolio-grade
+production-like posture where operator-driven restore is acceptable at first,
+but recovery expectations still need to be explicit and testable before real
+tenant data is stored.
+
+## Rationale
+
+- A 4-hour RTO gives enough room for an operator-run restore, application
+  configuration review, migration validation, and browser/API smoke validation.
+- A 24-hour RPO aligns with RDS automated backups and point-in-time restore as
+  the first production-like recovery mechanism.
+- The targets avoid implying high availability, multi-region failover, or
+  automated disaster recovery that LeaseFlow does not currently implement.
+- The targets are stricter than the current cost-aware dev posture, so they are
+  production-like goals rather than claims about today's dev environment.
+
+## Backup And Restore Expectations
+
+Production-like RDS should keep at least `7` days of automated backups. This
+supports the 24-hour RPO target with margin and gives operators a wider restore
+window for validation and recovery.
+
+Before production use, restore validation must prove:
+
+- the latest restorable point is available within the expected RPO window
+- a temporary restored DB can be created privately and encrypted
+- application migrations and schema checks pass through a private path
+- the application can be redeployed or reconfigured against the restored data
+- the total recovery workflow can complete inside the 4-hour RTO target
+
+## Validation Cadence
+
+Run production-like restore validation:
+
+- before storing real tenant data
+- before any production go-live claim
+- quarterly while a production-like environment exists
+- after meaningful DB schema, RDS module, backup retention, migration workflow,
+  or restore runbook changes
+
+Evidence must record pass/fail status against the 4-hour RTO and 24-hour RPO,
+but it must not include tenant data, tenant IDs, DB endpoints, secrets, SSM
+values, JWTs, passwords, full connection strings, or row contents.
+
+## Current Dev Boundary
+
+The current dev stack remains cost-aware and destroyable:
+
+- `db_backup_retention_period = 1`
+- `db_deletion_protection = false`
+- `db_skip_final_snapshot = true`
+
+The dev restore validation runbook remains useful for proving the mechanics of
+private RDS restore. It does not prove the production-like RTO/RPO targets until
+the validation is timed and measured against the targets in this document.

--- a/docs/runbooks/dev-rds-restore-validation.md
+++ b/docs/runbooks/dev-rds-restore-validation.md
@@ -6,6 +6,11 @@ Validate that the Terraform-managed dev RDS PostgreSQL instance can be restored 
 
 This is an operator-run dev procedure, not an automated disaster recovery platform.
 
+Production-like recovery targets are defined separately in
+`docs/rto-rpo-targets.md`: RTO 4 hours and RPO 24 hours. This dev runbook
+validates restore mechanics; production-like validation must also measure and
+record whether the restore workflow meets those targets.
+
 ## Current Dev Assumptions
 
 - Source DB instance: `leaseflow-dev-postgres`.
@@ -66,6 +71,8 @@ Current decision:
   automation in this dev runbook.
 - Increase retention only when the recoverability benefit is explicitly accepted
   against the added storage cost.
+- For production-like validation, use the RTO/RPO targets in
+  `docs/rto-rpo-targets.md` and record pass/fail against them.
 
 ## Step 1: Capture Source Backup Readiness
 
@@ -218,6 +225,8 @@ Expected evidence:
 - Restored DB remains private and encrypted.
 - Restore metadata is captured.
 - Temporary restore DB is deleted after validation.
+- Production-like runs also record whether the 4-hour RTO and 24-hour RPO were
+  met.
 
 ## Evidence to Capture
 


### PR DESCRIPTION
## What changed and why

Defined production-like recovery targets for LeaseFlow.

This adds a focused RTO/RPO planning document and updates the production hardening, RDS protection, and dev restore validation docs so recovery expectations are explicit before any production-readiness claim.

Chosen targets:
- RTO: 4 hours
- RPO: 24 hours

## Assumptions

- This ticket is docs-only.
- Current dev RDS defaults remain unchanged and cost-aware.
- The production-like baseline remains at least 7 days of automated RDS backups.
- Meeting the targets requires future restore validation evidence; this PR defines the objective but does not prove it.

## Security validation

- No runtime, backend, frontend, Terraform, AWS, or database behavior changed.
- No tenant data, tenant IDs, DB endpoints, JWTs, secrets, SSM values, passwords, raw restore output, or connection strings were added.
- Docs continue to require private restore validation and no public RDS access.

## Cost validation

- No new AWS resources or cost-impacting configuration changes.
- Production-like backup retention expectations are planning guidance only.
- Dev defaults remain `backup_retention_period = 1`, deletion protection off, and final snapshot skipped.

## Validation

- `git diff --check`

## Remaining risks / TODOs

- RTO/RPO targets are not yet proven by evidence.
- Future production-like restore validation must measure pass/fail against the 4-hour RTO and 24-hour RPO.