### PR TITLE
feat: enable optional cognito totp mfa

### DIFF
--- a/docs/runbooks/cognito-totp-mfa-enrollment-recovery.md
+++ b/docs/runbooks/cognito-totp-mfa-enrollment-recovery.md
@@ -1,0 +1,96 @@
+# Cognito TOTP MFA Enrollment And Recovery
+
+## Purpose
+
+This runbook documents the dev validation path for Cognito software-token TOTP
+MFA and the safe operator recovery path for an MFA-locked account.
+
+LeaseFlow uses Cognito Hosted UI for browser sign-in. This runbook does not add
+a custom LeaseFlow TOTP enrollment screen, direct browser Cognito admin APIs,
+SMS MFA, WebAuthn, passkeys, or privileged role enforcement.
+
+## Current Scope
+
+- The dev Cognito user pool enables software-token TOTP MFA.
+- MFA mode is optional because LeaseFlow does not yet have admin/operator user
+  groups.
+- Browser authentication continues to use Cognito Hosted UI and OAuth code flow
+  with PKCE.
+- If a future admin/operator group is added, requiring MFA for that group needs
+  a separate design and test path.
+
+## Enrollment Validation
+
+Run this only against disposable dev users. Do not capture or share QR codes,
+TOTP shared secrets, one-time codes, passwords, JWTs, Cognito emails, tenant
+IDs, session storage, or raw AWS responses.
+
+What it does: loads the deployed dev Cognito and frontend values used for
+Hosted UI validation.
+Target service: Terraform-managed dev Cognito user pool and frontend outputs.
+
+```bash
+cd /mnt/c/Repos/LeaseFlow/infra/environments/dev
+export AWS_PROFILE=terraform
+export AWS_REGION=eu-north-1
+
+export USER_POOL_ID=$(terraform output -raw cognito_user_pool_id)
+export FRONTEND_URL=$(terraform output -raw frontend_cloudfront_url)
+```
+
+What it does: creates a disposable Hosted UI test user with a tenant claim.
+Target service: Amazon Cognito user pool.
+
+```bash
+cd /mnt/c/Repos/LeaseFlow
+bash scripts/dev/create-demo-user.sh
+```
+
+Then sign in through the local or hosted frontend and follow the Cognito Hosted
+UI / managed login MFA prompts if Cognito presents enrollment or challenge
+steps. Use a real authenticator app for the TOTP code. If optional MFA does not
+present an enrollment prompt for the selected test user, do not claim end-to-end
+enrollment evidence from #241; create a follow-up ticket for custom in-app
+enrollment or role-required MFA design.
+
+Safe evidence may include:
+
+- date
+- issue number
+- environment name
+- Hosted UI sign-in reached MFA setup/challenge: pass/fail
+- authenticator app TOTP challenge completed: pass/fail
+- frontend returned to the expected origin after sign-in: pass/fail
+
+## Recovery For MFA-Locked Dev Accounts
+
+Use recovery only after verifying the requester is allowed to recover the
+account. In dev, prefer deleting and recreating disposable users. For any
+non-disposable account, record only sanitized evidence.
+
+What it does: disables software-token MFA preference for one known Cognito user.
+Target service: Amazon Cognito user pool.
+
+```bash
+aws cognito-idp admin-set-user-mfa-preference \
+  --user-pool-id "$USER_POOL_ID" \
+  --username "<cognito-username>" \
+  --software-token-mfa-settings Enabled=false,PreferredMfa=false
+```
+
+What it does: sets a new operator-known password for a dev user when password
+recovery is also required.
+Target service: Amazon Cognito user pool.
+
+```bash
+aws cognito-idp admin-set-user-password \
+  --user-pool-id "$USER_POOL_ID" \
+  --username "<cognito-username>" \
+  --password "<new-temporary-password>" \
+  --permanent
+```
+
+Do not paste real usernames, passwords, TOTP codes, QR codes, tenant values,
+JWTs, or raw AWS output into tickets or evidence. After recovery, the user
+should sign in through Hosted UI and re-enroll MFA if required by the operator
+process.

--- a/docs/security-baseline.md
+++ b/docs/security-baseline.md
@@ -52,7 +52,9 @@ Mitigations:
 - Validate JWT signature, issuer, audience, expiry, and required claims on every protected request.
 - Derive user identity and tenant context from validated token claims, not from client-supplied fields.
 - For tenant-scoped HTTP API calls, use the Cognito ID token so the backend receives `custom:tenant_id`.
-- Require strong password policy and support MFA in Cognito as the account base matures.
+- Require a strong password policy and enable optional Cognito software-token
+  TOTP MFA through Hosted UI. Role-required MFA remains a future control until
+  admin/operator roles exist.
 - Use short-lived tokens and avoid long-lived static credentials for workloads.
 
 ### Tampering
@@ -220,7 +222,9 @@ The MVP does not require a full incident management platform, but it does requir
 
 - PostgreSQL Row Level Security for defense-in-depth tenant enforcement,
   following `docs/postgresql-rls-tenant-isolation-hardening.md`
-- Cognito MFA rollout for higher-risk roles
+- Cognito MFA is available as optional Hosted UI software-token TOTP. Requiring
+  MFA for higher-risk admin/operator roles remains future work because those
+  roles do not exist yet.
 - Production SES delivery hardening for persisted tenant notifications,
   following `docs/ses-production-delivery-hardening.md`.
 - Backup retention review when recovery expectations outgrow the one-day dev window

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,6 +14,7 @@ automatically use a PostgreSQL database running in WSL.
 
 - Cognito Hosted UI sign in and sign out
 - OAuth authorization code flow with PKCE
+- optional Cognito Hosted UI software-token TOTP MFA support
 - protected browser routes
 - authenticated dashboard summary
 - properties list, create, and update
@@ -178,7 +179,9 @@ printf 'DEMO_PASSWORD=%s\n' "$DEMO_PASSWORD"
 Do not commit or paste the temporary email, password, tenant value, JWTs, or
 session storage values into evidence. Cognito passwords cannot be retrieved
 later; if you lose the password, set a new one with `admin-set-user-password`.
-The browser frontend must still use Hosted UI login, not admin auth APIs.
+The browser frontend must still use Hosted UI login, not admin auth APIs. Use
+`docs/runbooks/cognito-totp-mfa-enrollment-recovery.md` when validating TOTP MFA
+or recovering an MFA-locked dev account.
 
 ## Run
 
@@ -361,6 +364,8 @@ npm run build
 ## Security notes
 
 - Browser auth uses Cognito Hosted UI, not admin auth APIs.
+- Cognito software-token TOTP MFA is enabled in optional mode. LeaseFlow does
+  not implement a custom in-app TOTP enrollment UI.
 - Protected API calls use the Cognito `id_token` because the backend depends on
   `custom:tenant_id`.
 - Hosted UI requests `openid email profile` so readable custom attributes can

--- a/infra/README.md
+++ b/infra/README.md
@@ -31,6 +31,9 @@ The dev stack includes browser auth, browser CORS, and a hosted SPA path for
 the real frontend.
 
 - Cognito app client is configured for Hosted UI OAuth authorization code flow.
+- Cognito User Pool enables optional software-token TOTP MFA. SMS MFA,
+  WebAuthn/passkeys, and admin/operator-role-required MFA are not part of the
+  current dev stack.
 - Cognito uses a managed domain prefix that you must set explicitly in
   `terraform.tfvars`.
 - API Gateway HTTP API allows browser calls only from approved origins.
@@ -50,6 +53,8 @@ the real frontend.
 - The existing `demo-client` remains a separate local demo/operator tool.
 - Use `frontend/README.md` for browser `.env.local`, Hosted UI troubleshooting,
   and temporary Cognito demo user setup.
+- Use `docs/runbooks/cognito-totp-mfa-enrollment-recovery.md` for MFA
+  validation and MFA-locked account recovery.
 
 ## SES email foundation
 

--- a/infra/modules/cognito/main.tf
+++ b/infra/modules/cognito/main.tf
@@ -29,7 +29,11 @@ locals {
 resource "aws_cognito_user_pool" "this" {
   name = "${var.name_prefix}-user-pool"
 
-  mfa_configuration = "OFF"
+  mfa_configuration = "OPTIONAL"
+
+  software_token_mfa_configuration {
+    enabled = true
+  }
 
   password_policy {
     minimum_length    = 12

--- a/infra/modules/cognito/tests/defaults.tftest.hcl
+++ b/infra/modules/cognito/tests/defaults.tftest.hcl
@@ -16,6 +16,21 @@ run "exposes_tenant_id_claim_for_api_auth" {
   command = apply
 
   assert {
+    condition     = aws_cognito_user_pool.this.mfa_configuration == "OPTIONAL"
+    error_message = "User pool should offer optional MFA so users can enroll TOTP without requiring MFA for every dev sign-in."
+  }
+
+  assert {
+    condition     = aws_cognito_user_pool.this.software_token_mfa_configuration[0].enabled == true
+    error_message = "User pool should enable TOTP software-token MFA."
+  }
+
+  assert {
+    condition     = try(length(aws_cognito_user_pool.this.sms_configuration), 0) == 0
+    error_message = "User pool should not configure SMS MFA."
+  }
+
+  assert {
     condition = length([
       for attribute in aws_cognito_user_pool.this.schema : attribute
       if attribute.name == "tenant_id"


### PR DESCRIPTION
## What changed and why

Enables optional Cognito software-token TOTP MFA for the dev user pool and documents the Hosted UI validation and MFA-locked account recovery path.

This keeps the current auth architecture intact: browser sign-in still uses Cognito Hosted UI, and LeaseFlow does not add a custom in-app TOTP enrollment UI in this PR.

## Assumptions

- Admin/operator groups do not exist yet, so MFA is optional for all users rather than required by role.
- “Frontend enrollment path” means Cognito Hosted UI / managed login, not a custom LeaseFlow TOTP setup screen.
- SMS MFA, WebAuthn/passkeys, and role-required MFA are out of scope.

## Security validation

- Terraform tests verify Cognito MFA is `OPTIONAL`, software-token TOTP is enabled, and SMS MFA is not configured.
- Existing Hosted UI OAuth and `custom:tenant_id` readable/not-writable client constraints remain covered by the Cognito module test.
- No tenant isolation behavior changes were made; `tenant_id` handling remains JWT-claim based.

## Cost validation

No new AWS services were added. This only changes Cognito User Pool MFA configuration and docs, so no meaningful new dev cost is expected.

## Validation

- `terraform fmt -recursive infra`
- `cd infra/modules/cognito && terraform init -backend=false && terraform test`
- `cd infra/environments/dev && terraform init -backend=false && terraform validate`
- `git diff --check`

## Remaining risks / TODOs

- Hosted UI MFA enrollment must still be manually verified after applying the Terraform change.
- If future requirements need admin/operator-required MFA or custom in-app TOTP enrollment, that should be a separate ticket.